### PR TITLE
Roll Viewer

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@snowpack/plugin-sass": "^1.4.0",
     "@tonejs/piano": "^0.2.1",
     "midi-player-js": "^2.0.13",
+    "openseadragon": "^2.4.2",
     "svelte": "^3.29.4",
     "svelte-preprocess": "^4.7.0",
     "tone": "^14.7.58",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -11,6 +11,7 @@
   import RollSelector from "./components/RollSelector.svelte";
   import RollDetails from "./components/RollDetails.svelte";
   import PlaybackControls from "./components/PlaybackControls.svelte";
+  import RollViewer from "./components/RollViewer.svelte";
   import Notification, { notify } from "./ui-components/Notification.svelte";
 
   const title = "Pianolatron Development";
@@ -96,5 +97,6 @@
 {#if appReady}
   <RollDetails />
   <PlaybackControls {playPauseApp} {stopApp} {skipToPercentage} />
+  <RollViewer imageUrl={currentRoll.image_url} />
 {/if}
 <Notification />

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -9,10 +9,30 @@
   import { onMount } from "svelte";
   import OpenSeadragon from "openseadragon";
 
+  import { rollMetadata } from "../stores";
+
   export let imageUrl;
+  let openSeadragon;
+
+  export const panViewportToTick = (tick) => {
+    if (!openSeadragon) return;
+    const { viewport } = openSeadragon;
+    const viewportBounds = viewport.getBounds();
+    const linePx =
+      parseInt($rollMetadata.FIRST_HOLE, 10) + (scrollDownwards ? tick : -tick);
+
+    const lineViewport = viewport.imageToViewportCoordinates(0, linePx);
+
+    const lineCenter = new OpenSeadragon.Point(
+      viewportBounds.width / 2,
+      lineViewport.y,
+    );
+
+    viewport.panTo(lineCenter);
+  };
 
   onMount(async () => {
-    const openSeadragon = OpenSeadragon({
+    openSeadragon = OpenSeadragon({
       id: "roll-viewer",
       showNavigationControl: false,
       panHorizontal: false,
@@ -24,6 +44,8 @@
 
     openSeadragon.open(imageUrl);
   });
+
+  $: scrollDownwards = $rollMetadata.ROLL_TYPE === "welte-red";
 </script>
 
 <div id="roll-viewer" />

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -40,7 +40,7 @@
     const lineViewport = viewport.imageToViewportCoordinates(0, linePx);
 
     const lineCenter = new OpenSeadragon.Point(
-      viewportBounds.width / 2,
+      viewportBounds.x + viewportBounds.width / 2,
       lineViewport.y,
     );
 

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -14,6 +14,10 @@
       top: 50%;
       width: 100%;
     }
+
+    :global(.openseadragon-canvas:focus) {
+      outline: none;
+    }
   }
 </style>
 

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -1,0 +1,29 @@
+<style>
+  #roll-viewer {
+    width: 100%;
+    height: 200px;
+  }
+</style>
+
+<script>
+  import { onMount } from "svelte";
+  import OpenSeadragon from "openseadragon";
+
+  export let imageUrl;
+
+  onMount(async () => {
+    const openSeadragon = OpenSeadragon({
+      id: "roll-viewer",
+      showNavigationControl: false,
+      panHorizontal: false,
+      visibilityRatio: 1,
+      defaultZoomLevel: 1,
+      minZoomLevel: 0.01,
+      maxZoomLevel: 4,
+    });
+
+    openSeadragon.open(imageUrl);
+  });
+</script>
+
+<div id="roll-viewer" />

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -42,6 +42,10 @@
       maxZoomLevel: 4,
     });
 
+    openSeadragon.addOnceHandler("update-viewport", () => {
+      panViewportToTick(0);
+    });
+
     openSeadragon.open(imageUrl);
   });
 

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -29,11 +29,15 @@
 
   export let imageUrl;
   let openSeadragon;
+  let dragging;
 
   const panViewportToTick = (tick) => {
     if (!openSeadragon) return;
     const { viewport } = openSeadragon;
-    const viewportBounds = viewport.getBounds();
+    // if we're dragging we want the target bounds, if otherwise (and most
+    //   especially if we happen to be zooming) we want the current bounds
+    const viewportBounds = viewport.getBounds(!dragging);
+
     const linePx =
       parseInt($rollMetadata.FIRST_HOLE, 10) + (scrollDownwards ? tick : -tick);
 
@@ -61,6 +65,14 @@
 
     openSeadragon.addOnceHandler("update-viewport", () => {
       panViewportToTick(0);
+    });
+
+    openSeadragon.addHandler("canvas-drag", () => {
+      dragging = true;
+    });
+
+    openSeadragon.addHandler("canvas-drag-end", () => {
+      dragging = false;
     });
 
     openSeadragon.open(imageUrl);

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -51,7 +51,7 @@
     openSeadragon = OpenSeadragon({
       id: "roll-viewer",
       showNavigationControl: false,
-      panHorizontal: false,
+      panHorizontal: true,
       visibilityRatio: 1,
       defaultZoomLevel: 1,
       minZoomLevel: 0.01,

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -9,6 +9,7 @@
       content: "";
       display: block;
       height: 1px;
+      pointer-events: none;
       position: absolute;
       top: 50%;
       width: 100%;

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -25,7 +25,7 @@
   export let imageUrl;
   let openSeadragon;
 
-  export const panViewportToTick = (tick) => {
+  const panViewportToTick = (tick) => {
     if (!openSeadragon) return;
     const { viewport } = openSeadragon;
     const viewportBounds = viewport.getBounds();

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -56,6 +56,7 @@
       defaultZoomLevel: 1,
       minZoomLevel: 0.01,
       maxZoomLevel: 4,
+      constrainDuringPan: true,
     });
 
     openSeadragon.addOnceHandler("update-viewport", () => {

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -9,7 +9,7 @@
   import { onMount } from "svelte";
   import OpenSeadragon from "openseadragon";
 
-  import { rollMetadata } from "../stores";
+  import { rollMetadata, currentTick } from "../stores";
 
   export let imageUrl;
   let openSeadragon;
@@ -49,6 +49,7 @@
     openSeadragon.open(imageUrl);
   });
 
+  $: panViewportToTick($currentTick);
   $: scrollDownwards = $rollMetadata.ROLL_TYPE === "welte-red";
 </script>
 

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -1,7 +1,18 @@
-<style>
+<style lang="scss">
   #roll-viewer {
-    width: 100%;
+    position: relative;
     height: 200px;
+    width: 100%;
+
+    &::after {
+      background: red;
+      content: "";
+      display: block;
+      height: 1px;
+      position: absolute;
+      top: 50%;
+      width: 100%;
+    }
   }
 </style>
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4022,6 +4022,11 @@ open@^7.0.4:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
 
+openseadragon@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/openseadragon/-/openseadragon-2.4.2.tgz#f25d833d0ab9941599d65a3e2b44bec546c9f15c"
+  integrity sha512-398KbZwRtOYA6OmeWRY4Q0737NTacQ9Q6whmr9Lp1MNQO3p0eBz5LIASRne+4gwequcSM1vcHcjfy3dIndQziw==
+
 optionator@^0.8.1:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.3.tgz#84fa1d036fe9d3c7e21d99884b601167ec8fb495"


### PR DESCRIPTION
I had originally planned for this to be more feature-complete before PR-ing, but I think it's best I ask you to take a look at this now and we get the basic functionality in.  Panning the roll vertically and having the audio sync was giving me a headache, and I want to work on something else for a bit and come back to it :)  (I also have a thought about how that might be implemented differently, perhaps? better.)

Notes on this PR:

1) Zooming and horizontal panning should be rock solid -- if they're not in any environment for any reason, please let me know (can wait until merged and pushed to `gh-pages` for ease of testing on, e.g., mobile devices).

2) This implementation calls `panViewportToTick` on every tick (effectively from `midiSamplePlayer.on("play")`.  You have a note in the prototype code that reads:
    > syncing at every note effect also can cause problems on certain browsers if the playback events start to lag behind their scheduled times.

    I've not been able to make this cause a problem yet, but it wants some proper battle testing in different environments and on some crippled VMs and lower-powered devices.

3) This currently resets the roll on "stop".  Again you have a note about this, and in addition to your proposed callback solution we could also supply the `immediate` argument to the [`panTo`](https://openseadragon.github.io/docs/OpenSeadragon.Viewport.html#panTo) method.  Personally I think resetting on "stop" is the better behaviour (the progress slider does...), but I'll defer to you and the PIs :)

4) in any event there may be a case for scrolling `immediate`ly by default when the progress slider is moved, for example.  Something to consider (we could possibly toggle the behaviour at runtime with a discreet and/or hidden checkbox).

5) I have some ideas about styling and layout, but obviously they're not in here yet :)