### PR TITLE
Fixes

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -125,6 +125,7 @@
   const skipToTick = (tick) => {
     if (tick < 0) pausePlayback();
     $currentTick = tick;
+    activeNotes.reset();
     updatePlayer(() => midiSamplePlayer.skipToTick($currentTick));
   };
 

--- a/src/components/Keyboard.svelte
+++ b/src/components/Keyboard.svelte
@@ -118,7 +118,9 @@
       }
     }
   }
-  svg.pedal {
+  div.pedal {
+    // SVG pedals are wrapped in <div/> tags because SVG animation performance sucks
+    //  so badly on Chromium-based browsers on Mac OS that the whole app suffers.
     filter: drop-shadow(0px 8px 3px black) saturate(0.4);
     margin: 0 4%;
     transform: rotate3d(1, 0, 0, 30deg);
@@ -129,10 +131,15 @@
     margin-top: -25px;
     cursor: pointer;
     width: 3%;
+    display: inline-block;
 
     &.depressed {
       filter: drop-shadow(0px 4px 2px black) saturate(0.6);
       transform: rotate3d(0, 0, 0, 0);
+    }
+
+    svg {
+      width: 100%;
     }
   }
 </style>
@@ -262,27 +269,26 @@
   </symbol>
 </svg>
 
-<svg
-  xmlns="http://www.w3.org/2000/svg"
-  width="46.9"
-  height="61.6"
+<div
   class="pedal"
   on:mousedown={() => ($softOnOff = true)}
   on:mouseup={() => ($softOnOff = false)}
   on:mouseout={() => ($softOnOff = false)}
   class:depressed={$softOnOff}
 >
-  <use href="#pedal" />
-</svg>
-<svg
-  xmlns="http://www.w3.org/2000/svg"
-  width="46.9"
-  height="61.6"
+  <svg xmlns="http://www.w3.org/2000/svg" width="46.9" height="61.6">
+    <use href="#pedal" />
+  </svg>
+</div>
+
+<div
   class="pedal"
   on:mousedown={() => ($sustainOnOff = true)}
   on:mouseup={() => ($sustainOnOff = false)}
   on:mouseout={() => ($sustainOnOff = false)}
   class:depressed={$sustainOnOff}
 >
-  <use href="#pedal" />
-</svg>
+  <svg xmlns="http://www.w3.org/2000/svg" width="46.9" height="61.6">
+    <use href="#pedal" />
+  </svg>
+</div>

--- a/src/components/Keyboard.svelte
+++ b/src/components/Keyboard.svelte
@@ -109,15 +109,12 @@
       }
 
       :global(:nth-child(2).depressed) {
+        background: $active-key-highlight;
         border-bottom-width: 2px;
         box-shadow: inset 0 -1px 1px rgba(255, 255, 255, 0.4),
           0 1px 0 rgba(0, 0, 0, 0.8), 0 2px 2px rgba(0, 0, 0, 0.4),
           0 -1px 0 #000;
         height: 57%;
-      }
-
-      :global(:nth-child(2).depressed) {
-        background: $active-key-highlight;
       }
     }
   }
@@ -187,7 +184,7 @@
   let mouseDown = false;
   let playing = new Set();
   const stopPlaying = () => {
-    playing.forEach((note) => stopNote(note));
+    playing.forEach(stopNote);
     playing = new Set();
   };
 </script>

--- a/src/components/SamplePlayer.svelte
+++ b/src/components/SamplePlayer.svelte
@@ -99,6 +99,7 @@
     piano.pedalUp();
     if ($sustainOnOff) piano.pedalDown();
     $activeNotes.forEach(stopNote);
+    activeNotes.reset();
   };
 
   const resetPlayback = () => {

--- a/src/components/SamplePlayer.svelte
+++ b/src/components/SamplePlayer.svelte
@@ -170,13 +170,7 @@
         }
       } else if (name === "Controller Change" && $rollPedalingOnOff) {
         if (number === controllerChange.SUSTAIN_PEDAL) {
-          if (value === controllerChange.PEDAL_ON) {
-            piano.pedalDown();
-            sustainOnOff.set(true);
-          } else {
-            piano.pedalUp();
-            sustainOnOff.set(false);
-          }
+          sustainOnOff.set(value === controllerChange.PEDAL_ON);
         } else if (number === controllerChange.SOFT_PEDAL) {
           softOnOff.set(value === controllerChange.PEDAL_ON);
         }

--- a/src/stores.js
+++ b/src/stores.js
@@ -38,7 +38,7 @@ export const sustainOnOff = createStore(false);
 export const accentOnOff = createStore(false);
 
 // Playback Settings
-export const volumeCoefficient = createStore(1);
+export const volumeCoefficient = createStore(1.5);
 export const bassVolumeCoefficient = createStore(1);
 export const trebleVolumeCoefficient = createStore(1);
 


### PR DESCRIPTION
* Remove superfluous calls to `piano.pedalDown()` and `piano.pedalUp()` in `<SamplePlayer/>` component.
* **Wrap SVG pedals in `<div/>`s, and animate the `<div/>`s for performance on Mac OS blink-based browsers**
* Change default volume level to 1.5
* Release`<Keyboard/>` keys when panning away