### PR TITLE
<FilteredSelect/> component for <RollSelector/>

### DIFF
--- a/src/components/RollSelector.svelte
+++ b/src/components/RollSelector.svelte
@@ -1,19 +1,13 @@
-<style>
-  select {
-    padding: 0.25em 0;
-    width: 100%;
-  }
-</style>
-
 <script>
-  // bundling this, for now at least
+  import FilteredSelect from "../ui-components/FilteredSelect.svelte";
   import catalog from "../assets/catalog.json";
 
   export let currentRoll = catalog[Math.floor(Math.random() * catalog.length)];
 </script>
 
-<select bind:value={currentRoll}>
-  {#each catalog as roll}
-    <option value={roll}>{roll.title}</option>
-  {/each}
-</select>
+<FilteredSelect
+  items={catalog}
+  bind:selectedItem={currentRoll}
+  labelFieldName="title"
+  searchFieldName="title"
+/>

--- a/src/ui-components/FilteredSelect.svelte
+++ b/src/ui-components/FilteredSelect.svelte
@@ -81,18 +81,20 @@
   let filteredListItems;
 
   let open = false;
-  let highlightedIndex = -1;
+  let activeListItemIndex = -1;
 
   let input;
   let list;
 
-  const selectListItem = (listItem = filteredListItems[highlightedIndex]) => {
+  const selectListItem = (
+    listItem = filteredListItems[activeListItemIndex],
+  ) => {
     selectedItem = listItem.item;
     open = false;
   };
 
-  const highlight = (index) => {
-    highlightedIndex = clamp(index, 0, filteredListItems.length - 1);
+  const activateListItem = (index) => {
+    activeListItemIndex = clamp(index, 0, filteredListItems.length - 1);
     const el = list.querySelector(".selected");
     if (el) {
       if (typeof el.scrollIntoViewIfNeeded === "function") {
@@ -101,17 +103,17 @@
     }
   };
 
-  const activate = () => {
+  const activateDropdown = () => {
     input.value = "";
     filteredListItems = listItems;
     open = true;
-    highlight(items.indexOf(selectedItem));
+    activateListItem(items.indexOf(selectedItem));
   };
 
   const search = async () => {
     open = true;
     filteredListItems = listItems;
-    highlightedIndex = 0;
+    activeListItemIndex = 0;
 
     if (!text) return;
     const filteredText = text
@@ -167,18 +169,18 @@
     bind:this={input}
     bind:value={text}
     on:input={search}
-    on:focus={activate}
-    on:click={activate}
+    on:focus={activateDropdown}
+    on:click={activateDropdown}
     on:keydown|stopPropagation={({ key }) => {
       switch (key) {
         case 'ArrowDown':
-          if (!open) activate();
-          highlight(highlightedIndex + 1);
+          if (!open) activateDropdown();
+          activateListItem(activeListItemIndex + 1);
           break;
 
         case 'ArrowUp':
-          if (!open) activate();
-          highlight(highlightedIndex - 1);
+          if (!open) activateDropdown();
+          activateListItem(activeListItemIndex - 1);
           break;
 
         case 'Escape':
@@ -197,9 +199,9 @@
     {#if filteredListItems?.length}
       {#each filteredListItems as listItem, i}
         <li
-          class:selected={i === highlightedIndex}
+          class:selected={i === activeListItemIndex}
           on:click={() => selectListItem(listItem)}
-          on:pointerenter={() => (highlightedIndex = i)}
+          on:pointerenter={() => (activeListItemIndex = i)}
         >
           {@html listItem.markedUp || listItem.label}
         </li>

--- a/src/ui-components/FilteredSelect.svelte
+++ b/src/ui-components/FilteredSelect.svelte
@@ -183,6 +183,16 @@
           activateListItem(activeListItemIndex - 1);
           break;
 
+        case 'PageDown':
+          if (!open) activateDropdown();
+          activateListItem(activeListItemIndex + 15);
+          break;
+
+        case 'PageUp':
+          if (!open) activateDropdown();
+          activateListItem(activeListItemIndex - 15);
+          break;
+
         case 'Escape':
           if (open) open = false;
           break;

--- a/src/ui-components/FilteredSelect.svelte
+++ b/src/ui-components/FilteredSelect.svelte
@@ -29,6 +29,7 @@
     font: inherit;
     height: 100%;
     padding: 5px 2.5em 5px 11px;
+    text-overflow: ellipsis;
     width: 100%;
   }
 

--- a/src/ui-components/FilteredSelect.svelte
+++ b/src/ui-components/FilteredSelect.svelte
@@ -1,0 +1,217 @@
+<style lang="scss">
+  .filtered-select {
+    height: 2.25em;
+    position: relative;
+    width: 100%;
+
+    &::after {
+      border: 3px solid var(--primary-accent);
+      border-right: 0;
+      border-top: 0;
+      border-radius: 2px;
+      content: " ";
+      display: block;
+      height: 0.625em;
+      margin-top: -0.4375em;
+      pointer-events: none;
+      position: absolute;
+      right: 1.125em;
+      top: 50%;
+      transform: rotate(-45deg);
+      transform-origin: center;
+      width: 0.625em;
+      z-index: 4;
+    }
+  }
+
+  input {
+    cursor: pointer;
+    font: inherit;
+    height: 100%;
+    padding: 5px 2.5em 5px 11px;
+    width: 100%;
+  }
+
+  ul {
+    background: #fff;
+    border: 1px solid #999;
+    display: none;
+    margin: 0;
+    max-height: calc(15 * (1rem + 10px) + 15px);
+    min-width: 100%;
+    overflow-y: auto;
+    padding: 10px 0;
+    position: relative;
+    top: 0px;
+    user-select: none;
+    width: fit-content;
+    z-index: 99;
+
+    &.open {
+      display: block;
+    }
+  }
+
+  li {
+    color: #333;
+    cursor: pointer;
+    line-height: 1;
+    padding: 5px 15px;
+    white-space: nowrap;
+    width: 100%;
+
+    &.selected {
+      background-color: var(--primary-accent);
+      color: #fff;
+    }
+  }
+</style>
+
+<script>
+  import { clamp } from "../utils";
+
+  export let items = [];
+  export let selectedItem;
+
+  export let labelFieldName;
+  export let searchFieldName = labelFieldName;
+
+  let text;
+  let listItems = [];
+  let filteredListItems;
+
+  let open = false;
+  let highlightedIndex = -1;
+
+  let input;
+  let list;
+
+  const selectListItem = (listItem = filteredListItems[highlightedIndex]) => {
+    selectedItem = listItem.item;
+    open = false;
+  };
+
+  const highlight = (index) => {
+    highlightedIndex = clamp(index, 0, filteredListItems.length - 1);
+    const el = list.querySelector(".selected");
+    if (el) {
+      if (typeof el.scrollIntoViewIfNeeded === "function") {
+        el.scrollIntoViewIfNeeded();
+      }
+    }
+  };
+
+  const activate = () => {
+    input.setSelectionRange(0, input.value.length);
+    filteredListItems = listItems;
+    open = true;
+    highlight(items.indexOf(selectedItem));
+  };
+
+  const search = async () => {
+    open = true;
+    filteredListItems = listItems;
+    highlightedIndex = 0;
+
+    if (!text) return;
+    const filteredText = text
+      .replace(/[&/\\#,+()$~%.'":*?<>{}]/g, " ")
+      .trim()
+      .toLowerCase();
+
+    if (filteredText) {
+      const searchParts = filteredText.split(" ");
+
+      filteredListItems = listItems
+        .filter((listItem) =>
+          searchParts.every((searchPart) =>
+            listItem.searchContent.includes(searchPart),
+          ),
+        )
+        .map((item) => {
+          const newItem = { ...item };
+          newItem.markedUp = item.label;
+          searchParts.forEach((searchPart) => {
+            newItem.markedUp = newItem.markedUp.replace(
+              new RegExp(searchPart, "ig"),
+              "<b>$&</b>",
+            );
+          });
+          return newItem;
+        });
+    }
+  };
+
+  const prepareListItems = () => {
+    listItems = items.map((item) => ({
+      searchContent: (searchFieldName ? item[searchFieldName] : item)
+        .toLowerCase()
+        .trim(),
+      label: labelFieldName ? item[labelFieldName] : item,
+      item,
+    }));
+  };
+
+  const onSelectedItemChanged = () => {
+    text = labelFieldName ? selectedItem[labelFieldName] : selectedItem;
+  };
+
+  /* eslint-disable no-unused-expressions, no-sequences */
+  $: items, prepareListItems();
+  $: open, onSelectedItemChanged();
+</script>
+
+<div class="filtered-select">
+  <input
+    type="text"
+    bind:this={input}
+    bind:value={text}
+    on:input={search}
+    on:focus={activate}
+    on:click={activate}
+    on:keydown|stopPropagation={({ key }) => {
+      switch (key) {
+        case 'ArrowDown':
+          open = true;
+          highlight(highlightedIndex + 1);
+          break;
+
+        case 'ArrowUp':
+          open = true;
+          highlight(highlightedIndex - 1);
+          break;
+
+        case 'Escape':
+          if (open) open = false;
+          break;
+
+        case 'Enter':
+          selectListItem();
+          break;
+
+        default:
+      }
+    }}
+  />
+  <ul class:open bind:this={list}>
+    {#if filteredListItems?.length}
+      {#each filteredListItems as listItem, i}
+        <li
+          class:selected={i === highlightedIndex}
+          on:click={() => selectListItem(listItem)}
+          on:pointerenter={() => (highlightedIndex = i)}
+        >
+          {@html listItem.markedUp || listItem.label}
+        </li>
+      {/each}
+    {:else}
+      <li>No results found</li>
+    {/if}
+  </ul>
+</div>
+
+<svelte:window
+  on:click={({ target, defaultPrevented }) => {
+    if (!(list.contains(target) || input.contains(target)) && !defaultPrevented) open = false;
+  }}
+/>

--- a/src/ui-components/FilteredSelect.svelte
+++ b/src/ui-components/FilteredSelect.svelte
@@ -44,7 +44,7 @@
     position: relative;
     top: 0px;
     user-select: none;
-    width: fit-content;
+    width: max-content;
     z-index: 99;
 
     &.open {

--- a/src/ui-components/FilteredSelect.svelte
+++ b/src/ui-components/FilteredSelect.svelte
@@ -188,6 +188,10 @@
 <div class="filtered-select">
   <input
     type="text"
+    autocomplete="off"
+    autocorrect="off"
+    autocapitalize="off"
+    spellcheck="false"
     bind:this={input}
     bind:value={text}
     on:input={search}

--- a/src/ui-components/FilteredSelect.svelte
+++ b/src/ui-components/FilteredSelect.svelte
@@ -63,6 +63,16 @@
     &.selected {
       background-color: var(--primary-accent);
       color: #fff;
+
+      :global(mark) {
+        color: #fff;
+      }
+    }
+
+    :global(mark) {
+      background-color: unset;
+      color: green;
+      font-weight: 700;
     }
   }
 </style>
@@ -148,7 +158,7 @@
           searchParts.forEach((searchPart) => {
             newItem.markedUp = newItem.markedUp.replace(
               new RegExp(searchPart, "ig"),
-              "<b>$&</b>",
+              "<mark>$&</mark>",
             );
           });
           return newItem;

--- a/src/ui-components/FilteredSelect.svelte
+++ b/src/ui-components/FilteredSelect.svelte
@@ -68,6 +68,7 @@
 </style>
 
 <script>
+  import { tick } from "svelte";
   import { clamp } from "../utils";
 
   export let items = [];
@@ -93,13 +94,22 @@
     open = false;
   };
 
-  const activateListItem = (index) => {
+  const activateListItem = async (index) => {
     activeListItemIndex = clamp(index, 0, filteredListItems.length - 1);
-    const el = list.querySelector(".selected");
-    if (el) {
-      if (typeof el.scrollIntoViewIfNeeded === "function") {
-        el.scrollIntoViewIfNeeded();
-      }
+
+    await tick();
+
+    const activeListItem = list.querySelector(".selected");
+
+    if (activeListItem) {
+      const {
+        top: listItemTop,
+        bottom: listItemBottom,
+      } = activeListItem.getBoundingClientRect();
+      const { top: listTop, bottom: listBottom } = list.getBoundingClientRect();
+
+      if (listItemBottom > listBottom) activeListItem.scrollIntoView(false);
+      if (listItemTop < listTop) activeListItem.scrollIntoView();
     }
   };
 

--- a/src/ui-components/FilteredSelect.svelte
+++ b/src/ui-components/FilteredSelect.svelte
@@ -172,7 +172,7 @@
 
   /* eslint-disable no-unused-expressions, no-sequences */
   $: items, prepareListItems();
-  $: open, onSelectedItemChanged();
+  $: selectedItem, onSelectedItemChanged();
 </script>
 
 <div class="filtered-select">
@@ -207,6 +207,7 @@
 
         case 'Escape':
           if (open) open = false;
+          onSelectedItemChanged();
           break;
 
         case 'Enter':
@@ -236,6 +237,9 @@
 
 <svelte:window
   on:click={({ target, defaultPrevented }) => {
-    if (!(list.contains(target) || input.contains(target)) && !defaultPrevented) open = false;
+    if (!(list.contains(target) || input.contains(target)) && !defaultPrevented) {
+      open = false;
+      onSelectedItemChanged();
+    }
   }}
 />

--- a/src/ui-components/FilteredSelect.svelte
+++ b/src/ui-components/FilteredSelect.svelte
@@ -113,10 +113,12 @@
     }
   };
 
-  const activateDropdown = () => {
-    input.value = "";
-    filteredListItems = listItems;
+  const activateDropdown = async () => {
+    if (open) return;
     open = true;
+    await tick();
+    text = "";
+    filteredListItems = listItems;
     activateListItem(items.indexOf(selectedItem));
   };
 
@@ -184,22 +186,22 @@
     on:keydown|stopPropagation={({ key }) => {
       switch (key) {
         case 'ArrowDown':
-          if (!open) activateDropdown();
+          activateDropdown();
           activateListItem(activeListItemIndex + 1);
           break;
 
         case 'ArrowUp':
-          if (!open) activateDropdown();
+          activateDropdown();
           activateListItem(activeListItemIndex - 1);
           break;
 
         case 'PageDown':
-          if (!open) activateDropdown();
+          activateDropdown();
           activateListItem(activeListItemIndex + 15);
           break;
 
         case 'PageUp':
-          if (!open) activateDropdown();
+          activateDropdown();
           activateListItem(activeListItemIndex - 15);
           break;
 

--- a/src/ui-components/FilteredSelect.svelte
+++ b/src/ui-components/FilteredSelect.svelte
@@ -102,7 +102,7 @@
   };
 
   const activate = () => {
-    input.setSelectionRange(0, input.value.length);
+    input.value = "";
     filteredListItems = listItems;
     open = true;
     highlight(items.indexOf(selectedItem));
@@ -172,12 +172,12 @@
     on:keydown|stopPropagation={({ key }) => {
       switch (key) {
         case 'ArrowDown':
-          open = true;
+          if (!open) activate();
           highlight(highlightedIndex + 1);
           break;
 
         case 'ArrowUp':
-          open = true;
+          if (!open) activate();
           highlight(highlightedIndex - 1);
           break;
 

--- a/src/ui-components/FlexCollapsible.svelte
+++ b/src/ui-components/FlexCollapsible.svelte
@@ -11,7 +11,7 @@
       display: flex;
       flex-direction: column;
       gap: 0.5em;
-      overflow: hidden;
+      overflow: visible;
       padding: 0.5em;
       position: absolute;
       top: 0;


### PR DESCRIPTION
There are a couple of "Select2"-type components out there for Svelte that can be `npm install`ed (or `yarn add`ed, I suppose), but they're all a bit heavy and over-featured for this case, none had a really perfect UX, and most importantly all the ones I could find were lacking in at least one important respect, so would have needed some kind of hacking anyway.  This is written from scratch to meet our needs specifically.

It should be fully keyboard accessible/driveable, and will accept multiple "words" (e.g. type "bee lam").  I think it's pretty robust at this point (with the caveats listed below).  Please let me know if there are any UI/UX problems or niggles.

A couple of improvements/additions remain outstanding:
* Roll-type filtering (I think I know how I'd like to do it)
* Stripping accents for searching (as usual with these kinds of tasks -- and I've done it a tonne of times in a tonne of different programming environments, as you might imagine! -- the challenging part is the marking-up of the matches in context)
* I've not done any Safari or iPad / touchscreen testing at this point.

The first commit represents a lot of dev. work but my commits got really messy and I didn't have the energy to tidy them so I just squashed the mess into one commit last night and the rest of the commit are iterations from there.