### PR TITLE
Misc Fixes

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -211,7 +211,6 @@
       stopNote,
       stopAllNotes,
     } = samplePlayer);
-    midiSamplePlayer.on("endOfFile", stopApp);
   });
 
   $: if (currentRoll !== previousRoll) loadRoll(currentRoll);

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -189,7 +189,7 @@
       });
 
     Promise.all([mididataReady, metadataReady, pianoReady]).then(
-      ({ 1: metadataJson }) => {
+      ([, metadataJson]) => {
         $rollMetadata = { ...$rollMetadata, ...metadataJson };
         if (metadataJson.holeData)
           buildHolesIntervalTree(metadataJson.holeData);

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -124,7 +124,17 @@
     });
   };
 
+  const skipToTick = (tick) => {
+    $currentTick = tick;
+    updatePlayer(() => midiSamplePlayer.skipToTick($currentTick));
+  };
+
+  const skipToPercentage = (percentage) =>
+    skipToTick(midiSamplePlayer.totalTicks * percentage);
+
   const playPauseApp = () => {
+    if ($currentTick < 0) skipToTick(0);
+
     if (midiSamplePlayer.isPlaying()) {
       midiSamplePlayer.pause();
       stopAllNotes();
@@ -154,14 +164,6 @@
     trebleVolumeCoefficient.reset();
     holesByTickInterval = new IntervalTree();
   };
-
-  const skipToTick = (tick) => {
-    $currentTick = tick;
-    updatePlayer(() => midiSamplePlayer.skipToTick($currentTick));
-  };
-
-  const skipToPercentage = (percentage) =>
-    skipToTick(midiSamplePlayer.totalTicks * percentage);
 
   const loadRoll = (roll) => {
     mididataReady = fetch(`./assets/midi/${roll.druid}.mid`)

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -54,8 +54,6 @@
   import { fade } from "svelte/transition";
   import IntervalTree from "node-interval-tree";
   import {
-    softOnOff,
-    sustainOnOff,
     bassVolumeCoefficient,
     trebleVolumeCoefficient,
     tempoCoefficient,
@@ -63,7 +61,6 @@
     activeNotes,
     currentTick,
     rollMetadata,
-    rollPedalingOnOff,
     overlayKeyboard,
   } from "./stores";
   import { clamp } from "./utils";
@@ -213,12 +210,6 @@
   $: playbackProgress.update(() =>
     clamp($currentTick / midiSamplePlayer?.totalTicks, 0, 1),
   );
-  $: if ($rollPedalingOnOff) {
-    // TODO: set roll pedalling according to (as yet unavailable) pedalMap
-  } else {
-    sustainOnOff.set(false);
-    softOnOff.set(false);
-  }
 </script>
 
 <div id="app">

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -125,6 +125,7 @@
   };
 
   const skipToTick = (tick) => {
+    if (tick < 0) playPauseApp();
     $currentTick = tick;
     updatePlayer(() => midiSamplePlayer.skipToTick($currentTick));
   };
@@ -133,13 +134,12 @@
     skipToTick(midiSamplePlayer.totalTicks * percentage);
 
   const playPauseApp = () => {
-    if ($currentTick < 0) skipToTick(0);
-
     if (midiSamplePlayer.isPlaying()) {
       midiSamplePlayer.pause();
       stopAllNotes();
       activeNotes.reset();
     } else {
+      if ($currentTick < 0) skipToTick(0);
       midiSamplePlayer.play();
     }
   };

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -56,7 +56,6 @@
   import {
     softOnOff,
     sustainOnOff,
-    accentOnOff,
     bassVolumeCoefficient,
     trebleVolumeCoefficient,
     tempoCoefficient,
@@ -92,7 +91,9 @@
   let updatePlayer;
   let startNote;
   let stopNote;
-  let stopAllNotes;
+  let pausePlayback;
+  let startPlayback;
+  let resetPlayback;
 
   const slide = (node, { delay = 0, duration = 300 }) => {
     const o = parseInt(getComputedStyle(node).height, 10);
@@ -125,7 +126,7 @@
   };
 
   const skipToTick = (tick) => {
-    if (tick < 0) playPauseApp();
+    if (tick < 0) pausePlayback();
     $currentTick = tick;
     updatePlayer(() => midiSamplePlayer.skipToTick($currentTick));
   };
@@ -135,30 +136,23 @@
 
   const playPauseApp = () => {
     if (midiSamplePlayer.isPlaying()) {
-      midiSamplePlayer.pause();
-      stopAllNotes();
-      activeNotes.reset();
+      pausePlayback();
     } else {
-      if ($currentTick < 0) skipToTick(0);
-      midiSamplePlayer.play();
+      startPlayback();
     }
   };
 
   const stopApp = () => {
-    midiSamplePlayer.stop();
-    stopAllNotes();
-    playbackProgress.reset();
-    currentTick.reset();
-    activeNotes.reset();
-    softOnOff.reset();
-    sustainOnOff.reset();
-    accentOnOff.reset();
+    pausePlayback();
+    resetPlayback();
   };
 
   const resetApp = () => {
     mididataReady = false;
     appReady = false;
-    stopApp();
+    pausePlayback();
+    resetPlayback();
+    playbackProgress.reset();
     tempoCoefficient.reset();
     bassVolumeCoefficient.reset();
     trebleVolumeCoefficient.reset();
@@ -209,7 +203,9 @@
       updatePlayer,
       startNote,
       stopNote,
-      stopAllNotes,
+      pausePlayback,
+      startPlayback,
+      resetPlayback,
     } = samplePlayer);
   });
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -67,6 +67,7 @@
     rollPedalingOnOff,
     overlayKeyboard,
   } from "./stores";
+  import { clamp } from "./utils";
   import SamplePlayer from "./components/SamplePlayer.svelte";
   import RollSelector from "./components/RollSelector.svelte";
   import RollDetails from "./components/RollDetails.svelte";
@@ -212,7 +213,9 @@
   });
 
   $: if (currentRoll !== previousRoll) loadRoll(currentRoll);
-  $: playbackProgress.update(() => $currentTick / midiSamplePlayer?.totalTicks);
+  $: playbackProgress.update(() =>
+    clamp($currentTick / midiSamplePlayer?.totalTicks, 0, 1),
+  );
   $: if ($rollPedalingOnOff) {
     // TODO: set roll pedalling according to (as yet unavailable) pedalMap
   } else {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -208,15 +208,10 @@
       stopNote,
       stopAllNotes,
     } = samplePlayer);
-    midiSamplePlayer.on("endOfFile", () => stopApp());
+    midiSamplePlayer.on("endOfFile", stopApp);
   });
 
-  $: {
-    if (currentRoll !== previousRoll) {
-      loadRoll(currentRoll);
-    }
-  }
-
+  $: if (currentRoll !== previousRoll) loadRoll(currentRoll);
   $: playbackProgress.update(() => $currentTick / midiSamplePlayer?.totalTicks);
   $: if ($rollPedalingOnOff) {
     // TODO: set roll pedalling according to (as yet unavailable) pedalMap

--- a/src/components/KeyboardShortcuts.svelte
+++ b/src/components/KeyboardShortcuts.svelte
@@ -7,6 +7,7 @@
     volumeCoefficient,
     tempoCoefficient,
   } from "../stores";
+  import { clamp, enforcePrecision } from "../utils";
 
   const keyMap = Object.freeze({
     SOFT: "KeyQ",
@@ -38,13 +39,6 @@
       precision: 2,
     },
   };
-
-  const enforcePrecision = (value, precision) => {
-    const multiplier = 10 ** (precision || 0);
-    return Math.round(value * multiplier) / multiplier;
-  };
-
-  const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
 
   const updateStore = (
     { store, min, max, delta, shiftDelta, ctrlDelta, precision },

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -147,6 +147,7 @@
   import { fade } from "svelte/transition";
   import OpenSeadragon from "openseadragon";
   import { rollMetadata, currentTick, userSettings } from "../stores";
+  import { clamp } from "../utils";
   import RollViewerControls from "./RollViewerControls.svelte";
 
   export let imageUrl;
@@ -319,7 +320,6 @@
       skipToTick(
         scrollDownwards ? imgCenter.y - firstHolePx : firstHolePx - imgCenter.y,
       );
-
       strafing = true;
     });
     openSeadragon.addHandler("canvas-drag-end", () => (strafing = false));
@@ -335,13 +335,22 @@
 
   const panByIncrement = (up = true) => {
     const viewportBounds = viewport.getBounds();
+    const imgHeight = viewport.viewer.world.getItemAt(0).getContentSize().y;
     const imgBounds = viewport.viewportToImageRectangle(viewportBounds);
     const delta = up ? imgBounds.height / 10 : -imgBounds.height / 10;
     const centerY = imgBounds.y + imgBounds.height / 2;
     skipToTick(
       scrollDownwards
-        ? centerY + delta - firstHolePx
-        : firstHolePx - centerY - delta,
+        ? clamp(
+            centerY + delta - firstHolePx,
+            -firstHolePx,
+            imgHeight - firstHolePx,
+          )
+        : clamp(
+            firstHolePx - centerY - delta,
+            -firstHolePx,
+            imgHeight - firstHolePx,
+          ),
     );
   };
 

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -170,6 +170,7 @@
   let marks = [];
   let hoveredMark;
   let showControls;
+  let rollLength;
 
   const getNoteName = (trackerHole) => {
     const midiNumber = trackerHole + WELTE_MIDI_START;
@@ -335,7 +336,6 @@
 
   const panByIncrement = (up = true) => {
     const viewportBounds = viewport.getBounds();
-    const imgHeight = viewport.viewer.world.getItemAt(0).getContentSize().y;
     const imgBounds = viewport.viewportToImageRectangle(viewportBounds);
     const delta = up ? imgBounds.height / 10 : -imgBounds.height / 10;
     const centerY = imgBounds.y + imgBounds.height / 2;
@@ -344,12 +344,12 @@
         ? clamp(
             centerY + delta - firstHolePx,
             -firstHolePx,
-            imgHeight - firstHolePx,
+            rollLength - firstHolePx,
           )
         : clamp(
             firstHolePx - centerY - delta,
             -firstHolePx,
-            imgHeight - firstHolePx,
+            rollLength - firstHolePx,
           ),
     );
   };
@@ -357,6 +357,7 @@
   $: advanceToTick($currentTick);
   $: highlightHoles($currentTick);
   $: scrollDownwards = $rollMetadata.ROLL_TYPE === "welte-red";
+  $: rollLength = parseInt($rollMetadata.IMAGE_LENGTH, 10);
   $: firstHolePx = scrollDownwards
     ? parseInt($rollMetadata.FIRST_HOLE, 10)
     : parseInt($rollMetadata.IMAGE_LENGTH, 10) -

--- a/src/components/SamplePlayer.svelte
+++ b/src/components/SamplePlayer.svelte
@@ -161,6 +161,12 @@
     },
   );
 
+  midiSamplePlayer.on("endOfFile", () => {
+    softOnOff.reset();
+    sustainOnOff.reset();
+    activeNotes.reset();
+  });
+
   /* eslint-disable no-unused-expressions, no-sequences */
   $: $sustainOnOff ? piano.pedalDown() : piano.pedalUp();
   $: $tempoCoefficient, updatePlayer();

--- a/src/components/SamplePlayer.svelte
+++ b/src/components/SamplePlayer.svelte
@@ -187,6 +187,12 @@
   $: $sustainOnOff ? piano.pedalDown() : piano.pedalUp();
   $: $tempoCoefficient, updatePlayer();
   $: $useMidiTempoEventsOnOff, updatePlayer();
+  $: if ($rollPedalingOnOff) {
+    // TODO: set roll pedalling according to (as yet unavailable) pedalMap
+  } else {
+    sustainOnOff.set(false);
+    softOnOff.set(false);
+  }
 
   export {
     midiSamplePlayer,

--- a/src/components/SamplePlayer.svelte
+++ b/src/components/SamplePlayer.svelte
@@ -24,7 +24,6 @@
     SUSTAIN_PEDAL: 64,
     SOFT_PEDAL: 67, // (una corda)
     PEDAL_ON: 127,
-    PANNING_POSITION: 10,
   });
 
   const DEFAULT_NOTE_VELOCITY = 50.0;

--- a/src/components/SamplePlayer.svelte
+++ b/src/components/SamplePlayer.svelte
@@ -96,6 +96,26 @@
     $activeNotes.forEach(stopNote);
   };
 
+  const resetPlayback = () => {
+    currentTick.reset();
+    midiSamplePlayer.stop();
+  };
+
+  const pausePlayback = () => {
+    midiSamplePlayer.pause();
+    stopAllNotes();
+    activeNotes.reset();
+    softOnOff.reset();
+    sustainOnOff.reset();
+    accentOnOff.reset();
+  };
+
+  const startPlayback = () => {
+    if ($currentTick < 0) resetPlayback();
+    updatePlayer();
+    midiSamplePlayer.play();
+  };
+
   midiSamplePlayer.on("fileLoaded", () => {
     const decodeHtmlEntities = (string) =>
       string
@@ -161,11 +181,7 @@
     },
   );
 
-  midiSamplePlayer.on("endOfFile", () => {
-    softOnOff.reset();
-    sustainOnOff.reset();
-    activeNotes.reset();
-  });
+  midiSamplePlayer.on("endOfFile", pausePlayback);
 
   /* eslint-disable no-unused-expressions, no-sequences */
   $: $sustainOnOff ? piano.pedalDown() : piano.pedalUp();
@@ -178,6 +194,8 @@
     updatePlayer,
     startNote,
     stopNote,
-    stopAllNotes,
+    pausePlayback,
+    startPlayback,
+    resetPlayback,
   };
 </script>

--- a/src/components/SamplePlayer.svelte
+++ b/src/components/SamplePlayer.svelte
@@ -27,7 +27,7 @@
     PANNING_POSITION: 10,
   });
 
-  const DEFAULT_NOTE_VELOCITY = 33.0;
+  const DEFAULT_NOTE_VELOCITY = 50.0;
   const DEFAULT_TEMPO = 60;
   const SOFT_PEDAL_RATIO = 0.67;
   const HALF_BOUNDARY = 66; // F# above Middle C; divides the keyboard into two "pans"
@@ -73,7 +73,7 @@
 
   const startNote = (noteNumber, velocity) => {
     const modifiedVelocity =
-      ((($playExpressionsOnOff && velocity) || DEFAULT_NOTE_VELOCITY) / 128) *
+      ((($playExpressionsOnOff && velocity) || DEFAULT_NOTE_VELOCITY) / 100) *
       (($softOnOff && SOFT_PEDAL_RATIO) || 1) *
       (($accentOnOff && ACCENT_BUMP) || 1) *
       $volumeCoefficient *

--- a/src/index.html
+++ b/src/index.html
@@ -16,7 +16,7 @@
   </div>
   <footer>
     <a href="http://cidr.stanford.edu/" title="Center for Interdisciplinary Digital Research @ Stanford Libraries">
-      <img src="/assets/cidr_i.8x25.png" alt="CIDR logo" />
+      <img src="assets/cidr_i.8x25.png" alt="CIDR logo" />
       Powered by CIDR
     </a>
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,6 @@
+export const enforcePrecision = (value, precision) => {
+  const multiplier = 10 ** (precision || 0);
+  return Math.round(value * multiplier) / multiplier;
+};
+
+export const clamp = (value, min, max) => Math.min(Math.max(value, min), max);


### PR DESCRIPTION
This wound up a bit more unruly (a bit less ruly?) than I'd intended, but here's what's here (in order):

* URL fix for the little CIDR "i"
* A couple of linting commits
* Fix for velocity computations (`midi-player-js` returns a value between 0 and 100, not between 0 and 127)
* All the rest are ultimately targeted at preventing panning/scrolling off the ends of the roll, and handling associated playback behaviour (especially when beyond the range of the actual note holes).  This ended up involving a minor refactor of some of the `<SamplePlayer/>` internals to expose a more optimal API to the main app component.  The other user-facing change that got caught up in this process is that the roll no longer automatically returns to the beginning when the playback reaches the end.  This was already something I was planning on changing, as it seems a much better UX to me this way.  Dissenting opinions welcome, though!