### PR TITLE
Read json metadata

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -34,6 +34,7 @@
     playbackProgress,
     activeNotes,
     currentTick,
+    rollMetadata,
   } from "./stores";
   import { midiSamplePlayer, pianoReady } from "./components/SamplePlayer";
   import RollSelector from "./components/RollSelector.svelte";
@@ -48,7 +49,6 @@
   let metadataReady;
   let currentRoll;
   let previousRoll;
-  let currentMetadata;
 
   const playPauseApp = () => {
     if (midiSamplePlayer.isPlaying()) {
@@ -110,7 +110,10 @@
         if (metadataResponse.status === 200) return metadataResponse.json();
         throw new Error("Error fetching metadata file! (Operation cancelled)");
       })
-      .then((metadataJson) => (currentMetadata = metadataJson))
+      .then(
+        (metadataJson) =>
+          ($rollMetadata = { ...$rollMetadata, ...metadataJson }),
+      )
       .catch((err) => {
         notify({ title: "Error!", message: err, type: "error" });
         currentRoll = previousRoll;

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -110,19 +110,18 @@
         if (metadataResponse.status === 200) return metadataResponse.json();
         throw new Error("Error fetching metadata file! (Operation cancelled)");
       })
-      .then(
-        (metadataJson) =>
-          ($rollMetadata = { ...$rollMetadata, ...metadataJson }),
-      )
       .catch((err) => {
         notify({ title: "Error!", message: err, type: "error" });
         currentRoll = previousRoll;
       });
 
-    Promise.all([mididataReady, metadataReady, pianoReady]).then(() => {
-      appReady = true;
-      previousRoll = currentRoll;
-    });
+    Promise.all([mididataReady, metadataReady, pianoReady]).then(
+      ({ 1: metadataJson }) => {
+        $rollMetadata = { ...$rollMetadata, ...metadataJson };
+        appReady = true;
+        previousRoll = currentRoll;
+      },
+    );
   };
 
   $: {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -45,8 +45,10 @@
 
   let appReady = false;
   let mididataReady;
+  let metadataReady;
   let currentRoll;
   let previousRoll;
+  let currentMetadata;
 
   const playPauseApp = () => {
     if (midiSamplePlayer.isPlaying()) {
@@ -97,16 +99,24 @@
       .then((mididataArrayBuffer) => {
         resetApp();
         midiSamplePlayer.loadArrayBuffer(mididataArrayBuffer);
-        Promise.all([mididataReady, pianoReady]).then(() => {
-          appReady = true;
-        });
       })
       .catch((err) => {
         notify({ title: "Error!", message: err, type: "error" });
         currentRoll = previousRoll;
       });
 
-    Promise.all([mididataReady, pianoReady]).then(() => {
+    metadataReady = fetch(`./assets/json/${roll.druid}.json`)
+      .then((metadataResponse) => {
+        if (metadataResponse.status === 200) return metadataResponse.json();
+        throw new Error("Error fetching metadata file! (Operation cancelled)");
+      })
+      .then((metadataJson) => (currentMetadata = metadataJson))
+      .catch((err) => {
+        notify({ title: "Error!", message: err, type: "error" });
+        currentRoll = previousRoll;
+      });
+
+    Promise.all([mididataReady, metadataReady, pianoReady]).then(() => {
       appReady = true;
       previousRoll = currentRoll;
     });

--- a/src/assets/json/dj406yq6980.json
+++ b/src/assets/json/dj406yq6980.json
@@ -1,0 +1,7 @@
+{
+  "title": "Feuerzauber",
+  "composer": "Brassin, Louis",
+  "performer": "Hofmann, Josef",
+  "label": "663 Welte-Mignon",
+  "PURL": "https://purl.stanford.edu/dj406yq6980"
+}

--- a/src/assets/json/kr397bv2881.json
+++ b/src/assets/json/kr397bv2881.json
@@ -1,0 +1,7 @@
+{
+  "title": "Sonate path\u00e9tique",
+  "composer": "Beethoven, Ludwig van",
+  "performer": "Lamond, Frederic",
+  "label": "562 Welte-Mignon",
+  "PURL": "https://purl.stanford.edu/kr397bv2881"
+}

--- a/src/assets/json/pz594dj8436.json
+++ b/src/assets/json/pz594dj8436.json
@@ -1,7 +1,7 @@
 {
   "title": "corsarias",
   "composer": "Alonso, Francisco",
-  "performer": "unknown",
+  "performer": null,
   "label": "4391 Princesa",
   "PURL": "https://purl.stanford.edu/pz594dj8436"
 }

--- a/src/assets/json/pz594dj8436.json
+++ b/src/assets/json/pz594dj8436.json
@@ -1,0 +1,7 @@
+{
+  "title": "corsarias",
+  "composer": "Alonso, Francisco",
+  "performer": "unknown",
+  "label": "4391 Princesa",
+  "PURL": "https://purl.stanford.edu/pz594dj8436"
+}

--- a/src/assets/json/rx870zt5437.json
+++ b/src/assets/json/rx870zt5437.json
@@ -1,7 +1,7 @@
 {
   "title": "Galleguita",
   "composer": "Pettorossi, Horacio",
-  "performer": "unknown",
+  "performer": null,
   "label": "4394 Princesa",
   "PURL": "https://purl.stanford.edu/rx870zt5437"
 }

--- a/src/assets/json/rx870zt5437.json
+++ b/src/assets/json/rx870zt5437.json
@@ -1,0 +1,7 @@
+{
+  "title": "Galleguita",
+  "composer": "Pettorossi, Horacio",
+  "performer": "unknown",
+  "label": "4394 Princesa",
+  "PURL": "https://purl.stanford.edu/rx870zt5437"
+}

--- a/src/assets/json/wt621xq0875.json
+++ b/src/assets/json/wt621xq0875.json
@@ -1,0 +1,7 @@
+{
+  "title": "Sonate path\u00e9tique",
+  "composer": "Beethoven, Ludwig van",
+  "performer": "Lamond, Frederic",
+  "label": "561 Welte-Mignon",
+  "PURL": "https://purl.stanford.edu/wt621xq0875"
+}

--- a/src/assets/json/yj598pj2879.json
+++ b/src/assets/json/yj598pj2879.json
@@ -1,0 +1,7 @@
+{
+  "title": "Soir\u00e9e de Vienne",
+  "composer": "Liszt, Franz",
+  "performer": "Albert, Eugen d'",
+  "label": "412 Welte-Mignon",
+  "PURL": "https://purl.stanford.edu/yj598pj2879"
+}

--- a/src/assets/json/zb497jz4405.json
+++ b/src/assets/json/zb497jz4405.json
@@ -1,0 +1,7 @@
+{
+  "title": "T\u00fcrkischer Marsch",
+  "composer": "Mozart, Wolfgang Amadeus",
+  "performer": "Reinecke, Carl",
+  "label": "182 Welte-Mignon",
+  "PURL": "https://purl.stanford.edu/zb497jz4405"
+}

--- a/src/components/RollDetails.svelte
+++ b/src/components/RollDetails.svelte
@@ -19,15 +19,17 @@
 
 <dl>
   <dt>Title</dt>
-  <dd>{$rollMetadata.TITLE || $rollMetadata.title}</dd>
+  <dd>{$rollMetadata.TITLE || $rollMetadata.title || 'Unavailable'}</dd>
   <dt>Performer</dt>
-  <dd>{$rollMetadata.PERFORMER || $rollMetadata.performer}</dd>
+  <dd>{$rollMetadata.PERFORMER || $rollMetadata.performer || 'Unavailable'}</dd>
   <dt>Composer</dt>
-  <dd>{$rollMetadata.COMPOSER || $rollMetadata.composer}</dd>
+  <dd>{$rollMetadata.COMPOSER || $rollMetadata.composer || 'Unavailable'}</dd>
   <dt>Label</dt>
-  <dd>{$rollMetadata.LABEL || $rollMetadata.label}</dd>
+  <dd>{$rollMetadata.LABEL || $rollMetadata.label || 'Unavailable'}</dd>
   <dt>PURL</dt>
-  <dd><a href={$rollMetadata.PURL}>{$rollMetadata.PURL}</a></dd>
+  <dd>
+    <a href={$rollMetadata.PURL}>{$rollMetadata.PURL || 'Unavailable'}</a>
+  </dd>
   <dt>Call No</dt>
-  <dd>{$rollMetadata.CALLNUM}</dd>
+  <dd>{$rollMetadata.CALLNUM || 'Unavailable'}</dd>
 </dl>

--- a/src/components/RollDetails.svelte
+++ b/src/components/RollDetails.svelte
@@ -19,13 +19,13 @@
 
 <dl>
   <dt>Title</dt>
-  <dd>{$rollMetadata.TITLE}</dd>
+  <dd>{$rollMetadata.TITLE || $rollMetadata.title}</dd>
   <dt>Performer</dt>
-  <dd>{$rollMetadata.PERFORMER}</dd>
+  <dd>{$rollMetadata.PERFORMER || $rollMetadata.performer}</dd>
   <dt>Composer</dt>
-  <dd>{$rollMetadata.COMPOSER}</dd>
+  <dd>{$rollMetadata.COMPOSER || $rollMetadata.composer}</dd>
   <dt>Label</dt>
-  <dd>{$rollMetadata.LABEL}</dd>
+  <dd>{$rollMetadata.LABEL || $rollMetadata.label}</dd>
   <dt>PURL</dt>
   <dd><a href={$rollMetadata.PURL}>{$rollMetadata.PURL}</a></dd>
   <dt>Call No</dt>

--- a/src/components/RollDetails.svelte
+++ b/src/components/RollDetails.svelte
@@ -11,25 +11,41 @@
     margin-top: 0.5em;
     margin-bottom: 0.2em;
   }
+
+  dd :global(span) {
+    opacity: 0.5;
+  }
 </style>
 
 <script>
   import { rollMetadata } from "../stores";
+
+  const unavailable = "<span>Unavailable</span>";
 </script>
 
 <dl>
   <dt>Title</dt>
-  <dd>{$rollMetadata.TITLE || $rollMetadata.title || 'Unavailable'}</dd>
+  <dd>
+    {@html $rollMetadata.TITLE || $rollMetadata.title || unavailable}
+  </dd>
   <dt>Performer</dt>
-  <dd>{$rollMetadata.PERFORMER || $rollMetadata.performer || 'Unavailable'}</dd>
+  <dd>
+    {@html $rollMetadata.PERFORMER || $rollMetadata.performer || unavailable}
+  </dd>
   <dt>Composer</dt>
-  <dd>{$rollMetadata.COMPOSER || $rollMetadata.composer || 'Unavailable'}</dd>
+  <dd>
+    {@html $rollMetadata.COMPOSER || $rollMetadata.composer || unavailable}
+  </dd>
   <dt>Label</dt>
-  <dd>{$rollMetadata.LABEL || $rollMetadata.label || 'Unavailable'}</dd>
+  <dd>
+    {@html $rollMetadata.LABEL || $rollMetadata.label || unavailable}
+  </dd>
   <dt>PURL</dt>
   <dd>
-    <a href={$rollMetadata.PURL}>{$rollMetadata.PURL || 'Unavailable'}</a>
+    <a href={$rollMetadata.PURL}>{@html $rollMetadata.PURL || unavailable}</a>
   </dd>
   <dt>Call No</dt>
-  <dd>{$rollMetadata.CALLNUM || 'Unavailable'}</dd>
+  <dd>
+    {@html $rollMetadata.CALLNUM || unavailable}
+  </dd>
 </dl>

--- a/src/components/RollDetails.svelte
+++ b/src/components/RollDetails.svelte
@@ -12,6 +12,10 @@
     margin-bottom: 0.2em;
   }
 
+  dd:not(:has(a)) {
+    text-transform: capitalize;
+  }
+
   dd :global(span) {
     opacity: 0.5;
   }


### PR DESCRIPTION
This PR begins the process of drawing on (an) additional file(s) beyond the `.mid` to generate the interface.  As such it also opens the conversation about exactly how to do this :)

For the purposes of getting started, the JSON files have been committed to this repo, but not the script which generates/assembles them, which is presently in a personal repo (the files in this commit were created from this version:  https://github.com/simonwiles/pianolatron-data/blob/1cf25ed677ff24b1cd0bb0b877c9e785dc7c1215/build-metadata.py).  We need to decide how much of this apparatus belongs here, how much in a separate (presumably sul-cidr) repo, and how much should be considered transient artifacts that aren't persisted (e.g. the MODS, midi, and .txt files that are needed to generate the JSON).

There are also problems with some of the metadata itself, of course.  Some things related to the MODS files that stand out and that are directly related to this PR:

1) The MODS files for all the rolls in our little development corpus are converted from MARCXML, so something different may be necessary for the "born-MODS" stuff (will try to find an example, or ask Kevin);

2) The metadata presented in the MODS files is different (sometimes inferior?) to what's in the MIDI metadata tracks (where the latter exists).  Not sure exactly how this works given that the latter was created on the basis of the former?  Depending on what we actually want to have in the Pianolatron app interface, some investigation may be required here.

3) The MODS for the 88-note rolls don't appear to contain anything corresponding to a performer/instrumentalist.  Is this perhaps to be expected, given the nature of the non-reproducing rolls?

4) Some of the metadata may need some post-processing (see f84b7b8 in this PR and https://github.com/sul-cidr/pianolatron/blob/bc9a3306e7cbae30b741cd4f0b0addda75c6a7a5/src/assets/json/pz594dj8436.json).