### PR TITLE
Layout rearrangement

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -15,8 +15,6 @@
   import Keyboard from "./components/Keyboard.svelte";
   import Notification, { notify } from "./ui-components/Notification.svelte";
 
-  const title = "Pianolatron Development";
-
   let appReady = false;
   let mididataReady;
   let currentRoll;
@@ -93,7 +91,6 @@
   $: playbackProgress.update(() => $currentTick / midiSamplePlayer.totalTicks);
 </script>
 
-<h1>{title}</h1>
 <RollSelector bind:currentRoll />
 {#if appReady}
   <RollDetails />

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,3 +1,31 @@
+<style>
+  #app {
+    display: grid;
+    grid-template-rows: 1fr auto;
+    grid-template-columns: auto 1fr auto;
+    grid-template-areas:
+      "left roll right"
+      "keyboard keyboard keyboard";
+    height: 100vh;
+  }
+
+  #roll-details {
+    grid-area: left;
+  }
+
+  #roll {
+    grid-area: roll;
+  }
+
+  #audio-controls {
+    grid-area: right;
+  }
+
+  #keyboard {
+    grid-area: keyboard;
+  }
+</style>
+
 <script>
   import {
     pedalling,
@@ -91,11 +119,23 @@
   $: playbackProgress.update(() => $currentTick / midiSamplePlayer.totalTicks);
 </script>
 
-<RollSelector bind:currentRoll />
-{#if appReady}
-  <RollDetails />
-  <PlaybackControls {playPauseApp} {stopApp} {skipToPercentage} />
-  <RollViewer imageUrl={currentRoll.image_url} />
-  <Keyboard keyCount="87" {activeNotes} />
-{/if}
+<div id="app">
+  <div id="roll-details">
+    <RollSelector bind:currentRoll />
+    {#if appReady}
+      <RollDetails />
+    {/if}
+  </div>
+  {#if appReady}
+    <div id="audio-controls">
+      <PlaybackControls {playPauseApp} {stopApp} {skipToPercentage} />
+    </div>
+    <div id="roll">
+      <RollViewer imageUrl={currentRoll.image_url} />
+    </div>
+    <div id="keyboard">
+      <Keyboard keyCount="87" {activeNotes} />
+    </div>
+  {/if}
+</div>
 <Notification />

--- a/src/components/Keyboard.svelte
+++ b/src/components/Keyboard.svelte
@@ -1,21 +1,34 @@
 <style lang="scss">
   $key-width: 1.8vw;
   $active-key-highlight: #b5e2ff;
+  $felt-strip-height: 12px;
 
   #keyboard {
+    display: flow-root;
     margin: 1em auto;
     position: relative;
     width: fit-content;
   }
 
   div#keys {
-    border-top: 2px solid #222;
     display: block;
     height: calc(#{$key-width} * 6);
-    margin: 0;
+    margin-top: $felt-strip-height;
     padding: 0;
     width: 100%;
 
+    &::before {
+      background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAQAAAAICAYAAADeM14FAAAAd0lEQVQYV0WMPQoDIRQGv1dZKFjIWjyst1i23sOlyQFShNQ5nZVg7Q+CaDApMuUwDL3Oc+acoZQCEYGex/EVvXdIKUHv65ree2itUUoBPfZ91lqxEEKA7szTOYcY4++zHq01GGOwSrpt22RmhBD+xRgDKSVYa/EBmDYy7EuYDVgAAAAASUVORK5CYII=);
+      content: "";
+      position: absolute;
+      top: 0;
+      height: $felt-strip-height;
+      left: -4px;
+      right: -4px;
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.7), 1px 0px 3px rgba(0, 0, 0, 0.7),
+        -1px 0px 3px rgba(0, 0, 0, 0.7);
+      z-index: 3;
+    }
     div {
       float: left;
       position: relative;

--- a/src/components/PlaybackControls.svelte
+++ b/src/components/PlaybackControls.svelte
@@ -30,24 +30,6 @@
 </script>
 
 <div id="score-controls">
-  <button type="button" on:click={playPauseApp}>Play/Pause</button>
-  <button type="button" on:click={stopApp}>Stop</button>
-  <button
-    type="button"
-    class:pedal-on={$pedalling.soft}
-    aria-pressed={$pedalling.soft}
-    on:click={() => pedalling.update((val) => ({ ...val, soft: !val.soft }))}
-  >Soft</button>
-  <button
-    type="button"
-    class:pedal-on={$pedalling.sustain}
-    aria-pressed={$pedalling.sustain}
-    on:click={() => pedalling.update((val) => ({
-        ...val,
-        sustain: !val.sustain,
-      }))}
-  >Sustain</button>
-
   <div class="control">
     <span>Master Volume:</span>
     <RangeSlider
@@ -105,4 +87,22 @@
     />
     {($playbackProgress * 100).toFixed(2)}%
   </div>
+
+  <button type="button" on:click={playPauseApp}>Play/Pause</button>
+  <button type="button" on:click={stopApp}>Stop</button>
+  <button
+    type="button"
+    class:pedal-on={$pedalling.soft}
+    aria-pressed={$pedalling.soft}
+    on:click={() => pedalling.update((val) => ({ ...val, soft: !val.soft }))}
+  >Soft</button>
+  <button
+    type="button"
+    class:pedal-on={$pedalling.sustain}
+    aria-pressed={$pedalling.sustain}
+    on:click={() => pedalling.update((val) => ({
+        ...val,
+        sustain: !val.sustain,
+      }))}
+  >Sustain</button>
 </div>

--- a/src/components/PlaybackControls.svelte
+++ b/src/components/PlaybackControls.svelte
@@ -1,6 +1,6 @@
 <style lang="scss">
-  #score-controls {
-    margin: 0.5em;
+  #playback-controls {
+    margin: 6em 2em 0 2em;
   }
   .control {
     align-items: center;
@@ -50,7 +50,7 @@
   export let skipToPercentage;
 </script>
 
-<div id="score-controls">
+<div id="playback-controls">
   <div class="control">
     <span>Master Volume:</span>
     <span>{$volume.master}</span>

--- a/src/components/PlaybackControls.svelte
+++ b/src/components/PlaybackControls.svelte
@@ -12,6 +12,7 @@
     :first-child {
       width: 8em;
     }
+
     :global(input[type="range"]) {
       width: 20em;
     }

--- a/src/components/PlaybackControls.svelte
+++ b/src/components/PlaybackControls.svelte
@@ -1,20 +1,23 @@
 <style lang="scss">
+  #score-controls {
+    margin: 0.5em;
+  }
   .pedal-on {
     background: yellow;
   }
 
   .control {
     align-items: center;
-    display: flex;
+    display: grid;
     gap: 0.5em;
     padding: 0.5em 0;
-
-    :first-child {
-      width: 8em;
-    }
+    grid:
+      "title value" auto
+      "slider slider" auto / 1fr auto;
 
     :global(input[type="range"]) {
-      width: 20em;
+      grid-area: slider;
+      width: 100%;
     }
   }
 </style>
@@ -32,6 +35,7 @@
 <div id="score-controls">
   <div class="control">
     <span>Master Volume:</span>
+    <span>{$volume.master}</span>
     <RangeSlider
       min="0"
       max="4"
@@ -39,10 +43,10 @@
       bind:value={$volume.master}
       name="volume"
     />
-    {$volume.master}
   </div>
   <div class="control">
     <span>Bass Volume:</span>
+    <span>{$volume.left}</span>
     <RangeSlider
       min="0"
       max="4"
@@ -50,10 +54,10 @@
       bind:value={$volume.left}
       name="volume"
     />
-    {$volume.left}
   </div>
   <div class="control">
     <span>Treble Volume:</span>
+    <span>{$volume.right}</span>
     <RangeSlider
       min="0"
       max="4"
@@ -61,10 +65,10 @@
       bind:value={$volume.right}
       name="volume"
     />
-    {$volume.right}
   </div>
   <div class="control">
     <span>Tempo:</span>
+    <span>{$tempoControl}</span>
     <RangeSlider
       min="0"
       max="180"
@@ -72,10 +76,10 @@
       bind:value={$tempoControl}
       name="tempo"
     />
-    {$tempoControl}
   </div>
   <div class="control">
     <span>Progress:</span>
+    <span>{($playbackProgress * 100).toFixed(2)}%</span>
     <RangeSlider
       min="0"
       max="1"
@@ -85,7 +89,6 @@
       on:input={({ target: { value } }) => skipToPercentage(value)}
       mousewheel={false}
     />
-    {($playbackProgress * 100).toFixed(2)}%
   </div>
 
   <button type="button" on:click={playPauseApp}>Play/Pause</button>

--- a/src/components/PlaybackControls.svelte
+++ b/src/components/PlaybackControls.svelte
@@ -2,10 +2,6 @@
   #score-controls {
     margin: 0.5em;
   }
-  .pedal-on {
-    background: yellow;
-  }
-
   .control {
     align-items: center;
     display: grid;
@@ -18,6 +14,28 @@
     :global(input[type="range"]) {
       grid-area: slider;
       width: 100%;
+    }
+  }
+
+  button {
+    display: inline-block;
+    padding: 0.35em 0.8em;
+    border: 0.1em solid #ffffff;
+    margin: 0;
+    border-radius: 0.25em;
+    color: #ffffff;
+    transition: all 0.2s;
+    background-color: $primary-accent;
+
+    &:hover,
+    &.pedal-on {
+      color: $primary-accent;
+      border-color: $primary-accent;
+      background-color: #ffffff;
+    }
+
+    &.pedal-on {
+      background-color: yellow;
     }
   }
 </style>

--- a/src/components/RollDetails.svelte
+++ b/src/components/RollDetails.svelte
@@ -1,18 +1,15 @@
 <style lang="scss">
-  ul {
-    background: beige;
-    border-bottom: 1px solid black;
-    columns: 2;
+  dl {
     display: block;
-    list-style: none;
-    margin: 0;
-    padding: 0.5em 2em;
+    margin: 1em;
+    padding: 0.5em 1em;
   }
 
-  strong {
+  dt {
     font-family: $primary-typeface;
-    display: inline-block;
-    width: 6em;
+    font-size: 1.4em;
+    margin-top: 0.5em;
+    margin-bottom: 0.2em;
   }
 </style>
 
@@ -20,14 +17,17 @@
   import { rollMetadata } from "../stores";
 </script>
 
-<ul>
-  <li><strong>Title:</strong> {$rollMetadata.TITLE}</li>
-  <li><strong>Performer:</strong> {$rollMetadata.PERFORMER}</li>
-  <li><strong>Composer:</strong> {$rollMetadata.COMPOSER}</li>
-  <li><strong>Label:</strong> {$rollMetadata.LABEL}</li>
-  <li>
-    <strong>PURL:</strong>
-    <a href={$rollMetadata.PURL}>{$rollMetadata.PURL}</a>
-  </li>
-  <li><strong>Call No:</strong> {$rollMetadata.CALLNUM}</li>
-</ul>
+<dl>
+  <dt>Title</dt>
+  <dd>{$rollMetadata.TITLE}</dd>
+  <dt>Performer</dt>
+  <dd>{$rollMetadata.PERFORMER}</dd>
+  <dt>Composer</dt>
+  <dd>{$rollMetadata.COMPOSER}</dd>
+  <dt>Label</dt>
+  <dd>{$rollMetadata.LABEL}</dd>
+  <dt>PURL</dt>
+  <dd><a href={$rollMetadata.PURL}>{$rollMetadata.PURL}</a></dd>
+  <dt>Call No</dt>
+  <dd>{$rollMetadata.CALLNUM}</dd>
+</dl>

--- a/src/components/RollSelector.svelte
+++ b/src/components/RollSelector.svelte
@@ -1,3 +1,10 @@
+<style>
+  select {
+    margin: 1em;
+    padding: 0.25em 0;
+  }
+</style>
+
 <script>
   // bundling this, for now at least
   import catalog from "../assets/catalog.json";

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -4,7 +4,7 @@
     height: 100%;
     width: 100%;
 
-    &::after {
+    &::before {
       background: red;
       content: "";
       display: block;
@@ -13,6 +13,19 @@
       position: absolute;
       top: 50%;
       width: 100%;
+      z-index: 3;
+    }
+
+    &::after {
+      background-color: $background-color;
+      bottom: 0;
+      content: " ";
+      left: 0;
+      mix-blend-mode: multiply;
+      pointer-events: none;
+      position: absolute;
+      right: 0;
+      top: 0;
     }
 
     :global(.openseadragon-canvas:focus) {

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -5,7 +5,7 @@
     width: 100%;
 
     &::before {
-      background: red;
+      background: $primary-accent;
       content: "";
       display: block;
       height: 1px;

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -1,7 +1,7 @@
 <style lang="scss">
   #roll-viewer {
     position: relative;
-    height: 200px;
+    height: 100%;
     width: 100%;
 
     &::after {

--- a/src/globals.scss
+++ b/src/globals.scss
@@ -1,4 +1,5 @@
 $primary-typeface: serif;
 $secondary-typeface: sans-serif;
 
+$background-color: #dad7cb; // Stanford's "cloud"
 $primary-accent: rebeccapurple;

--- a/src/globals.scss
+++ b/src/globals.scss
@@ -2,4 +2,4 @@ $primary-typeface: serif;
 $secondary-typeface: sans-serif;
 
 $background-color: #dad7cb; // Stanford's "cloud"
-$primary-accent: rebeccapurple;
+$primary-accent: #8c1515; // "cardinal"

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,7 +1,43 @@
 @import "globals";
 
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body,
+h1,
+h2,
+h3,
+h4,
+p,
+figure,
+blockquote,
+dl,
+dd {
+  margin: 0;
+}
+
+html:focus-within {
+  scroll-behavior: smooth;
+}
+
+input,
+button,
+textarea,
+select {
+  font: inherit;
+}
+
 body {
   font-family: $secondary-typeface;
+  min-height: 100vh;
+  text-rendering: optimizeSpeed;
+}
+
+a {
+  text-decoration-skip-ink: auto;
 }
 
 h1 {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -31,6 +31,7 @@ select {
 }
 
 body {
+  background: $background-color;
   font-family: $secondary-typeface;
   min-height: 100vh;
   text-rendering: optimizeSpeed;

--- a/src/ui-components/Notification.svelte
+++ b/src/ui-components/Notification.svelte
@@ -7,7 +7,7 @@
     left: 50%;
     min-width: 400px;
     position: absolute;
-    top: 50%;
+    top: 20%;
     transform: translate(-50%);
     z-index: 1000;
 


### PR DESCRIPTION
This is a start on rearranging the components into something resembling an interface.  See what you think.  It's all provisional and up-for-grabs, of course.

1) When the background colour is anything other that white, the white non-transparent background on the roll images is a bit obnoxious, so there's a solution here that uses CSS blend modes to make the white bits match the chosen `$background-color`.  There are some downsides to this, and it will only work for flat background colours, but I sorta feel like it's this (or something very like it) or a plain white background, tbh -- interested to know what you think.  I do have a commit on the [`manual-blend`](https://github.com/sul-cidr/pianolatron/tree/manual-blend) branch which does basically the same thing but calculates the needed overlay value at build-time with a binary search in an SCSS function, and hard-codes the value.

2) This PR includes a felt strip over the top of the keys.

3) The pedal-related buttons should probably go beneath the keyboard.

4) etc...