### PR TITLE
Pedaling Map

### DIFF
--- a/src/components/SamplePlayer.svelte
+++ b/src/components/SamplePlayer.svelte
@@ -66,8 +66,8 @@
 
     if (pedalingMap && $rollPedalingOnOff) {
       const pedals = pedalingMap.search($currentTick, $currentTick);
-      sustainOnOff.set(pedals.includes("SUSTAIN"));
-      softOnOff.set(pedals.includes("SOFT"));
+      sustainOnOff.set(pedals.includes(SUSTAIN_PEDAL));
+      softOnOff.set(pedals.includes(SOFT_PEDAL));
     } else {
       sustainOnOff.set(false);
       piano.pedalUp();
@@ -148,13 +148,13 @@
       (event) => event.name === "Controller Change",
     );
 
-    const enterEvents = (eventNumber, eventName) => {
+    const enterEvents = (eventNumber) => {
       let tickOn = false;
       controllerEvents
         .filter(({ number }) => number === eventNumber)
         .forEach(({ value, tick }) => {
           if (value === 0) {
-            if (tickOn) _pedalingMap.insert(tickOn, tick, eventName);
+            if (tickOn) _pedalingMap.insert(tickOn, tick, eventNumber);
             tickOn = false;
           } else if (value === 127) {
             if (!tickOn) tickOn = tick;
@@ -162,8 +162,8 @@
         });
     };
 
-    enterEvents(SOFT_PEDAL, "SOFT");
-    enterEvents(SUSTAIN_PEDAL, "SUSTAIN");
+    enterEvents(SOFT_PEDAL);
+    enterEvents(SUSTAIN_PEDAL);
 
     return _pedalingMap;
   };

--- a/src/components/SamplePlayer.svelte
+++ b/src/components/SamplePlayer.svelte
@@ -59,18 +59,20 @@
     return tempo;
   };
 
+  const setPlayerStateAtTick = (tick = $currentTick) => {
+    midiSamplePlayer.setTempo(getTempoAtTick(tick) * $tempoCoefficient);
+  };
+
   const updatePlayer = (fn = () => {}) => {
     if (midiSamplePlayer.isPlaying()) {
       midiSamplePlayer.pause();
       fn();
-      midiSamplePlayer.setTempo(
-        getTempoAtTick($currentTick) * $tempoCoefficient,
-      );
+      setPlayerStateAtTick($currentTick);
       midiSamplePlayer.play();
       return;
     }
     fn();
-    midiSamplePlayer.setTempo(getTempoAtTick($currentTick) * $tempoCoefficient);
+    setPlayerStateAtTick($currentTick);
   };
 
   const startNote = (noteNumber, velocity) => {

--- a/src/components/SamplePlayer.svelte
+++ b/src/components/SamplePlayer.svelte
@@ -96,21 +96,20 @@
     piano.pedalUp();
     if ($sustainOnOff) piano.pedalDown();
     $activeNotes.forEach(stopNote);
-    activeNotes.reset();
   };
 
   const resetPlayback = () => {
     currentTick.reset();
     midiSamplePlayer.stop();
+    activeNotes.reset();
+    softOnOff.reset();
+    sustainOnOff.reset();
+    accentOnOff.reset();
   };
 
   const pausePlayback = () => {
     midiSamplePlayer.pause();
     stopAllNotes();
-    activeNotes.reset();
-    softOnOff.reset();
-    sustainOnOff.reset();
-    accentOnOff.reset();
   };
 
   const startPlayback = () => {

--- a/src/components/SamplePlayer.svelte
+++ b/src/components/SamplePlayer.svelte
@@ -20,11 +20,8 @@
 
   let tempoMap;
 
-  const controllerChange = Object.freeze({
-    SUSTAIN_PEDAL: 64,
-    SOFT_PEDAL: 67, // (una corda)
-    PEDAL_ON: 127,
-  });
+  const SOFT_PEDAL = 67;
+  const SUSTAIN_PEDAL = 64;
 
   const DEFAULT_NOTE_VELOCITY = 50.0;
   const DEFAULT_TEMPO = 60;
@@ -170,10 +167,10 @@
           activeNotes.add(noteNumber);
         }
       } else if (name === "Controller Change" && $rollPedalingOnOff) {
-        if (number === controllerChange.SUSTAIN_PEDAL) {
-          sustainOnOff.set(value === controllerChange.PEDAL_ON);
-        } else if (number === controllerChange.SOFT_PEDAL) {
-          softOnOff.set(value === controllerChange.PEDAL_ON);
+        if (number === SUSTAIN_PEDAL) {
+          sustainOnOff.set(!!value);
+        } else if (number === SOFT_PEDAL) {
+          softOnOff.set(!!value);
         }
       } else if (name === "Set Tempo" && $useMidiTempoEventsOnOff) {
         midiSamplePlayer.setTempo(data * $tempoCoefficient);

--- a/src/components/SamplePlayer.svelte
+++ b/src/components/SamplePlayer.svelte
@@ -63,6 +63,16 @@
 
   const setPlayerStateAtTick = (tick = $currentTick) => {
     midiSamplePlayer.setTempo(getTempoAtTick(tick) * $tempoCoefficient);
+
+    if (pedallingMap && $rollPedalingOnOff) {
+      const pedals = pedallingMap.search($currentTick, $currentTick);
+      sustainOnOff.set(pedals.includes("SUSTAIN"));
+      softOnOff.set(pedals.includes("SOFT"));
+    } else {
+      sustainOnOff.set(false);
+      piano.pedalUp();
+      softOnOff.set(false);
+    }
   };
 
   const updatePlayer = (fn = () => {}) => {

--- a/src/components/SamplePlayer.svelte
+++ b/src/components/SamplePlayer.svelte
@@ -229,12 +229,7 @@
   $: $sustainOnOff ? piano.pedalDown() : piano.pedalUp();
   $: $tempoCoefficient, updatePlayer();
   $: $useMidiTempoEventsOnOff, updatePlayer();
-  $: if ($rollPedalingOnOff) {
-    // TODO: set roll pedalling according to (as yet unavailable) pedalMap
-  } else {
-    sustainOnOff.set(false);
-    softOnOff.set(false);
-  }
+  $: $rollPedalingOnOff, updatePlayer();
 
   export {
     midiSamplePlayer,

--- a/src/components/SamplePlayer.svelte
+++ b/src/components/SamplePlayer.svelte
@@ -20,7 +20,7 @@
   } from "../stores";
 
   let tempoMap;
-  let pedallingMap;
+  let pedalingMap;
 
   const SOFT_PEDAL = 67;
   const SUSTAIN_PEDAL = 64;
@@ -64,8 +64,8 @@
   const setPlayerStateAtTick = (tick = $currentTick) => {
     midiSamplePlayer.setTempo(getTempoAtTick(tick) * $tempoCoefficient);
 
-    if (pedallingMap && $rollPedalingOnOff) {
-      const pedals = pedallingMap.search($currentTick, $currentTick);
+    if (pedalingMap && $rollPedalingOnOff) {
+      const pedals = pedalingMap.search($currentTick, $currentTick);
       sustainOnOff.set(pedals.includes("SUSTAIN"));
       softOnOff.set(pedals.includes("SOFT"));
     } else {
@@ -142,8 +142,8 @@
       }, []);
   };
 
-  const buildPedallingMap = (eventsTrack) => {
-    const _pedallingMap = new IntervalTree();
+  const buildPedalingMap = (eventsTrack) => {
+    const _pedalingMap = new IntervalTree();
     const controllerEvents = eventsTrack.filter(
       (event) => event.name === "Controller Change",
     );
@@ -154,7 +154,7 @@
         .filter(({ number }) => number === eventNumber)
         .forEach(({ value, tick }) => {
           if (value === 0) {
-            if (tickOn) _pedallingMap.insert(tickOn, tick, eventName);
+            if (tickOn) _pedalingMap.insert(tickOn, tick, eventName);
             tickOn = false;
           } else if (value === 127) {
             if (!tickOn) tickOn = tick;
@@ -165,11 +165,11 @@
     enterEvents(SOFT_PEDAL, "SOFT");
     enterEvents(SUSTAIN_PEDAL, "SUSTAIN");
 
-    return _pedallingMap;
+    return _pedalingMap;
   };
 
   midiSamplePlayer.on("fileLoaded", () => {
-    pedallingMap = new IntervalTree();
+    pedalingMap = new IntervalTree();
     const decodeHtmlEntities = (string) =>
       string
         .replace(/&#(\d+);/g, (match, num) => String.fromCodePoint(num))
@@ -193,7 +193,7 @@
     );
 
     tempoMap = buildTempoMap(metadataTrack);
-    pedallingMap = buildPedallingMap(midiSamplePlayer.events[1]);
+    pedalingMap = buildPedalingMap(midiSamplePlayer.events[1]);
   });
 
   midiSamplePlayer.on("playing", ({ tick }) => {


### PR DESCRIPTION
This doesn't add much in terms of visible user-facing functionality except:
1) you can watch the pedals go up and down as you scroll a non-playing roll;
2) you can re-enable roll pedaling in the middle of a roll and have the pedals activated as appropriate without having to wait for the next relevant event.

I think that's basically it.  But this was needed, and paves the way for the same thing to be done with the activeKeys store so that the keyboard behaves the same way.