### PR TITLE
Vertical panning and wheeling

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -198,7 +198,11 @@
     </FlexCollapsible>
     {#if appReady}
       <div id="roll">
-        <RollViewer imageUrl={currentRoll.image_url} {holesByTickInterval} />
+        <RollViewer
+          imageUrl={currentRoll.image_url}
+          {holesByTickInterval}
+          {skipToTick}
+        />
       </div>
       <FlexCollapsible id="right-sidebar" width="20vw" position="left">
         <TabbedPanel {playPauseApp} {stopApp} {skipToPercentage} />

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -344,7 +344,13 @@
   on:mouseleave={() => (showControls = false)}
   on:wheel|capture|preventDefault={(event) => {
     if (event.ctrlKey) {
-      skipToTick($currentTick + (event.deltaY > 0 ? 150 : -150));
+      const { viewport } = openSeadragon;
+      const bounds = viewport.getBounds();
+      const delta = new OpenSeadragon.Point(0, event.deltaY > 0 ? bounds.height / 10 : -bounds.height / 10);
+      viewport.panBy(delta);
+      const center = viewport.getCenter(false);
+      const centerCoords = viewport.viewportToImageCoordinates(center);
+      skipToTick(scrollDownwards ? centerCoords.y - firstHolePx : firstHolePx - centerCoords.y);
       event.stopPropagation();
     }
   }}

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -308,16 +308,17 @@
       createHolesOverlaySvg();
       advanceToTick(0);
     });
-    openSeadragon.addHandler("canvas-drag", () => (strafing = true));
-    openSeadragon.addHandler("canvas-drag-end", () => {
+    openSeadragon.addHandler("canvas-drag", () => {
       const { viewport } = openSeadragon;
       const viewportCenter = viewport.getCenter(false);
       const imgCenter = viewport.viewportToImageCoordinates(viewportCenter);
       skipToTick(
         scrollDownwards ? imgCenter.y - firstHolePx : firstHolePx - imgCenter.y,
       );
-      strafing = false;
+
+      strafing = true;
     });
+    openSeadragon.addHandler("canvas-drag-end", () => (strafing = false));
     openSeadragon.addHandler("open", () => {
       const tiledImage = openSeadragon.viewport.viewer.world.getItemAt(0);
       tiledImage.addOnceHandler(

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -148,6 +148,7 @@
 
   export let imageUrl;
   export let holesByTickInterval;
+  export let skipToTick;
 
   const WELTE_MIDI_START = 10;
   const WELTE_RED_FIRST_NOTE = 24;
@@ -308,7 +309,15 @@
       advanceToTick(0);
     });
     openSeadragon.addHandler("canvas-drag", () => (strafing = true));
-    openSeadragon.addHandler("canvas-drag-end", () => (strafing = false));
+    openSeadragon.addHandler("canvas-drag-end", () => {
+      const { viewport } = openSeadragon;
+      const viewportCenter = viewport.getCenter(false);
+      const imgCenter = viewport.viewportToImageCoordinates(viewportCenter);
+      skipToTick(
+        scrollDownwards ? imgCenter.y - firstHolePx : firstHolePx - imgCenter.y,
+      );
+      strafing = false;
+    });
     openSeadragon.addHandler("open", () => {
       const tiledImage = openSeadragon.viewport.viewer.world.getItemAt(0);
       tiledImage.addOnceHandler(

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -345,12 +345,11 @@
   on:wheel|capture|preventDefault={(event) => {
     if (event.ctrlKey) {
       const { viewport } = openSeadragon;
-      const bounds = viewport.getBounds();
-      const delta = new OpenSeadragon.Point(0, event.deltaY > 0 ? bounds.height / 10 : -bounds.height / 10);
-      viewport.panBy(delta);
-      const center = viewport.getCenter(false);
-      const centerCoords = viewport.viewportToImageCoordinates(center);
-      skipToTick(scrollDownwards ? centerCoords.y - firstHolePx : firstHolePx - centerCoords.y);
+      const viewportBounds = viewport.getBounds();
+      const imgBounds = viewport.viewportToImageRectangle(viewportBounds);
+      const delta = event.deltaY > 0 ? imgBounds.height / 10 : -imgBounds.height / 10;
+      const centerY = imgBounds.y + imgBounds.height / 2;
+      skipToTick(scrollDownwards ? centerY + delta - firstHolePx : firstHolePx - centerY + delta);
       event.stopPropagation();
     }
   }}

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -342,6 +342,12 @@
   id="roll-viewer"
   on:mouseenter={() => (showControls = true)}
   on:mouseleave={() => (showControls = false)}
+  on:wheel|capture|preventDefault={(event) => {
+    if (event.ctrlKey) {
+      skipToTick($currentTick + (event.deltaY > 0 ? 150 : -150));
+      event.stopPropagation();
+    }
+  }}
   class:active-note-details={$userSettings.activeNoteDetails}
 >
   {#if !rollImageReady}


### PR DESCRIPTION
This is the best I've been able to get this so far, then (looks awful simple when you look at the overall diff!).

* Vertical panning works nicely when the roll is stopped.  There could perhaps be a conversation to be had around the sensitivity settings.  The panning is using OpenSeadragon's native implementation, and it does expose some values we could easily adjust.

* The panning works very comfortably while playing on the Chromium-based browsers, and fails (but tolerably so) on FF.

* Ctrl+Mousewheel (on the roll image) scrolls the roll (I assume this maps to Cmd+Mousewheel on Macs -- it's only just occurred to me now to think about that).  The scroll increment is 10% of the viewport height per event, which feels comfortable to me.  We may have the whole scroll-direction inversion Macs vs. non-Macs thing here again.  Writing these notes now I also wonder whether overlay buttons could be provided to offer the same scroll up/down functionality without the mousewheel.

