### PR TITLE
Add advanced visualization settings option to show/hide piano keyboard

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -61,6 +61,7 @@
     activeNotes,
     currentTick,
     rollMetadata,
+    pianoKeyboardOnOff,
     overlayKeyboard,
   } from "./stores";
   import { clamp } from "./utils";
@@ -234,7 +235,7 @@
           {holesByTickInterval}
           {skipToTick}
         />
-        {#if $overlayKeyboard}
+        {#if $pianoKeyboardOnOff && $overlayKeyboard}
           <div id="keyboard-overlay" transition:fade>
             <Keyboard keyCount="88" {activeNotes} {startNote} {stopNote} />
           </div>
@@ -245,7 +246,7 @@
       </FlexCollapsible>
     {/if}
   </div>
-  {#if !$overlayKeyboard}
+  {#if $pianoKeyboardOnOff && !$overlayKeyboard}
     <div id="keyboard-container" transition:slide>
       <Keyboard keyCount="88" {activeNotes} {startNote} {stopNote} />
     </div>

--- a/src/components/AdvancedSettings.svelte
+++ b/src/components/AdvancedSettings.svelte
@@ -64,6 +64,7 @@
     playExpressionsOnOff,
     rollPedalingOnOff,
     useMidiTempoEventsOnOff,
+    pianoKeyboardOnOff,
     userSettings,
   } from "../stores";
 
@@ -83,6 +84,10 @@
     <div>
       Show details for Active Notes:
       <input type="checkbox" bind:checked={$userSettings.activeNoteDetails} />
+    </div>
+    <div>
+      Display Piano Keyboard:
+      <input type="checkbox" bind:checked={$pianoKeyboardOnOff} />
     </div>
   </fieldset>
 

--- a/src/stores.js
+++ b/src/stores.js
@@ -54,6 +54,7 @@ export const playbackProgress = createStore(0);
 export const activeNotes = createSetStore();
 
 // User Settings
+export const pianoKeyboardOnOff = createStore(true);
 export const overlayKeyboard = createStore(false);
 export const userSettings = createStore({
   theme: "cardinal",


### PR DESCRIPTION
It might be a bit tidier to merge the two piano keyboard settings (so far, they're `overlayKeyboard` and `pianoKeyboardOnoff`) into one store. On the other hand, `overlayKeyboard` is used in `KeyboardControls.svelte` while `pianoKeyboardOnOff` is not, so there's a slight logical justification for keeping them separate.