### PR TITLE
Roll viewer controls pt. 2

### DIFF
--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -93,7 +93,6 @@
 
 <script>
   import { onMount } from "svelte";
-  import { fade } from "svelte/transition";
   import OpenSeadragon from "openseadragon";
   import { rollMetadata, currentTick } from "../stores";
   import RollViewerControls from "./RollViewerControls.svelte";
@@ -277,8 +276,6 @@
   on:mouseleave={() => (showControls = false)}
 >
   {#if showControls}
-    <div transition:fade>
-      <RollViewerControls {openSeadragon} {minZoomLevel} {maxZoomLevel} />
-    </div>
+    <RollViewerControls {openSeadragon} {minZoomLevel} {maxZoomLevel} />
   {/if}
 </div>

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -276,6 +276,11 @@
   on:mouseleave={() => (showControls = false)}
 >
   {#if showControls}
-    <RollViewerControls {openSeadragon} {minZoomLevel} {maxZoomLevel} />
+    <RollViewerControls
+      bind:dragging
+      {openSeadragon}
+      {minZoomLevel}
+      {maxZoomLevel}
+    />
   {/if}
 </div>

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -4,48 +4,6 @@
   $highlight-hover-outline-width: 6px;
   $highlight-hover-outline-offset: 8px;
 
-  #roll-viewer-controls {
-    background: rgba(0, 0, 0, 0.4);
-    border-radius: 4px;
-    opacity: 0;
-    pointer-events: none;
-    left: 50%;
-    padding: 8px;
-    position: absolute;
-    top: 8px;
-    transform: translateX(-50%);
-    transition: opacity 500ms ease;
-    z-index: 25;
-
-    &:hover {
-      opacity: 1;
-      pointer-events: all;
-    }
-
-    button {
-      background: none;
-      border: none;
-      color: #ffffff;
-      cursor: pointer;
-      margin: 0;
-      padding: 0.35em 0.8em;
-      transition: all 0.2s;
-
-      &:focus,
-      &:active {
-        outline: 0;
-      }
-
-      &:hover {
-        outline: 1px solid white;
-      }
-
-      &:active {
-        color: grey;
-      }
-    }
-  }
-
   #roll-viewer {
     position: relative;
     height: 100%;
@@ -74,12 +32,6 @@
       right: 0;
       top: 0;
     }
-
-    &:hover + #roll-viewer-controls {
-      opacity: 1;
-      pointer-events: all;
-    }
-
     :global(canvas) {
       background: white !important;
     }
@@ -141,8 +93,10 @@
 
 <script>
   import { onMount } from "svelte";
+  import { fade } from "svelte/transition";
   import OpenSeadragon from "openseadragon";
   import { rollMetadata, currentTick } from "../stores";
+  import RollViewerControls from "./RollViewerControls.svelte";
 
   export let imageUrl;
   export let holesByTickInterval;
@@ -160,16 +114,7 @@
   let dragging;
   let marks = [];
   let hoveredMark;
-
-  const centerRoll = () => {
-    const { viewport } = openSeadragon;
-    const viewportBounds = viewport.getBounds();
-    const lineCenter = new OpenSeadragon.Point(
-      0.5,
-      viewportBounds.y + viewportBounds.height / 2,
-    );
-    viewport.panTo(lineCenter);
-  };
+  let showControls;
 
   const getNoteName = (trackerHole) => {
     const midiNumber = trackerHole + WELTE_MIDI_START;
@@ -326,79 +271,14 @@
       parseInt($rollMetadata.FIRST_HOLE, 10);
 </script>
 
-<div id="roll-viewer" />
-<div id="roll-viewer-controls">
-  <button
-    on:click={() => openSeadragon.viewport.zoomTo(Math.min(openSeadragon.viewport.getZoom() * 1.1, maxZoomLevel))}
-  >
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      width="24"
-      height="24"
-      viewBox="0 0 24 24"
-      stroke-width="2"
-      stroke="currentColor"
-      fill="none"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-    >
-      <line x1="12" y1="5" x2="12" y2="19" />
-      <line x1="5" y1="12" x2="19" y2="12" />
-    </svg>
-  </button>
-  <button
-    on:click={() => openSeadragon.viewport.zoomTo(Math.max(openSeadragon.viewport.getZoom() * 0.9, minZoomLevel))}
-  >
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      width="24"
-      height="24"
-      viewBox="0 0 24 24"
-      stroke-width="2"
-      stroke="currentColor"
-      fill="none"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-    >
-      <line x1="5" y1="12" x2="19" y2="12" />
-    </svg>
-  </button>
-  <button on:click={centerRoll}>
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      width="24"
-      height="24"
-      viewBox="0 0 24 24"
-      stroke-width="2"
-      stroke="currentColor"
-      fill="none"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-    >
-      <line x1="4" y1="6" x2="20" y2="6" />
-      <line x1="8" y1="12" x2="16" y2="12" />
-      <line x1="6" y1="18" x2="18" y2="18" />
-    </svg>
-  </button>
-  <button
-    on:click={() => {
-      openSeadragon.viewport.zoomTo(1);
-      centerRoll();
-    }}
-  >
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      height="24"
-      viewBox="0 0 24 24"
-      stroke-width="2"
-      stroke="currentColor"
-      fill="none"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-    >
-      <polyline points="7 8 3 12 7 16" />
-      <polyline points="17 8 21 12 17 16" />
-      <line x1="3" y1="12" x2="21" y2="12" />
-    </svg>
-  </button>
+<div
+  id="roll-viewer"
+  on:mouseenter={() => (showControls = true)}
+  on:mouseleave={() => (showControls = false)}
+>
+  {#if showControls}
+    <div transition:fade>
+      <RollViewerControls {openSeadragon} {minZoomLevel} {maxZoomLevel} />
+    </div>
+  {/if}
 </div>

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -110,7 +110,7 @@
 
   let openSeadragon;
   let firstHolePx;
-  let dragging;
+  let strafing;
   let marks = [];
   let hoveredMark;
   let showControls;
@@ -205,12 +205,12 @@
     openSeadragon.viewport.viewer.addOverlay(svg, entireViewportRectangle);
   };
 
-  const panViewportToTick = (tick) => {
+  const advanceToTick = (tick) => {
     if (!openSeadragon) return;
     const { viewport } = openSeadragon;
-    // if we're dragging we want the target bounds, if otherwise (and most
-    //   especially if we happen to be zooming) we want the current bounds
-    const viewportBounds = viewport.getBounds(!dragging);
+    // if we're panning horizontally we want the target bounds, if otherwise
+    //  (and most especially if we happen to be zooming) we want the current bounds
+    const viewportBounds = viewport.getBounds(!strafing);
     const linePx = firstHolePx + (scrollDownwards ? tick : -tick);
     const lineViewport = viewport.imageToViewportCoordinates(0, linePx);
     const lineCenter = new OpenSeadragon.Point(
@@ -254,14 +254,14 @@
 
     openSeadragon.addOnceHandler("update-viewport", () => {
       createHolesOverlaySvg();
-      panViewportToTick(0);
+      advanceToTick(0);
     });
-    openSeadragon.addHandler("canvas-drag", () => (dragging = true));
-    openSeadragon.addHandler("canvas-drag-end", () => (dragging = false));
+    openSeadragon.addHandler("canvas-drag", () => (strafing = true));
+    openSeadragon.addHandler("canvas-drag-end", () => (strafing = false));
     openSeadragon.open(imageUrl);
   });
 
-  $: panViewportToTick($currentTick);
+  $: advanceToTick($currentTick);
   $: highlightHoles($currentTick);
   $: scrollDownwards = $rollMetadata.ROLL_TYPE === "welte-red";
   $: firstHolePx = scrollDownwards
@@ -277,7 +277,7 @@
 >
   {#if showControls}
     <RollViewerControls
-      bind:dragging
+      bind:strafing
       {openSeadragon}
       {minZoomLevel}
       {maxZoomLevel}

--- a/src/components/RollViewerControls.svelte
+++ b/src/components/RollViewerControls.svelte
@@ -104,23 +104,6 @@
       <line x1="5" y1="12" x2="19" y2="12" />
     </svg>
   </button>
-  <button on:click={centerRoll}>
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      width="24"
-      height="24"
-      viewBox="0 0 24 24"
-      stroke-width="2"
-      stroke="currentColor"
-      fill="none"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-    >
-      <line x1="4" y1="6" x2="20" y2="6" />
-      <line x1="8" y1="12" x2="16" y2="12" />
-      <line x1="6" y1="18" x2="18" y2="18" />
-    </svg>
-  </button>
   <button
     disabled={currentZoom === 1}
     on:click={() => {

--- a/src/components/RollViewerControls.svelte
+++ b/src/components/RollViewerControls.svelte
@@ -33,6 +33,7 @@
 
       &:disabled {
         color: grey;
+        cursor: not-allowed;
       }
     }
   }

--- a/src/components/RollViewerControls.svelte
+++ b/src/components/RollViewerControls.svelte
@@ -1,0 +1,129 @@
+<style lang="scss">
+  #roll-viewer-controls {
+    background: rgba(0, 0, 0, 0.4);
+    border-radius: 4px;
+    left: 50%;
+    padding: 8px;
+    position: absolute;
+    top: 8px;
+    transform: translateX(-50%);
+    z-index: 25;
+
+    button {
+      background: none;
+      border: none;
+      color: #ffffff;
+      cursor: pointer;
+      margin: 0;
+      padding: 0.35em 0.8em;
+      transition: all 0.2s;
+
+      &:focus,
+      &:active {
+        outline: 0;
+      }
+
+      &:hover {
+        outline: 1px solid white;
+      }
+
+      &:active {
+        color: grey;
+      }
+    }
+  }
+</style>
+
+<script>
+  import OpenSeadragon from "openseadragon";
+
+  export let openSeadragon;
+  export let maxZoomLevel;
+  export let minZoomLevel;
+
+  const centerRoll = () => {
+    const { viewport } = openSeadragon;
+    const viewportBounds = viewport.getBounds();
+    const lineCenter = new OpenSeadragon.Point(
+      0.5,
+      viewportBounds.y + viewportBounds.height / 2,
+    );
+    viewport.panTo(lineCenter);
+  };
+</script>
+
+<div id="roll-viewer-controls">
+  <button
+    on:click={() => openSeadragon.viewport.zoomTo(Math.min(openSeadragon.viewport.getZoom() * 1.1, maxZoomLevel))}
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      stroke-width="2"
+      stroke="currentColor"
+      fill="none"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <line x1="12" y1="5" x2="12" y2="19" />
+      <line x1="5" y1="12" x2="19" y2="12" />
+    </svg>
+  </button>
+  <button
+    on:click={() => openSeadragon.viewport.zoomTo(Math.max(openSeadragon.viewport.getZoom() * 0.9, minZoomLevel))}
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      stroke-width="2"
+      stroke="currentColor"
+      fill="none"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <line x1="5" y1="12" x2="19" y2="12" />
+    </svg>
+  </button>
+  <button on:click={centerRoll}>
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      stroke-width="2"
+      stroke="currentColor"
+      fill="none"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <line x1="4" y1="6" x2="20" y2="6" />
+      <line x1="8" y1="12" x2="16" y2="12" />
+      <line x1="6" y1="18" x2="18" y2="18" />
+    </svg>
+  </button>
+  <button
+    on:click={() => {
+      openSeadragon.viewport.zoomTo(1);
+      centerRoll();
+    }}
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      height="24"
+      viewBox="0 0 24 24"
+      stroke-width="2"
+      stroke="currentColor"
+      fill="none"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <polyline points="7 8 3 12 7 16" />
+      <polyline points="17 8 21 12 17 16" />
+      <line x1="3" y1="12" x2="21" y2="12" />
+    </svg>
+  </button>
+</div>

--- a/src/components/RollViewerControls.svelte
+++ b/src/components/RollViewerControls.svelte
@@ -40,6 +40,7 @@
 
 <script>
   import { onMount } from "svelte";
+  import { fade } from "svelte/transition";
   import OpenSeadragon from "openseadragon";
 
   export let openSeadragon;
@@ -66,7 +67,7 @@
   });
 </script>
 
-<div id="roll-viewer-controls">
+<div id="roll-viewer-controls" transition:fade>
   <button
     disabled={currentZoom >= maxZoomLevel}
     on:click={() => openSeadragon.viewport.zoomTo(Math.min(openSeadragon.viewport.getZoom() * 1.1, maxZoomLevel))}

--- a/src/components/RollViewerControls.svelte
+++ b/src/components/RollViewerControls.svelte
@@ -46,6 +46,7 @@
   export let openSeadragon;
   export let maxZoomLevel;
   export let minZoomLevel;
+  export let dragging;
 
   let currentZoom = openSeadragon.viewport.getZoom();
 
@@ -56,7 +57,9 @@
       0.5,
       viewportBounds.y + viewportBounds.height / 2,
     );
+    dragging = true;
     viewport.panTo(lineCenter);
+    setTimeout(() => (dragging = false), 1000);
   };
 
   const onZoom = () => (currentZoom = openSeadragon.viewport.getZoom());

--- a/src/components/RollViewerControls.svelte
+++ b/src/components/RollViewerControls.svelte
@@ -30,16 +30,23 @@
       &:active {
         color: grey;
       }
+
+      &:disabled {
+        color: grey;
+      }
     }
   }
 </style>
 
 <script>
+  import { onMount } from "svelte";
   import OpenSeadragon from "openseadragon";
 
   export let openSeadragon;
   export let maxZoomLevel;
   export let minZoomLevel;
+
+  let currentZoom = openSeadragon.viewport.getZoom();
 
   const centerRoll = () => {
     const { viewport } = openSeadragon;
@@ -50,10 +57,18 @@
     );
     viewport.panTo(lineCenter);
   };
+
+  const onZoom = () => (currentZoom = openSeadragon.viewport.getZoom());
+
+  onMount(() => {
+    openSeadragon.addHandler("zoom", onZoom);
+    return () => openSeadragon.removeHandler("zoom", onZoom);
+  });
 </script>
 
 <div id="roll-viewer-controls">
   <button
+    disabled={currentZoom >= maxZoomLevel}
     on:click={() => openSeadragon.viewport.zoomTo(Math.min(openSeadragon.viewport.getZoom() * 1.1, maxZoomLevel))}
   >
     <svg
@@ -72,6 +87,7 @@
     </svg>
   </button>
   <button
+    disabled={currentZoom <= minZoomLevel}
     on:click={() => openSeadragon.viewport.zoomTo(Math.max(openSeadragon.viewport.getZoom() * 0.9, minZoomLevel))}
   >
     <svg
@@ -106,6 +122,7 @@
     </svg>
   </button>
   <button
+    disabled={currentZoom === 1}
     on:click={() => {
       openSeadragon.viewport.zoomTo(1);
       centerRoll();

--- a/src/components/RollViewerControls.svelte
+++ b/src/components/RollViewerControls.svelte
@@ -46,7 +46,7 @@
   export let openSeadragon;
   export let maxZoomLevel;
   export let minZoomLevel;
-  export let dragging;
+  export let strafing;
 
   let currentZoom = openSeadragon.viewport.getZoom();
 
@@ -57,9 +57,9 @@
       0.5,
       viewportBounds.y + viewportBounds.height / 2,
     );
-    dragging = true;
+    strafing = true;
     viewport.panTo(lineCenter);
-    setTimeout(() => (dragging = false), 1000);
+    setTimeout(() => (strafing = false), 1000);
   };
 
   const onZoom = () => (currentZoom = openSeadragon.viewport.getZoom());

--- a/src/components/RollViewerControls.svelte
+++ b/src/components/RollViewerControls.svelte
@@ -124,7 +124,8 @@
     >
       <polyline points="7 8 3 12 7 16" />
       <polyline points="17 8 21 12 17 16" />
-      <line x1="3" y1="12" x2="21" y2="12" />
+      <line x1="3" y1="12" x2="9" y2="12" />
+      <line x1="14" y1="12" x2="20" y2="12" />
     </svg>
   </button>
 </div>


### PR DESCRIPTION
Here are a couple more updates for the roll viewer controls, then.  The user-facing changes are:

1) the buttons are now disabled when their use isn't appropriate (imo this is quite important for decent UX);

2) the fit-to-width icon is changed a little.  I'm not sure anything much more detailed is going to work well at this size, so I did this quickly.  Willing to revise again as needed;

3) you can now fit-to-width successfully while the roll is playing (this will have to be revisited, I expect, in order to make scrubbing and/or vertical panning possible, but that's for later);

4) I dropped the 'center' button -- it poses a number of technical and UI issues, and the functionality isn't actually very useful imo; again, willing to reconsider.