### PR TITLE
Overlay Keyboard

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -38,6 +38,14 @@
     flex: 0 1 auto;
     user-select: none;
   }
+
+  #keyboard-overlay {
+    position: absolute;
+    z-index: 23;
+    bottom: 0;
+    width: 100%;
+    opacity: 0.5;
+  }
 </style>
 
 <script>
@@ -72,6 +80,7 @@
   let currentRoll;
   let previousRoll;
   let holesByTickInterval = new IntervalTree();
+  let overlayKeyboard = false;
 
   const buildHolesIntervalTree = () => {
     const { ROLL_TYPE, FIRST_HOLE, IMAGE_LENGTH, holeData } = $rollMetadata;
@@ -195,6 +204,9 @@
             this time. Hole highlighting will not be enabled.
           </p>
         {/if}
+        <button
+          on:click={() => (overlayKeyboard = !overlayKeyboard)}
+        >kb</button>
       {/if}
     </FlexCollapsible>
     {#if appReady}
@@ -204,15 +216,22 @@
           {holesByTickInterval}
           {skipToTick}
         />
+        {#if overlayKeyboard}
+          <div id="keyboard-overlay">
+            <Keyboard keyCount="88" {activeNotes} {startNote} {stopNote} />
+          </div>
+        {/if}
       </div>
       <FlexCollapsible id="right-sidebar" width="20vw" position="left">
         <TabbedPanel {playPauseApp} {stopApp} {skipToPercentage} />
       </FlexCollapsible>
     {/if}
   </div>
-  <div id="keyboard-container">
-    <Keyboard keyCount="88" {activeNotes} {startNote} {stopNote} />
-  </div>
+  {#if !overlayKeyboard}
+    <div id="keyboard-container">
+      <Keyboard keyCount="88" {activeNotes} {startNote} {stopNote} />
+    </div>
+  {/if}
   {#if !appReady}
     <div id="loading">
       <div><span /> <span /> <span /> <span /> <span /></div>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -49,6 +49,7 @@
 </style>
 
 <script>
+  import { quartInOut } from "svelte/easing";
   import { fade } from "svelte/transition";
   import IntervalTree from "node-interval-tree";
   import {
@@ -82,6 +83,15 @@
   let previousRoll;
   let holesByTickInterval = new IntervalTree();
   let overlayKeyboard = false;
+
+  const slide = (node, { delay = 0, duration = 300 }) => {
+    const o = parseInt(getComputedStyle(node).height, 10);
+    return {
+      delay,
+      duration,
+      css: (t) => `height: ${quartInOut(t) * o}px`,
+    };
+  };
 
   const buildHolesIntervalTree = () => {
     const { ROLL_TYPE, FIRST_HOLE, IMAGE_LENGTH, holeData } = $rollMetadata;
@@ -229,7 +239,7 @@
     {/if}
   </div>
   {#if !overlayKeyboard}
-    <div id="keyboard-container">
+    <div id="keyboard-container" transition:slide>
       <Keyboard keyCount="88" {activeNotes} {startNote} {stopNote} />
     </div>
   {/if}

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -60,6 +60,7 @@
     activeNotes,
     currentTick,
     rollMetadata,
+    overlayKeyboard,
   } from "./stores";
   import {
     midiSamplePlayer,
@@ -82,7 +83,6 @@
   let currentRoll;
   let previousRoll;
   let holesByTickInterval = new IntervalTree();
-  let overlayKeyboard = false;
 
   const slide = (node, { delay = 0, duration = 300 }) => {
     const o = parseInt(getComputedStyle(node).height, 10);
@@ -216,7 +216,7 @@
           </p>
         {/if}
         <button
-          on:click={() => (overlayKeyboard = !overlayKeyboard)}
+          on:click={() => ($overlayKeyboard = !$overlayKeyboard)}
         >kb</button>
       {/if}
     </FlexCollapsible>
@@ -227,7 +227,7 @@
           {holesByTickInterval}
           {skipToTick}
         />
-        {#if overlayKeyboard}
+        {#if $overlayKeyboard}
           <div id="keyboard-overlay" transition:fade>
             <Keyboard keyCount="88" {activeNotes} {startNote} {stopNote} />
           </div>
@@ -238,7 +238,7 @@
       </FlexCollapsible>
     {/if}
   </div>
-  {#if !overlayKeyboard}
+  {#if !$overlayKeyboard}
     <div id="keyboard-container" transition:slide>
       <Keyboard keyCount="88" {activeNotes} {startNote} {stopNote} />
     </div>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -49,6 +49,7 @@
 </style>
 
 <script>
+  import { fade } from "svelte/transition";
   import IntervalTree from "node-interval-tree";
   import {
     pedalling,
@@ -217,7 +218,7 @@
           {skipToTick}
         />
         {#if overlayKeyboard}
-          <div id="keyboard-overlay">
+          <div id="keyboard-overlay" transition:fade>
             <Keyboard keyCount="88" {activeNotes} {startNote} {stopNote} />
           </div>
         {/if}

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -41,10 +41,10 @@
 
   #keyboard-overlay {
     position: absolute;
-    z-index: 23;
     bottom: 0;
     width: 100%;
     opacity: 0.5;
+    z-index: z($main-context, keyboard-overlay);
   }
 </style>
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -215,9 +215,6 @@
             this time. Hole highlighting will not be enabled.
           </p>
         {/if}
-        <button
-          on:click={() => ($overlayKeyboard = !$overlayKeyboard)}
-        >kb</button>
       {/if}
     </FlexCollapsible>
     {#if appReady}

--- a/src/components/Keyboard.svelte
+++ b/src/components/Keyboard.svelte
@@ -8,6 +8,19 @@
     aspect-ratio: 10 / 1;
     z-index: z($main-context, keyboard);
     position: relative;
+
+    :global(.overlay-buttons) {
+      opacity: 0;
+      transition: all 0.3s ease;
+
+      &:hover {
+        opacity: 1;
+      }
+    }
+
+    &:hover :global(.overlay-buttons) {
+      opacity: 1;
+    }
   }
 
   @supports not (aspect-ratio: 10 / 1) {
@@ -143,8 +156,6 @@
   export let stopNote;
   export let activeNotes;
 
-  let showControls;
-
   const notes = [
     "A",
     "A#",
@@ -188,11 +199,7 @@
   };
 </script>
 
-<div
-  id="keyboard"
-  on:mouseenter={() => (showControls = true)}
-  on:mouseleave={() => (showControls = false)}
->
+<div id="keyboard">
   <div
     id="keys"
     on:mousedown|preventDefault={({ target }) => {
@@ -230,9 +237,7 @@
       </div>
     {/each}
   </div>
-  {#if showControls}
-    <KeyboardControls />
-  {/if}
+  <KeyboardControls />
 </div>
 
 <svelte:window

--- a/src/components/Keyboard.svelte
+++ b/src/components/Keyboard.svelte
@@ -16,15 +16,19 @@
 
   @supports not (aspect-ratio: 10 / 1) {
     #keyboard {
-      height: 10vw;
+      padding-top: 10%;
+    }
+    div#keys {
+      top: 0;
     }
   }
 
   div#keys {
-    position: relative;
+    position: absolute;
     display: flex;
     padding: 0;
     height: 100%;
+    width: 100%;
 
     &::before {
       background-color: var(--primary-accent);

--- a/src/components/Keyboard.svelte
+++ b/src/components/Keyboard.svelte
@@ -136,11 +136,15 @@
 
 <script>
   import { pedalling } from "../stores";
+  import KeyboardControls from "./KeyboardControls.svelte";
 
   export let keyCount = 88;
   export let startNote;
   export let stopNote;
   export let activeNotes;
+
+  let showControls;
+
   const notes = [
     "A",
     "A#",
@@ -184,7 +188,11 @@
   };
 </script>
 
-<div id="keyboard">
+<div
+  id="keyboard"
+  on:mouseenter={() => (showControls = true)}
+  on:mouseleave={() => (showControls = false)}
+>
   <div
     id="keys"
     on:mousedown|preventDefault={({ target }) => {
@@ -222,7 +230,11 @@
       </div>
     {/each}
   </div>
+  {#if showControls}
+    <KeyboardControls />
+  {/if}
 </div>
+
 <svelte:window
   on:mouseup={() => {
     stopPlaying();

--- a/src/components/Keyboard.svelte
+++ b/src/components/Keyboard.svelte
@@ -9,15 +9,6 @@
     z-index: z($main-context, keyboard);
     position: relative;
 
-    :global(.overlay-buttons) {
-      opacity: 0;
-      transition: all 0.3s ease;
-
-      &:hover {
-        opacity: 1;
-      }
-    }
-
     &:hover :global(.overlay-buttons) {
       opacity: 1;
     }

--- a/src/components/Keyboard.svelte
+++ b/src/components/Keyboard.svelte
@@ -17,8 +17,6 @@
   @supports not (aspect-ratio: 10 / 1) {
     #keyboard {
       height: 10vw;
-      margin: 0;
-      padding: 1vh 1vw;
     }
   }
 

--- a/src/components/KeyboardControls.svelte
+++ b/src/components/KeyboardControls.svelte
@@ -1,10 +1,16 @@
-<style>
+<style lang="scss">
   div {
     left: 1em;
     top: 0;
     transform: translateY(-100%);
     border-radius: 4px 4px 0 0;
     padding: 0;
+    opacity: 0;
+    transition: all 0.3s ease;
+
+    &:hover {
+      opacity: 1;
+    }
   }
 </style>
 

--- a/src/components/KeyboardControls.svelte
+++ b/src/components/KeyboardControls.svelte
@@ -1,0 +1,58 @@
+<style>
+  div {
+    left: 1em;
+    top: 0;
+    transform: translateY(-100%);
+    border-radius: 4px 4px 0 0;
+    padding: 0;
+  }
+</style>
+
+<script>
+  import { fade } from "svelte/transition";
+  import { overlayKeyboard } from "../stores";
+</script>
+
+<div class="overlay-buttons" transition:fade>
+  <button on:click={() => ($overlayKeyboard = !$overlayKeyboard)}>
+    {#if $overlayKeyboard}
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        stroke-width="2"
+        stroke="currentColor"
+        fill="none"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
+        <path
+          d="M11 19h-6a2 2 0 0 1 -2 -2v-10a2 2 0 0 1 2 -2h14a2 2 0 0 1 2 2v4"
+        />
+        <rect x="14" y="14" width="7" height="5" rx="1" />
+        <line x1="7" y1="9" x2="11" y2="13" />
+        <path d="M8 13h3v-3" />
+      </svg>
+    {:else}
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        stroke-width="2"
+        stroke="currentColor"
+        fill="none"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
+        <path
+          d="M11 19h-6a2 2 0 0 1 -2 -2v-10a2 2 0 0 1 2 -2h14a2 2 0 0 1 2 2v4"
+        />
+        <rect x="14" y="14" width="7" height="5" rx="1" />
+        <line x1="7" y1="9" x2="11" y2="13" />
+        <path d="M7 12v-3h3" />
+      </svg>
+    {/if}
+  </button>
+</div>

--- a/src/components/KeyboardControls.svelte
+++ b/src/components/KeyboardControls.svelte
@@ -12,6 +12,10 @@
       opacity: 1;
     }
   }
+
+  button {
+    border-radius: 4px 4px 0 0;
+  }
 </style>
 
 <script>

--- a/src/stores.js
+++ b/src/stores.js
@@ -41,6 +41,8 @@ export const currentTick = createStore(0);
 
 export const activeNotes = createSetStore();
 
+export const overlayKeyboard = createStore(false);
+
 export const userSettings = createStore({
   theme: "cardinal",
   activeNoteDetails: false,

--- a/src/styles/z-index.scss
+++ b/src/styles/z-index.scss
@@ -12,5 +12,5 @@
   @return null;
 }
 
-$main-context: base, keyboard, sidebars, sidebar-collapse-labels,
+$main-context: base, sidebars, keyboard, sidebar-collapse-labels,
   keyboard-overlay, footer, overlay-buttons, notifications;

--- a/src/styles/z-index.scss
+++ b/src/styles/z-index.scss
@@ -12,5 +12,5 @@
   @return null;
 }
 
-$main-context: base, keyboard, sidebars, sidebar-collapse-labels, footer,
-  overlay-buttons, notifications;
+$main-context: base, keyboard, sidebars, sidebar-collapse-labels,
+  keyboard-overlay, footer, overlay-buttons, notifications;


### PR DESCRIPTION
I don't think there's too much to be said about this -- hopefully it "just works".

* I had been intending a second button to slide the keyboard out but *not* overlay it on the roll image (i.e. just to turn the keyboard off) -- this may still be appropriate.

* Also the button styling isn't ideal.  There's a bit of fragmentation between the different overlay buttons that could (and probably should/will) be addressed at some point; in this case I didn't want to use the CSS-only approach that I used for the collapsible sidebars because I really wanted the keyboard component destroyed and out of the DOM altogether when not on screen.

* The icon is not ideal either, but probably acceptable?  I toyed with creating something new and entirely bespoke, but decided to move on to other things instead, for now at least.

* There are also minor side issues like the white outline that has rounded corners on FF but not on other browsers.