### PR TITLE
Roll viewer controls

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -22,6 +22,7 @@
 
   #roll {
     grid-area: roll;
+    position: relative;
   }
 
   #audio-controls {

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -301,7 +301,11 @@
 
 <div id="roll-viewer" />
 <div id="roll-viewer-controls">
-  <button>
+  <button
+    on:click={() => {
+      openSeadragon.viewport.zoomBy(1.1);
+    }}
+  >
     <svg
       xmlns="http://www.w3.org/2000/svg"
       width="24"
@@ -317,7 +321,11 @@
       <line x1="5" y1="12" x2="19" y2="12" />
     </svg>
   </button>
-  <button>
+  <button
+    on:click={() => {
+      openSeadragon.viewport.zoomBy(0.9);
+    }}
+  >
     <svg
       xmlns="http://www.w3.org/2000/svg"
       width="24"

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -148,6 +148,16 @@
   let marks = [];
   let hoveredMark;
 
+  const centerRoll = () => {
+    const { viewport } = openSeadragon;
+    const viewportBounds = viewport.getBounds();
+    const lineCenter = new OpenSeadragon.Point(
+      0.5,
+      viewportBounds.y + viewportBounds.height / 2,
+    );
+    viewport.panTo(lineCenter);
+  };
+
   const getNoteName = (trackerHole) => {
     const midiNumber = trackerHole + WELTE_MIDI_START;
     if (
@@ -340,7 +350,7 @@
       <line x1="5" y1="12" x2="19" y2="12" />
     </svg>
   </button>
-  <button>
+  <button on:click={centerRoll}>
     <svg
       xmlns="http://www.w3.org/2000/svg"
       width="24"
@@ -357,7 +367,12 @@
       <line x1="6" y1="18" x2="18" y2="18" />
     </svg>
   </button>
-  <button>
+  <button
+    on:click={() => {
+      openSeadragon.viewport.zoomTo(1);
+      centerRoll();
+    }}
+  >
     <svg
       xmlns="http://www.w3.org/2000/svg"
       height="24"

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -306,14 +306,7 @@
 <div id="roll-viewer" />
 <div id="roll-viewer-controls">
   <button
-    on:click={() => {
-      const { viewport } = openSeadragon;
-      if (viewport.getZoom() * 1.1 >= maxZoomLevel) {
-        viewport.zoomTo(maxZoomLevel);
-      } else {
-        viewport.zoomBy(1.1);
-      }
-    }}
+    on:click={() => openSeadragon.viewport.zoomTo(Math.min(openSeadragon.viewport.getZoom() * 1.1, maxZoomLevel))}
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -331,14 +324,7 @@
     </svg>
   </button>
   <button
-    on:click={() => {
-      const { viewport } = openSeadragon;
-      if (viewport.getZoom() * 0.9 <= minZoomLevel) {
-        viewport.zoomTo(minZoomLevel);
-      } else {
-        viewport.zoomBy(0.9);
-      }
-    }}
+    on:click={() => openSeadragon.viewport.zoomTo(Math.max(openSeadragon.viewport.getZoom() * 0.9, minZoomLevel))}
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -138,6 +138,10 @@
   const WELTE_RED_FIRST_NOTE = 24;
   const WELTE_RED_LAST_NOTE = 103;
 
+  const defaultZoomLevel = 1;
+  const minZoomLevel = 0.1;
+  const maxZoomLevel = 4;
+
   let openSeadragon;
   let firstHolePx;
   let dragging;
@@ -275,9 +279,9 @@
       showNavigationControl: false,
       panHorizontal: true,
       visibilityRatio: 1,
-      defaultZoomLevel: 1,
-      minZoomLevel: 0.1,
-      maxZoomLevel: 4,
+      defaultZoomLevel,
+      minZoomLevel,
+      maxZoomLevel,
       constrainDuringPan: true,
     });
 
@@ -303,7 +307,12 @@
 <div id="roll-viewer-controls">
   <button
     on:click={() => {
-      openSeadragon.viewport.zoomBy(1.1);
+      const { viewport } = openSeadragon;
+      if (viewport.getZoom() * 1.1 >= maxZoomLevel) {
+        viewport.zoomTo(maxZoomLevel);
+      } else {
+        viewport.zoomBy(1.1);
+      }
     }}
   >
     <svg
@@ -323,7 +332,12 @@
   </button>
   <button
     on:click={() => {
-      openSeadragon.viewport.zoomBy(0.9);
+      const { viewport } = openSeadragon;
+      if (viewport.getZoom() * 0.9 <= minZoomLevel) {
+        viewport.zoomTo(minZoomLevel);
+      } else {
+        viewport.zoomBy(0.9);
+      }
     }}
   >
     <svg

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -30,6 +30,19 @@
       margin: 0;
       padding: 0.35em 0.8em;
       transition: all 0.2s;
+
+      &:focus,
+      &:active {
+        outline: 0;
+      }
+
+      &:hover {
+        outline: 1px solid white;
+      }
+
+      &:active {
+        color: grey;
+      }
     }
   }
 

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -4,6 +4,19 @@
   $highlight-hover-outline-width: 6px;
   $highlight-hover-outline-offset: 8px;
 
+  #roll-viewer-controls {
+    display: none;
+    position: absolute;
+    top: 8px;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 25;
+
+    &:hover {
+      display: block;
+    }
+  }
+
   #roll-viewer {
     position: relative;
     height: 100%;
@@ -31,6 +44,10 @@
       position: absolute;
       right: 0;
       top: 0;
+    }
+
+    &:hover + #roll-viewer-controls {
+      display: block;
     }
 
     :global(canvas) {
@@ -266,3 +283,9 @@
 </script>
 
 <div id="roll-viewer" />
+<div id="roll-viewer-controls">
+  <button>1</button>
+  <button>2</button>
+  <button>3</button>
+  <button>4</button>
+</div>

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -7,16 +7,19 @@
   #roll-viewer-controls {
     background: rgba(0, 0, 0, 0.4);
     border-radius: 4px;
-    display: none;
+    opacity: 0;
+    pointer-events: none;
     left: 50%;
     padding: 8px;
     position: absolute;
     top: 8px;
     transform: translateX(-50%);
+    transition: opacity 500ms ease;
     z-index: 25;
 
     &:hover {
-      display: block;
+      opacity: 1;
+      pointer-events: all;
     }
 
     button {
@@ -60,7 +63,8 @@
     }
 
     &:hover + #roll-viewer-controls {
-      display: block;
+      opacity: 1;
+      pointer-events: all;
     }
 
     :global(canvas) {

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -259,7 +259,7 @@
       panHorizontal: true,
       visibilityRatio: 1,
       defaultZoomLevel: 1,
-      minZoomLevel: 0.01,
+      minZoomLevel: 0.1,
       maxZoomLevel: 4,
       constrainDuringPan: true,
     });

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -5,15 +5,28 @@
   $highlight-hover-outline-offset: 8px;
 
   #roll-viewer-controls {
+    background: rgba(0, 0, 0, 0.4);
+    border-radius: 4px;
     display: none;
+    left: 50%;
+    padding: 8px;
     position: absolute;
     top: 8px;
-    left: 50%;
     transform: translateX(-50%);
     z-index: 25;
 
     &:hover {
       display: block;
+    }
+
+    button {
+      background: none;
+      border: none;
+      color: #ffffff;
+      cursor: pointer;
+      margin: 0;
+      padding: 0.35em 0.8em;
+      transition: all 0.2s;
     }
   }
 
@@ -284,8 +297,68 @@
 
 <div id="roll-viewer" />
 <div id="roll-viewer-controls">
-  <button>1</button>
-  <button>2</button>
-  <button>3</button>
-  <button>4</button>
+  <button>
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      stroke-width="2"
+      stroke="currentColor"
+      fill="none"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <line x1="12" y1="5" x2="12" y2="19" />
+      <line x1="5" y1="12" x2="19" y2="12" />
+    </svg>
+  </button>
+  <button>
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      stroke-width="2"
+      stroke="currentColor"
+      fill="none"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <line x1="5" y1="12" x2="19" y2="12" />
+    </svg>
+  </button>
+  <button>
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      stroke-width="2"
+      stroke="currentColor"
+      fill="none"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <line x1="4" y1="6" x2="20" y2="6" />
+      <line x1="8" y1="12" x2="16" y2="12" />
+      <line x1="6" y1="18" x2="18" y2="18" />
+    </svg>
+  </button>
+  <button>
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      height="24"
+      viewBox="0 0 24 24"
+      stroke-width="2"
+      stroke="currentColor"
+      fill="none"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <polyline points="7 8 3 12 7 16" />
+      <polyline points="17 8 21 12 17 16" />
+      <line x1="3" y1="12" x2="21" y2="12" />
+    </svg>
+  </button>
 </div>


### PR DESCRIPTION
This is a first pass at some roll viewer controls.  The ones OpenSeadragon provides aren't really what we want, and the options for customizing them are such that we are better off just doing our own.

This PR includes basic functionality -- I'm expecting a subsequent PR to address:
1) making the fit-to-width and center buttons work when the roll is playing;
2) add automatic `disabled` styling to indicate when max/min zoom has been reached, and when the roll is already centered / at fit-to-width;
3) probably refactor into a separate Svelte component;
4) other things?