### PR TITLE
Double overlays

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -58,6 +58,7 @@
   let currentRoll;
   let previousRoll;
   let holesByTickInterval = new IntervalTree();
+  let holeData;
 
   const buildHolesIntervalTree = (holeData) => {
     const scrollDownwards = $rollMetadata.ROLL_TYPE === "welte-red";
@@ -103,6 +104,7 @@
     tempoControl.set(60);
     volume.update((val) => ({ ...val, left: 1, right: 1 }));
     holesByTickInterval = new IntervalTree();
+    holeData = null;
   };
 
   const skipToTick = (tick) => {
@@ -148,8 +150,10 @@
     Promise.all([mididataReady, metadataReady, pianoReady]).then(
       ({ 1: metadataJson }) => {
         $rollMetadata = { ...$rollMetadata, ...metadataJson };
-        if (metadataJson.holeData)
-          buildHolesIntervalTree(metadataJson.holeData);
+        if (metadataJson.holeData) {
+          holeData = metadataJson.holeData;
+          buildHolesIntervalTree();
+        }
         appReady = true;
         previousRoll = currentRoll;
       },
@@ -184,7 +188,11 @@
       <PlaybackControls {playPauseApp} {stopApp} {skipToPercentage} />
     </div>
     <div id="roll">
-      <RollViewer imageUrl={currentRoll.image_url} {holesByTickInterval} />
+      <RollViewer
+        imageUrl={currentRoll.image_url}
+        {holesByTickInterval}
+        {holeData}
+      />
     </div>
     <div id="keyboard-container">
       <Keyboard keyCount="88" {activeNotes} />

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -58,23 +58,23 @@
   let currentRoll;
   let previousRoll;
   let holesByTickInterval = new IntervalTree();
-  let holeData;
 
-  const buildHolesIntervalTree = (holeData) => {
-    const scrollDownwards = $rollMetadata.ROLL_TYPE === "welte-red";
+  const buildHolesIntervalTree = () => {
+    const { ROLL_TYPE, FIRST_HOLE, IMAGE_LENGTH, holeData } = $rollMetadata;
+    const scrollDownwards = ROLL_TYPE === "welte-red";
     const firstHolePx = scrollDownwards
-      ? parseInt($rollMetadata.FIRST_HOLE, 10)
-      : parseInt($rollMetadata.IMAGE_LENGTH, 10) -
-        parseInt($rollMetadata.FIRST_HOLE, 10);
+      ? parseInt(FIRST_HOLE, 10)
+      : parseInt(IMAGE_LENGTH, 10) - parseInt(FIRST_HOLE, 10);
 
     holeData.forEach((hole) => {
+      const { ORIGIN_ROW, OFF_TIME } = hole;
       const tickOn = scrollDownwards
-        ? hole.ORIGIN_ROW - firstHolePx
-        : firstHolePx - hole.ORIGIN_ROW;
+        ? ORIGIN_ROW - firstHolePx
+        : firstHolePx - ORIGIN_ROW;
 
       const tickOff = scrollDownwards
-        ? hole.OFF_TIME - firstHolePx
-        : firstHolePx - hole.OFF_TIME;
+        ? OFF_TIME - firstHolePx
+        : firstHolePx - OFF_TIME;
 
       holesByTickInterval.insert(tickOn, tickOff, hole);
     });
@@ -104,7 +104,6 @@
     tempoControl.set(60);
     volume.update((val) => ({ ...val, left: 1, right: 1 }));
     holesByTickInterval = new IntervalTree();
-    holeData = null;
   };
 
   const skipToTick = (tick) => {
@@ -150,10 +149,8 @@
     Promise.all([mididataReady, metadataReady, pianoReady]).then(
       ({ 1: metadataJson }) => {
         $rollMetadata = { ...$rollMetadata, ...metadataJson };
-        if (metadataJson.holeData) {
-          holeData = metadataJson.holeData;
-          buildHolesIntervalTree();
-        }
+        if (metadataJson.holeData)
+          buildHolesIntervalTree(metadataJson.holeData);
         appReady = true;
         previousRoll = currentRoll;
       },
@@ -188,11 +185,7 @@
       <PlaybackControls {playPauseApp} {stopApp} {skipToPercentage} />
     </div>
     <div id="roll">
-      <RollViewer
-        imageUrl={currentRoll.image_url}
-        {holesByTickInterval}
-        {holeData}
-      />
+      <RollViewer imageUrl={currentRoll.image_url} {holesByTickInterval} />
     </div>
     <div id="keyboard-container">
       <Keyboard keyCount="88" {activeNotes} />

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -88,6 +88,7 @@
   import { rollMetadata, currentTick } from "../stores";
 
   export let imageUrl;
+  export let holesData;
   export let holesByTickInterval;
 
   const WELTE_MIDI_START = 10;

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -88,7 +88,6 @@
   import { rollMetadata, currentTick } from "../stores";
 
   export let imageUrl;
-  export let holesData;
   export let holesByTickInterval;
 
   const WELTE_MIDI_START = 10;

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -42,6 +42,7 @@
     }
 
     :global(mark) {
+      background-color: transparent;
       mix-blend-mode: multiply;
 
       &.active {

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -36,6 +36,7 @@
     :global(canvas) {
       background: white !important;
     }
+
     :global(.openseadragon-canvas:focus) {
       outline: none;
     }
@@ -106,6 +107,7 @@
   let firstHolePx;
   let dragging;
   let marks = [];
+  let hoveredMark;
 
   const getNoteName = (trackerHole) => {
     const midiNumber = trackerHole + WELTE_MIDI_START;
@@ -140,7 +142,7 @@
     if (noteName) mark.dataset.info = noteName;
     mark.addEventListener("mouseout", () => {
       if (!marks.map(([_hole]) => _hole).includes(hole))
-        openSeadragon.viewport.viewer.removeOverlay(mark);
+        openSeadragon.viewport.viewer.removeOverlay(hoveredMark);
     });
     const viewportRectangle = openSeadragon.viewport.imageToViewportRectangle(
       ORIGIN_COL,
@@ -184,7 +186,9 @@
       rect.setAttribute("width", WIDTH_COL);
       rect.setAttribute("height", OFF_TIME - ORIGIN_ROW);
       rect.addEventListener("mouseover", () => {
-        if (!marks.map(([_hole]) => _hole).includes(hole)) createMark(hole);
+        if (marks.map(([_hole]) => _hole).includes(hole)) return;
+        openSeadragon.viewport.viewer.removeOverlay(hoveredMark);
+        hoveredMark = createMark(hole);
       });
 
       g.appendChild(rect);

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -125,6 +125,44 @@
     return null;
   };
 
+  const createHolesOverlaySvg = () => {
+    const { IMAGE_WIDTH, IMAGE_LENGTH, holeData } = $rollMetadata;
+    const imageWidth = parseInt(IMAGE_WIDTH, 10);
+    const imageLength = parseInt(IMAGE_LENGTH, 10);
+
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    const g = document.createElementNS("http://www.w3.org/2000/svg", "g");
+
+    const entireViewportRectangle = openSeadragon.viewport.imageToViewportRectangle(
+      0,
+      0,
+      imageWidth,
+      imageLength,
+    );
+
+    svg.setAttribute("width", imageWidth);
+    svg.setAttribute("height", imageLength);
+    svg.setAttribute("viewBox", `0 0 ${imageWidth} ${imageLength}`);
+    svg.appendChild(g);
+
+    holeData.forEach((hole) => {
+      const rect = document.createElementNS(
+        "http://www.w3.org/2000/svg",
+        "rect",
+      );
+      const { ORIGIN_COL, ORIGIN_ROW, WIDTH_COL, OFF_TIME } = hole;
+
+      rect.setAttribute("x", ORIGIN_COL);
+      rect.setAttribute("y", ORIGIN_ROW);
+      rect.setAttribute("width", WIDTH_COL);
+      rect.setAttribute("height", OFF_TIME - ORIGIN_ROW);
+
+      g.appendChild(rect);
+    });
+
+    openSeadragon.viewport.viewer.addOverlay(svg, entireViewportRectangle);
+  };
+
   const panViewportToTick = (tick) => {
     if (!openSeadragon) return;
     const { viewport } = openSeadragon;
@@ -189,7 +227,10 @@
       constrainDuringPan: true,
     });
 
-    openSeadragon.addOnceHandler("update-viewport", () => panViewportToTick(0));
+    openSeadragon.addOnceHandler("update-viewport", () => {
+      createHolesOverlaySvg();
+      panViewportToTick(0);
+    });
     openSeadragon.addHandler("canvas-drag", () => (dragging = true));
     openSeadragon.addHandler("canvas-drag-end", () => (dragging = false));
     openSeadragon.open(imageUrl);

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -157,6 +157,8 @@
 
   const createHolesOverlaySvg = () => {
     const { IMAGE_WIDTH, IMAGE_LENGTH, holeData } = $rollMetadata;
+    if (!holeData) return;
+
     const imageWidth = parseInt(IMAGE_WIDTH, 10);
     const imageLength = parseInt(IMAGE_LENGTH, 10);
 


### PR DESCRIPTION
Using HTML-based overlays for all holes absolutely tanks performance, as you discovered with the prototype, and I couldn't find a way to do anything about that (OSD recalculates the positioning and size of every element when the viewer pans -- I'm not sure it really needs to tbh, but I didn't fancy delving far enough in to it right now to try to improve the behaviour, much less put together something that could be PR'd upstream).

A single SVG overlay works great, because OSD is only aware of the top level element, and the browser/SVG takes care of the rest.  The problem is that styling options are very limited with the SVG route (can't apply `mix-blend-mode` or similar differentially on individual elements within the SVG; dimensions are scaled with the SVG, rather than staying the same size through zoom events; animations and [pseudo-]pseudo-elements can be done, but I'd have needed to start from scratch with those), and I quite liked what I already had.

Eventually it occurred to me that I could have the best of both worlds if I just literally did both.  This PR adds an SVG overlay to the entire roll *and* uses the HTML overlay for active and hovered holes.  There's a tiny bit of glitchy-ness I had to work around concerning `mouseout` events firing inconsistently, but otherwise this is pretty tight, I think.

Outstanding:
* More information/formatting/whatever for the popups.

* Differential colouring for the control holes (desirable, presumably, but exactly what/how is not completely clear to me yet).

* There's a branch called `popup-when-active` with a one-line change on top of this PR that activates the "popups" (for want of a better expression) when the notes are active.  The styling is as here (the heavy `darkturquoise` border), so it doesn't look great, but it's something to look at.  I suppose this is the kind of feature that we would want to be toggle-able from a settings panel of some kind, so I might start working on one of those, soon, so we've somewhere to put UI that we don't want on the main screen.  Ideas for what this might look like (modal window?  slide-out drawer?  accordion of some sort?) very welcome!

* As I write this it occurs to me that since the SVG does nothing in this implementation except provide targets for `mouseover` events, with a bit of simple maths the targets could be made larger to make them easier to hit (it can be a bit fiddly to target small holes, especially at low zoom levels).  I'm not certain it would work, but as I think about it now I reckon it could be okay.  Your thoughts welcome!