### PR TITLE
Progress

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -4,6 +4,7 @@
     pianoReady,
     playPauseMidiFile,
     stopMidiFile,
+    skipToPercentage
   } from "./components/SamplePlayer";
   import RollDetails from "./components/RollDetails.svelte";
   import PlaybackControls from "./components/PlaybackControls.svelte";
@@ -27,5 +28,5 @@
 <h1>{title}</h1>
 {#if appReady}
   <RollDetails />
-  <PlaybackControls {playPauseMidiFile} {stopMidiFile} />
+  <PlaybackControls {playPauseMidiFile} {stopMidiFile} {skipToPercentage}/>
 {/if}

--- a/src/components/PlaybackControls.svelte
+++ b/src/components/PlaybackControls.svelte
@@ -88,9 +88,11 @@
       step="0.01"
       value={$playbackProgress}
       name="progress"
-      on:input={({target: {value}}) => skipToPercentage(value)}
+      on:input={({ target: { value } }) => {
+        skipToPercentage(value);
+        $playbackProgress = value;
+      }}
     />
     {($playbackProgress * 100).toFixed(2)}%
   </div>
-
 </div>

--- a/src/components/PlaybackControls.svelte
+++ b/src/components/PlaybackControls.svelte
@@ -5,7 +5,7 @@
 </style>
 
 <script>
-  import { pedalling, volume, tempoControl } from "../stores";
+  import { pedalling, volume, tempoControl, playbackProgress } from "../stores";
 
   export let playPauseMidiFile;
   export let stopMidiFile;
@@ -77,6 +77,18 @@
       name="tempo"
     />
     {$tempoControl}
+  </div>
+  <div>
+    Progress:
+    <input
+      type="range"
+      min="0"
+      max="1"
+      step="0.01"
+      bind:value={$playbackProgress}
+      name="progress"
+    />
+    {$playbackProgress}
   </div>
 
 </div>

--- a/src/components/PlaybackControls.svelte
+++ b/src/components/PlaybackControls.svelte
@@ -9,6 +9,7 @@
 
   export let playPauseMidiFile;
   export let stopMidiFile;
+  export let skipToPercentage;
 </script>
 
 <div id="score-controls">
@@ -85,10 +86,11 @@
       min="0"
       max="1"
       step="0.01"
-      bind:value={$playbackProgress}
+      value={$playbackProgress}
       name="progress"
+      on:input={({target: {value}}) => skipToPercentage(value)}
     />
-    {$playbackProgress}
+    {($playbackProgress * 100).toFixed(2)}%
   </div>
 
 </div>

--- a/src/components/SamplePlayer.js
+++ b/src/components/SamplePlayer.js
@@ -2,7 +2,13 @@
 import MidiPlayer from "midi-player-js";
 import { Piano } from "@tonejs/piano";
 
-import { rollMetadata, pedalling, volume, tempoControl } from "../stores";
+import {
+  rollMetadata,
+  pedalling,
+  volume,
+  tempoControl,
+  playbackProgress,
+} from "../stores";
 
 const midiSamplePlayer = new MidiPlayer.Player();
 
@@ -136,7 +142,7 @@ const stopNote = (noteNumber) => {
 
 midiSamplePlayer.on(
   "midiEvent",
-  ({ name, value, number, noteNumber, velocity, data }) => {
+  ({ name, value, number, noteNumber, velocity, data, tick }) => {
     if (name === "Note on") {
       if (velocity === 0) {
         // Note off
@@ -165,6 +171,7 @@ midiSamplePlayer.on(
       tempoRatio = 1.0 + (midiTempo - baseTempo) / baseTempo;
       midiSamplePlayer.setTempo(tempoControlValue * tempoRatio);
     }
+    playbackProgress.update(() => tick / midiSamplePlayer.totalTicks);
   },
 );
 

--- a/src/components/SamplePlayer.js
+++ b/src/components/SamplePlayer.js
@@ -12,6 +12,16 @@ import {
 
 const midiSamplePlayer = new MidiPlayer.Player();
 
+const updatePlayer = (fn) => {
+  if (midiSamplePlayer.isPlaying()) {
+    midiSamplePlayer.pause();
+    fn();
+    midiSamplePlayer.play();
+    return;
+  }
+  fn();
+};
+
 let softPedalOn;
 pedalling.subscribe(({ soft }) => {
   softPedalOn = soft;
@@ -31,13 +41,7 @@ let tempoRatio = 1.0;
 let tempoControlValue;
 tempoControl.subscribe((newTempo) => {
   tempoControlValue = newTempo;
-  if (midiSamplePlayer.isPlaying()) {
-    midiSamplePlayer.pause();
-    midiSamplePlayer.setTempo(tempoControlValue * tempoRatio);
-    midiSamplePlayer.play();
-  } else {
-    midiSamplePlayer.setTempo(tempoControlValue * tempoRatio);
-  }
+  updatePlayer(() => midiSamplePlayer.setTempo(tempoControlValue * tempoRatio));
 });
 
 const decodeHtmlEntities = (string) =>
@@ -59,15 +63,10 @@ const stopMidiFile = () => {
   midiSamplePlayer.stop();
 };
 
-const skipToPercentage = (percentage) => {
-  if (midiSamplePlayer.isPlaying()) {
-    midiSamplePlayer.pause();
-    midiSamplePlayer.skipToTick(midiSamplePlayer.totalTicks * percentage);
-    midiSamplePlayer.play();
-  } else {
-    midiSamplePlayer.skipToTick(midiSamplePlayer.totalTicks * percentage);
-  }
-};
+const skipToPercentage = (percentage) =>
+  updatePlayer(() =>
+    midiSamplePlayer.skipToTick(midiSamplePlayer.totalTicks * percentage),
+  );
 
 midiSamplePlayer.on("fileLoaded", () => {
   const metadataTrack = midiSamplePlayer.events[0];

--- a/src/components/SamplePlayer.js
+++ b/src/components/SamplePlayer.js
@@ -59,6 +59,16 @@ const stopMidiFile = () => {
   midiSamplePlayer.stop();
 };
 
+const skipToPercentage = (percentage) => {
+  if (midiSamplePlayer.isPlaying()) {
+    midiSamplePlayer.pause();
+    midiSamplePlayer.skipToTick(midiSamplePlayer.totalTicks * percentage);
+    midiSamplePlayer.play();
+  } else {
+    midiSamplePlayer.skipToTick(midiSamplePlayer.totalTicks * percentage);
+  }
+};
+
 midiSamplePlayer.on("fileLoaded", () => {
   const metadataTrack = midiSamplePlayer.events[0];
   /* @IMAGE_WIDTH and @IMAGE_LENGTH should be the same as from viewport._contentSize
@@ -175,4 +185,10 @@ midiSamplePlayer.on(
   },
 );
 
-export { midiSamplePlayer, playPauseMidiFile, stopMidiFile, pianoReady };
+export {
+  midiSamplePlayer,
+  playPauseMidiFile,
+  stopMidiFile,
+  pianoReady,
+  skipToPercentage,
+};

--- a/src/stores.js
+++ b/src/stores.js
@@ -4,3 +4,5 @@ export const tempoControl = writable(60);
 export const rollMetadata = writable({});
 export const pedalling = writable({ soft: false, sustain: false });
 export const volume = writable({ master: 1, left: 1, right: 1 });
+
+export const playbackProgress = writable(0);


### PR DESCRIPTION
This is a rudimentary progress slider for the basic MIDI playback.  The standout problem with it is that it only updates on MIDI ticks -- the solution to this will come when the roll viewer integration is added, I suppose.  Should merge cleanly to `main` once #5 is merged.

Also refactors the "stop → adjust → start again" logic to a reusable function -- not sure how useful this really is.