### PR TITLE
Vertical panning buttons

### DIFF
--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -330,6 +330,18 @@
     openSeadragon.open(imageUrl);
   });
 
+  const panByIncrement = (down = true) => {
+    const viewportBounds = viewport.getBounds();
+    const imgBounds = viewport.viewportToImageRectangle(viewportBounds);
+    const delta = down ? imgBounds.height / 10 : -imgBounds.height / 10;
+    const centerY = imgBounds.y + imgBounds.height / 2;
+    skipToTick(
+      scrollDownwards
+        ? centerY + delta - firstHolePx
+        : firstHolePx - centerY + delta,
+    );
+  };
+
   $: advanceToTick($currentTick);
   $: highlightHoles($currentTick);
   $: scrollDownwards = $rollMetadata.ROLL_TYPE === "welte-red";
@@ -345,11 +357,7 @@
   on:mouseleave={() => (showControls = false)}
   on:wheel|capture|preventDefault={(event) => {
     if (event.ctrlKey) {
-      const viewportBounds = viewport.getBounds();
-      const imgBounds = viewport.viewportToImageRectangle(viewportBounds);
-      const delta = event.deltaY > 0 ? imgBounds.height / 10 : -imgBounds.height / 10;
-      const centerY = imgBounds.y + imgBounds.height / 2;
-      skipToTick(scrollDownwards ? centerY + delta - firstHolePx : firstHolePx - centerY + delta);
+      panByIncrement(event.deltaY > 0);
       event.stopPropagation();
     }
   }}
@@ -364,6 +372,7 @@
       {openSeadragon}
       {minZoomLevel}
       {maxZoomLevel}
+      {panByIncrement}
     />
   {/if}
 </div>

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -330,15 +330,15 @@
     openSeadragon.open(imageUrl);
   });
 
-  const panByIncrement = (down = true) => {
+  const panByIncrement = (up = true) => {
     const viewportBounds = viewport.getBounds();
     const imgBounds = viewport.viewportToImageRectangle(viewportBounds);
-    const delta = down ? imgBounds.height / 10 : -imgBounds.height / 10;
+    const delta = up ? imgBounds.height / 10 : -imgBounds.height / 10;
     const centerY = imgBounds.y + imgBounds.height / 2;
     skipToTick(
       scrollDownwards
         ? centerY + delta - firstHolePx
-        : firstHolePx - centerY + delta,
+        : firstHolePx - centerY - delta,
     );
   };
 

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -159,6 +159,7 @@
   const maxZoomLevel = 4;
 
   let openSeadragon;
+  let viewport;
   let firstHolePx;
   let strafing = false;
   let rollImageReady;
@@ -199,15 +200,15 @@
     if (noteName) mark.dataset.info = noteName;
     mark.addEventListener("mouseout", () => {
       if (!marks.map(([_hole]) => _hole).includes(hole))
-        openSeadragon.viewport.viewer.removeOverlay(hoveredMark);
+        viewport.viewer.removeOverlay(hoveredMark);
     });
-    const viewportRectangle = openSeadragon.viewport.imageToViewportRectangle(
+    const viewportRectangle = viewport.imageToViewportRectangle(
       ORIGIN_COL,
       ORIGIN_ROW,
       WIDTH_COL,
       OFF_TIME - ORIGIN_ROW,
     );
-    openSeadragon.viewport.viewer.addOverlay(mark, viewportRectangle);
+    viewport.viewer.addOverlay(mark, viewportRectangle);
     return mark;
   };
 
@@ -221,7 +222,7 @@
     const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     const g = document.createElementNS("http://www.w3.org/2000/svg", "g");
 
-    const entireViewportRectangle = openSeadragon.viewport.imageToViewportRectangle(
+    const entireViewportRectangle = viewport.imageToViewportRectangle(
       0,
       0,
       imageWidth,
@@ -246,19 +247,18 @@
       rect.setAttribute("height", OFF_TIME - ORIGIN_ROW);
       rect.addEventListener("mouseover", () => {
         if (marks.map(([_hole]) => _hole).includes(hole)) return;
-        openSeadragon.viewport.viewer.removeOverlay(hoveredMark);
+        viewport.viewer.removeOverlay(hoveredMark);
         hoveredMark = createMark(hole);
       });
 
       g.appendChild(rect);
     });
 
-    openSeadragon.viewport.viewer.addOverlay(svg, entireViewportRectangle);
+    viewport.viewer.addOverlay(svg, entireViewportRectangle);
   };
 
   const advanceToTick = (tick) => {
     if (!openSeadragon) return;
-    const { viewport } = openSeadragon;
     // if we're panning horizontally we want the target bounds, if otherwise
     //  (and most especially if we happen to be zooming) we want the current bounds
     const viewportBounds = viewport.getBounds(!strafing);
@@ -279,7 +279,7 @@
 
     marks = marks.filter(([hole, elem]) => {
       if (holes.includes(hole)) return true;
-      openSeadragon.viewport.viewer.removeOverlay(elem);
+      viewport.viewer.removeOverlay(elem);
       return false;
     });
 
@@ -304,12 +304,13 @@
       preserveImageSizeOnResize: true,
     });
 
+    ({ viewport } = openSeadragon);
+
     openSeadragon.addOnceHandler("update-viewport", () => {
       createHolesOverlaySvg();
       advanceToTick(0);
     });
     openSeadragon.addHandler("canvas-drag", () => {
-      const { viewport } = openSeadragon;
       const viewportCenter = viewport.getCenter(false);
       const imgCenter = viewport.viewportToImageCoordinates(viewportCenter);
       skipToTick(
@@ -320,7 +321,7 @@
     });
     openSeadragon.addHandler("canvas-drag-end", () => (strafing = false));
     openSeadragon.addHandler("open", () => {
-      const tiledImage = openSeadragon.viewport.viewer.world.getItemAt(0);
+      const tiledImage = viewport.viewer.world.getItemAt(0);
       tiledImage.addOnceHandler(
         "fully-loaded-change",
         () => (rollImageReady = true),
@@ -344,7 +345,6 @@
   on:mouseleave={() => (showControls = false)}
   on:wheel|capture|preventDefault={(event) => {
     if (event.ctrlKey) {
-      const { viewport } = openSeadragon;
       const viewportBounds = viewport.getBounds();
       const imgBounds = viewport.viewportToImageRectangle(viewportBounds);
       const delta = event.deltaY > 0 ? imgBounds.height / 10 : -imgBounds.height / 10;

--- a/src/components/RollViewerControls.svelte
+++ b/src/components/RollViewerControls.svelte
@@ -62,6 +62,7 @@
   export let maxZoomLevel;
   export let minZoomLevel;
   export let strafing;
+  export let panByIncrement;
 
   const { viewport } = openSeadragon;
   let currentZoom = viewport.getZoom();
@@ -148,7 +149,7 @@
   </button>
 </div>
 <div id="pan-controls" transition:fade>
-  <button disabled={false} on:click={() => {}}>
+  <button disabled={false} on:click={() => panByIncrement(true)}>
     <svg
       xmlns="http://www.w3.org/2000/svg"
       width="24"
@@ -165,7 +166,7 @@
       <line x1="8" y1="9" x2="12" y2="5" />
     </svg>
   </button>
-  <button disabled={false} on:click={() => {}}>
+  <button disabled={false} on:click={() => panByIncrement(false)}>
     <svg
       xmlns="http://www.w3.org/2000/svg"
       width="24"

--- a/src/components/RollViewerControls.svelte
+++ b/src/components/RollViewerControls.svelte
@@ -63,6 +63,7 @@
   export let minZoomLevel;
   export let strafing;
   export let panByIncrement;
+  export let panInterval;
 
   const { viewport } = openSeadragon;
   let currentZoom = viewport.getZoom();
@@ -149,7 +150,13 @@
   </button>
 </div>
 <div id="pan-controls" transition:fade>
-  <button disabled={false} on:click={() => panByIncrement(false)}>
+  <button
+    disabled={false}
+    on:mousedown={() => {
+      panByIncrement(false);
+      panInterval = setInterval(() => panByIncrement(false), 100);
+    }}
+  >
     <svg
       xmlns="http://www.w3.org/2000/svg"
       width="24"
@@ -166,7 +173,13 @@
       <line x1="8" y1="9" x2="12" y2="5" />
     </svg>
   </button>
-  <button disabled={false} on:click={() => panByIncrement(true)}>
+  <button
+    disabled={false}
+    on:mousedown={() => {
+      panByIncrement(true);
+      panInterval = setInterval(() => panByIncrement(true), 100);
+    }}
+  >
     <svg
       xmlns="http://www.w3.org/2000/svg"
       width="24"
@@ -184,3 +197,4 @@
     </svg>
   </button>
 </div>
+<svelte:window on:mouseup={() => clearInterval(panInterval)} />

--- a/src/components/RollViewerControls.svelte
+++ b/src/components/RollViewerControls.svelte
@@ -149,7 +149,7 @@
   </button>
 </div>
 <div id="pan-controls" transition:fade>
-  <button disabled={false} on:click={() => panByIncrement(true)}>
+  <button disabled={false} on:click={() => panByIncrement(false)}>
     <svg
       xmlns="http://www.w3.org/2000/svg"
       width="24"
@@ -166,7 +166,7 @@
       <line x1="8" y1="9" x2="12" y2="5" />
     </svg>
   </button>
-  <button disabled={false} on:click={() => panByIncrement(false)}>
+  <button disabled={false} on:click={() => panByIncrement(true)}>
     <svg
       xmlns="http://www.w3.org/2000/svg"
       width="24"

--- a/src/components/RollViewerControls.svelte
+++ b/src/components/RollViewerControls.svelte
@@ -49,10 +49,10 @@
   export let minZoomLevel;
   export let strafing;
 
-  let currentZoom = openSeadragon.viewport.getZoom();
+  const { viewport } = openSeadragon;
+  let currentZoom = viewport.getZoom();
 
   const centerRoll = () => {
-    const { viewport } = openSeadragon;
     const viewportBounds = viewport.getBounds();
     const lineCenter = new OpenSeadragon.Point(
       0.5,
@@ -63,7 +63,7 @@
     setTimeout(() => (strafing = false), 1000);
   };
 
-  const onZoom = () => (currentZoom = openSeadragon.viewport.getZoom());
+  const onZoom = () => (currentZoom = viewport.getZoom());
 
   onMount(() => {
     openSeadragon.addHandler("zoom", onZoom);
@@ -74,7 +74,7 @@
 <div id="roll-viewer-controls" transition:fade>
   <button
     disabled={currentZoom >= maxZoomLevel}
-    on:click={() => openSeadragon.viewport.zoomTo(Math.min(openSeadragon.viewport.getZoom() * 1.1, maxZoomLevel))}
+    on:click={() => viewport.zoomTo(Math.min(viewport.getZoom() * 1.1, maxZoomLevel))}
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -93,7 +93,7 @@
   </button>
   <button
     disabled={currentZoom <= minZoomLevel}
-    on:click={() => openSeadragon.viewport.zoomTo(Math.max(openSeadragon.viewport.getZoom() * 0.9, minZoomLevel))}
+    on:click={() => viewport.zoomTo(Math.max(viewport.getZoom() * 0.9, minZoomLevel))}
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -112,7 +112,7 @@
   <button
     disabled={currentZoom === 1}
     on:click={() => {
-      openSeadragon.viewport.zoomTo(1);
+      viewport.zoomTo(1);
       centerRoll();
     }}
   >

--- a/src/components/RollViewerControls.svelte
+++ b/src/components/RollViewerControls.svelte
@@ -1,12 +1,9 @@
 <style lang="scss">
-  #roll-viewer-controls {
+  div {
     background: rgba(0, 0, 0, 0.4);
     border-radius: 4px;
-    left: 50%;
     padding: 8px;
     position: absolute;
-    top: 8px;
-    transform: translateX(-50%);
     z-index: 25;
 
     button {
@@ -35,6 +32,23 @@
         color: grey;
         cursor: not-allowed;
       }
+    }
+  }
+
+  #roll-viewer-controls {
+    left: 50%;
+    top: 8px;
+    transform: translateX(-50%);
+  }
+  #pan-controls {
+    top: 50%;
+    right: 8px;
+    transform: translateY(-50%);
+    display: flex;
+    flex-direction: column;
+
+    button {
+      padding: 0.8em 0.35em;
     }
   }
 </style>
@@ -130,6 +144,42 @@
       <polyline points="17 8 21 12 17 16" />
       <line x1="3" y1="12" x2="9" y2="12" />
       <line x1="14" y1="12" x2="20" y2="12" />
+    </svg>
+  </button>
+</div>
+<div id="pan-controls" transition:fade>
+  <button disabled={false} on:click={() => {}}>
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      stroke-width="2"
+      stroke="currentColor"
+      fill="none"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <line x1="12" y1="5" x2="12" y2="19" />
+      <line x1="16" y1="9" x2="12" y2="5" />
+      <line x1="8" y1="9" x2="12" y2="5" />
+    </svg>
+  </button>
+  <button disabled={false} on:click={() => {}}>
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      stroke-width="2"
+      stroke="currentColor"
+      fill="none"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <line x1="12" y1="5" x2="12" y2="19" />
+      <line x1="16" y1="15" x2="12" y2="19" />
+      <line x1="8" y1="15" x2="12" y2="19" />
     </svg>
   </button>
 </div>


### PR DESCRIPTION
Some buttons for those who don't have a <kbd>ctrl</kbd>/<kbd>cmd</kbd> key (also better discoverability etc.).

A couple of things thrown up by this:

1) Previously the <kbd>ctrl</kbd>/<kbd>cmd</kbd> + mousewheel thing was moving in opposite directions depending on the direction of the roll.  This was not intentional on my part (!), but perhaps you noticed and liked it?

2) It's possible to scroll off the ends of the roll and into infinity, it seems (with buttons or mousewheel).

3) Not directly related to this PR, but I noticed while testing:  using the zoom functionality can cause the red line "tracker bar" indicator to get out of sync with where the actually playback position is.  This is a little unpolished.

I consider (2) and (3) to be fairly minor polishing issues that I'm inclined to wait until the PIs have seen all the recent changes before cleaning up.  Seem reasonable?