### PR TITLE
Tempo

### DIFF
--- a/src/components/PlaybackControls.svelte
+++ b/src/components/PlaybackControls.svelte
@@ -5,7 +5,7 @@
 </style>
 
 <script>
-  import { pedalling, volume } from "../stores";
+  import { pedalling, volume, tempo } from "../stores";
 
   export let playPauseMidiFile;
   export let stopMidiFile;
@@ -66,4 +66,17 @@
     />
     {$volume.right}
   </div>
+  <div>
+    Tempo:
+    <input
+      type="range"
+      min="0"
+      max="180"
+      step="10"
+      bind:value={$tempo}
+      name="tempo"
+    />
+    {$tempo}
+  </div>
+
 </div>

--- a/src/components/PlaybackControls.svelte
+++ b/src/components/PlaybackControls.svelte
@@ -5,7 +5,7 @@
 </style>
 
 <script>
-  import { pedalling, volume, tempo } from "../stores";
+  import { pedalling, volume, tempoControl } from "../stores";
 
   export let playPauseMidiFile;
   export let stopMidiFile;
@@ -73,10 +73,10 @@
       min="0"
       max="180"
       step="10"
-      bind:value={$tempo}
+      bind:value={$tempoControl}
       name="tempo"
     />
-    {$tempo}
+    {$tempoControl}
   </div>
 
 </div>

--- a/src/components/SamplePlayer.js
+++ b/src/components/SamplePlayer.js
@@ -20,7 +20,7 @@ volume.subscribe(({ master, right, left }) => {
   leftVolumeRatio = left;
 });
 
-let baseTempo = 60;
+let baseTempo;
 let tempoRatio = 1.0;
 let tempoControlValue;
 tempoControl.subscribe((newTempo) => {
@@ -79,6 +79,12 @@ midiSamplePlayer.on("fileLoaded", () => {
         ),
     ),
   );
+
+  baseTempo = metadataTrack
+    .filter((event) => event.name === "Set Tempo")
+    .reduce((prevEvent, event) =>
+      event.tick < prevEvent.tick ? event : prevEvent,
+    ).data;
 });
 
 const controllerChange = Object.freeze({

--- a/src/components/SamplePlayer.js
+++ b/src/components/SamplePlayer.js
@@ -2,7 +2,7 @@
 import MidiPlayer from "midi-player-js";
 import { Piano } from "@tonejs/piano";
 
-import { rollMetadata, pedalling, volume, tempo } from "../stores";
+import { rollMetadata, pedalling, volume, tempoControl } from "../stores";
 
 const midiSamplePlayer = new MidiPlayer.Player();
 
@@ -20,7 +20,7 @@ volume.subscribe(({ master, right, left }) => {
   leftVolumeRatio = left;
 });
 
-tempo.subscribe((newTempo) => {
+tempoControl.subscribe((newTempo) => {
   midiSamplePlayer.setTempo(newTempo);
 });
 

--- a/src/components/SamplePlayer.js
+++ b/src/components/SamplePlayer.js
@@ -2,7 +2,9 @@
 import MidiPlayer from "midi-player-js";
 import { Piano } from "@tonejs/piano";
 
-import { rollMetadata, pedalling, volume } from "../stores";
+import { rollMetadata, pedalling, volume, tempo } from "../stores";
+
+const midiSamplePlayer = new MidiPlayer.Player();
 
 let softPedalOn;
 pedalling.subscribe(({ soft }) => {
@@ -18,14 +20,16 @@ volume.subscribe(({ master, right, left }) => {
   leftVolumeRatio = left;
 });
 
+tempo.subscribe((newTempo) => {
+  midiSamplePlayer.setTempo(newTempo);
+});
+
 const decodeHtmlEntities = (string) =>
   string
     .replace(/&#(\d+);/g, (match, num) => String.fromCodePoint(num))
     .replace(/&#x([A-Za-z0-9]+);/g, (match, num) =>
       String.fromCodePoint(parseInt(num, 16)),
     );
-
-const midiSamplePlayer = new MidiPlayer.Player();
 
 const playPauseMidiFile = () => {
   if (midiSamplePlayer.isPlaying()) {

--- a/src/stores.js
+++ b/src/stores.js
@@ -1,6 +1,6 @@
 import { writable } from "svelte/store";
 
-export const tempo = writable(60);
+export const tempoControl = writable(60);
 export const rollMetadata = writable({});
 export const pedalling = writable({ soft: false, sustain: false });
 export const volume = writable({ master: 1, left: 1, right: 1 });

--- a/src/stores.js
+++ b/src/stores.js
@@ -1,5 +1,6 @@
 import { writable } from "svelte/store";
 
+export const tempo = writable(60);
 export const rollMetadata = writable({});
 export const pedalling = writable({ soft: false, sustain: false });
 export const volume = writable({ master: 1, left: 1, right: 1 });


### PR DESCRIPTION
Okay, let's get this rolling.  This is the simplest implementation of a tempo slider to start with.  Obviously this doesn't deal with the advanced functionality yet, which (I think?) is all connected with disabling the midi files' own timing instructions and/or replacing them?

Some notes for consideration, nonetheless:

w/r/t base tempo
1) will tempo changes always be available on the metadata track (i.e. track 0)?
2) would it be safe to simply look for an event with tick = 0?
3) in the event that we're generating our own metadata, `baseTempo` could perhaps be predetermined offline and then read from JSON to avoid any need to calculate at play time.

Also, there's an issue concerning the display for the tempo slider.  Three options that spring to mind:
1) try to show the actual bpm value (as computed from the roll instructions and the slider value);
2) show the value as a modifier (1x / 100% if unaltered or something);
3) don't show a value :)

Suggest we merge this and note these for addressing in the future, perhaps with an issue to return to or a note for discussion, as appropriate (unless it's blindingly obvious what the correct resolution is, in which case let's by all means resolve right away).