### PR TITLE
Fix upward, downward panning limits for upward scrolling rolls

### DIFF
--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -347,8 +347,8 @@
           )
         : clamp(
             firstHolePx - centerY - delta,
-            -firstHolePx,
-            imageLength - firstHolePx,
+            firstHolePx - imageLength,
+            firstHolePx,
           ),
     );
   };


### PR DESCRIPTION
For the 88-note rolls, which recently received better playback/note highlighting support, the current panning constraints disallow upward panning via the up/down panning buttons or <kbd>ctrl</kbd>-mousewheel at a short, seemingly arbitrary distance up the roll (the location actually is related to the difference between the image length and the pixel location of the first "tick") and allow downward panning to way beyond the bottom (start) of the roll. This adjustment to the clamping limits fixes both issues.