### PR TITLE
Tempo Map

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -65,6 +65,7 @@
   import {
     midiSamplePlayer,
     pianoReady,
+    updatePlayer,
     startNote,
     stopNote,
     stopAllNotes,
@@ -144,13 +145,7 @@
 
   const skipToTick = (tick) => {
     $currentTick = tick;
-    if (midiSamplePlayer.isPlaying()) {
-      midiSamplePlayer.pause();
-      midiSamplePlayer.skipToTick($currentTick);
-      midiSamplePlayer.play();
-    } else {
-      midiSamplePlayer.skipToTick($currentTick);
-    }
+    updatePlayer(() => midiSamplePlayer.skipToTick($currentTick));
   };
 
   const skipToPercentage = (percentage) =>

--- a/src/components/PlaybackSettings.svelte
+++ b/src/components/PlaybackSettings.svelte
@@ -61,11 +61,11 @@
   </div>
   <div class="control">
     <span>Tempo:</span>
-    <span>{$tempoControl}</span>
+    <span>{($tempoControl * 100).toFixed(0)}%</span>
     <RangeSlider
-      min="1"
-      max="180"
-      step="1"
+      min="0.1"
+      max="4"
+      step=".001"
       bind:value={$tempoControl}
       name="tempo"
     />

--- a/src/components/SamplePlayer.js
+++ b/src/components/SamplePlayer.js
@@ -36,6 +36,7 @@ const getTempoAtTick = (tick) => {
   while (tempoMap[i][0] <= tick) {
     [, tempo] = tempoMap[i];
     i += 1;
+    if (i >= tempoMap.length) break;
   }
   return tempo;
 };

--- a/src/components/SamplePlayer.js
+++ b/src/components/SamplePlayer.js
@@ -170,4 +170,11 @@ midiSamplePlayer.on(
   },
 );
 
-export { midiSamplePlayer, pianoReady, startNote, stopNote, stopAllNotes };
+export {
+  midiSamplePlayer,
+  pianoReady,
+  updatePlayer,
+  startNote,
+  stopNote,
+  stopAllNotes,
+};

--- a/src/components/SamplePlayer.js
+++ b/src/components/SamplePlayer.js
@@ -37,11 +37,11 @@ volume.subscribe(({ master, right, left }) => {
 });
 
 let tempoMap;
-let tempoRatio = 1.0;
-let tempoControlValue;
-tempoControl.subscribe((newTempo) => {
-  tempoControlValue = newTempo;
-  updatePlayer(() => midiSamplePlayer.setTempo(tempoControlValue * tempoRatio));
+let currentTempo;
+let tempoRatio;
+tempoControl.subscribe((_tempoRatio) => {
+  tempoRatio = _tempoRatio;
+  updatePlayer(() => midiSamplePlayer.setTempo(currentTempo * tempoRatio));
 });
 
 const decodeHtmlEntities = (string) =>
@@ -69,6 +69,8 @@ midiSamplePlayer.on("fileLoaded", () => {
   tempoMap = metadataTrack
     .filter((event) => event.name === "Set Tempo")
     .map(({ tick, data }) => [tick, data]);
+
+  [[, currentTempo]] = tempoMap;
 });
 
 const controllerChange = Object.freeze({
@@ -164,8 +166,8 @@ midiSamplePlayer.on(
         }));
       }
     } else if (name === "Set Tempo") {
-      tempoRatio = 1.0 + (data - tempoMap[0][1]) / tempoMap[0][1];
-      midiSamplePlayer.setTempo(tempoControlValue * tempoRatio);
+      currentTempo = data;
+      midiSamplePlayer.setTempo(data * tempoRatio);
     }
   },
 );

--- a/src/components/SamplePlayer.js
+++ b/src/components/SamplePlayer.js
@@ -36,7 +36,7 @@ volume.subscribe(({ master, right, left }) => {
   leftVolumeRatio = left;
 });
 
-let baseTempo;
+let tempoMap;
 let tempoRatio = 1.0;
 let tempoControlValue;
 tempoControl.subscribe((newTempo) => {
@@ -66,11 +66,9 @@ midiSamplePlayer.on("fileLoaded", () => {
     ),
   );
 
-  baseTempo = metadataTrack
+  tempoMap = metadataTrack
     .filter((event) => event.name === "Set Tempo")
-    .reduce((prevEvent, event) =>
-      event.tick < prevEvent.tick ? event : prevEvent,
-    ).data;
+    .map(({ tick, data }) => [tick, data]);
 });
 
 const controllerChange = Object.freeze({
@@ -166,8 +164,7 @@ midiSamplePlayer.on(
         }));
       }
     } else if (name === "Set Tempo") {
-      const midiTempo = parseFloat(data);
-      tempoRatio = 1.0 + (midiTempo - baseTempo) / baseTempo;
+      tempoRatio = 1.0 + (data - tempoMap[0][1]) / tempoMap[0][1];
       midiSamplePlayer.setTempo(tempoControlValue * tempoRatio);
     }
   },

--- a/src/components/SamplePlayer.js
+++ b/src/components/SamplePlayer.js
@@ -81,7 +81,11 @@ midiSamplePlayer.on("fileLoaded", () => {
 
   tempoMap = metadataTrack
     .filter((event) => event.name === "Set Tempo")
-    .map(({ tick, data }) => [tick, data]);
+    .reduce((_tempoMap, { tick, data }) => {
+      if (!_tempoMap.map(([, _data]) => _data).includes(data))
+        _tempoMap.push([tick, data]);
+      return _tempoMap;
+    }, []);
 });
 
 const controllerChange = Object.freeze({

--- a/src/stores.js
+++ b/src/stores.js
@@ -25,7 +25,7 @@ const createSetStore = () => {
   };
 };
 
-export const tempoControl = createStore(60);
+export const tempoControl = createStore(1);
 export const rollMetadata = createStore({});
 export const pedalling = createStore({
   soft: false,


### PR DESCRIPTION
Tempo Map PR as discussed.  Storing the (user-controlled) tempo value as a coefficient seems desirable, but that can of course be separate from the way it is displayed to users (i.e. we could still convert back to bpm or something if such a conversion seems logically consistent and valid).

See also 7fa3e72 below.  Are we happy just to accept that `midi-player-js` only returns integers for tempo events and move along?  Or should this be on our issue list?