### PR TITLE
`<RollSelector/>` rich formatting and adding label numbers

### DIFF
--- a/src/components/RollSelector.svelte
+++ b/src/components/RollSelector.svelte
@@ -1,10 +1,13 @@
-<style>
+<style lang="scss">
   :global(small) {
     color: grey;
     display: inline-block;
-    width: 5ch;
     text-align: right;
     margin-right: 1ch;
+
+    &:first-child {
+      width: 5ch;
+    }
   }
 </style>
 

--- a/src/components/RollSelector.svelte
+++ b/src/components/RollSelector.svelte
@@ -1,5 +1,5 @@
 <style lang="scss">
-  :global(small) {
+  :global(.filtered-select small) {
     color: grey;
     display: inline-block;
     text-align: right;

--- a/src/components/RollSelector.svelte
+++ b/src/components/RollSelector.svelte
@@ -1,6 +1,10 @@
 <style>
   :global(small) {
     color: grey;
+    display: inline-block;
+    width: 5ch;
+    text-align: right;
+    margin-right: 1ch;
   }
 </style>
 
@@ -10,7 +14,10 @@
 
   const listItems = catalog.map((item) => ({
     ...item,
-    _label: `[${item.label}] ${item.title}`,
+    _label: `${item.label.match(/^\d+/)} ${item.title} [${item.label.replace(
+      /^\d*\s?/,
+      "",
+    )}]`,
   }));
   export let currentRoll =
     listItems[Math.floor(Math.random() * catalog.length)];
@@ -21,5 +28,5 @@
   bind:selectedItem={currentRoll}
   labelFieldName="_label"
   searchFieldName="_label"
-  postMarkup={(str) => str.replace(/^\[[^\]]+\]/, "<small>$&</small>")}
+  postMarkup={(str) => str.replace(/^\d+|\[[^\]]+\]$/g, "<small>$&</small>")}
 />

--- a/src/components/RollSelector.svelte
+++ b/src/components/RollSelector.svelte
@@ -1,13 +1,25 @@
+<style>
+  :global(small) {
+    color: grey;
+  }
+</style>
+
 <script>
   import FilteredSelect from "../ui-components/FilteredSelect.svelte";
   import catalog from "../assets/catalog.json";
 
-  export let currentRoll = catalog[Math.floor(Math.random() * catalog.length)];
+  const listItems = catalog.map((item) => ({
+    ...item,
+    _label: `[${item.label}] ${item.title}`,
+  }));
+  export let currentRoll =
+    listItems[Math.floor(Math.random() * catalog.length)];
 </script>
 
 <FilteredSelect
-  items={catalog}
+  items={listItems}
   bind:selectedItem={currentRoll}
-  labelFieldName="title"
-  searchFieldName="title"
+  labelFieldName="_label"
+  searchFieldName="_label"
+  postMarkup={(str) => str.replace(/^\[[^\]]+\]/, "<small>$&</small>")}
 />

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -43,89 +43,90 @@
       right: 0;
       top: 0;
     }
-  }
 
-  :global(canvas) {
-    background: white !important;
-  }
-
-  :global(.openseadragon-canvas:focus) {
-    outline: none;
-  }
-
-  :global(svg rect) {
-    fill: none;
-    pointer-events: all;
-  }
-  :global(mark) {
-    background-color: transparent;
-
-    &:hover {
+    :global(mark) {
       background-color: transparent;
-      box-shadow: none;
-      outline: $highlight-hover-outline-width solid
-        $highlight-hover-outline-color;
-      outline-offset: $highlight-hover-outline-offset;
-      z-index: 1;
 
-      &::before {
-        height: 0;
-        position: relative;
+      &:hover {
+        background-color: transparent;
+        box-shadow: none;
+        outline: $highlight-hover-outline-width solid
+          $highlight-hover-outline-color;
+        outline-offset: $highlight-hover-outline-offset;
+        z-index: 1;
+
+        &::before {
+          height: 0;
+          position: relative;
+        }
       }
     }
-  }
 
-  :global(mark.active::before) {
-    position: absolute;
-    content: "";
-    top: 0;
-    left: 0;
-    bottom: 0;
-    right: 0;
-    mix-blend-mode: multiply;
-    animation: mark-recede 0.5s ease-in-out;
-    background-color: $hole-highlight-color;
-    box-shadow: 0 0 5px $hole-highlight-color;
-    display: inline-block;
-  }
+    :global(mark.active::before) {
+      position: absolute;
+      content: "";
+      top: 0;
+      left: 0;
+      bottom: 0;
+      right: 0;
+      mix-blend-mode: multiply;
+      animation: mark-recede 0.5s ease-in-out;
+      background-color: $hole-highlight-color;
+      box-shadow: 0 0 5px $hole-highlight-color;
+      display: inline-block;
+    }
 
-  :global(mark:hover[data-info]::after) {
-    background-color: $highlight-hover-outline-color;
-    color: white;
-    content: attr(data-info);
-    display: block;
-    font-weight: bold;
-    left: calc(
-      100% + #{$highlight-hover-outline-offset} + #{$highlight-hover-outline-width}
-    );
-    padding: 8px ($highlight-hover-outline-width + 4px) 8px 4px;
-    position: absolute;
-    text-shadow: 0px 0px 8px black;
-    top: -($highlight-hover-outline-offset + $highlight-hover-outline-width);
-    transform: none;
-  }
-  .active-note-details {
-    :global(mark.active[data-info]::after) {
-      background-color: none;
+    :global(mark:hover[data-info]::after) {
+      background-color: $highlight-hover-outline-color;
       color: white;
       content: attr(data-info);
       display: block;
       font-weight: bold;
-      left: 50%;
-      padding: 8px 4px;
-      position: absolute;
-      text-shadow: 0px 0px 8px black;
-      top: 0;
-      mix-blend-mode: normal;
-      transform: translate(-50%, -100%);
-    }
-
-    :global(mark.active[data-info]:hover::after) {
       left: calc(
         100% + #{$highlight-hover-outline-offset} + #{$highlight-hover-outline-width}
       );
+      padding: 8px ($highlight-hover-outline-width + 4px) 8px 4px;
+      position: absolute;
+      text-shadow: 0px 0px 8px black;
       top: -($highlight-hover-outline-offset + $highlight-hover-outline-width);
       transform: none;
+    }
+
+    :global(canvas) {
+      background: white !important;
+    }
+
+    :global(.openseadragon-canvas:focus) {
+      outline: none;
+    }
+
+    :global(svg rect) {
+      fill: none;
+      pointer-events: all;
+    }
+    &.active-note-details {
+      :global(mark.active[data-info]::after) {
+        background-color: none;
+        color: white;
+        content: attr(data-info);
+        display: block;
+        font-weight: bold;
+        left: 50%;
+        padding: 8px 4px;
+        position: absolute;
+        text-shadow: 0px 0px 8px black;
+        top: 0;
+        mix-blend-mode: normal;
+        transform: translate(-50%, -100%);
+      }
+
+      :global(mark.active[data-info]:hover::after) {
+        left: calc(
+          100% + #{$highlight-hover-outline-offset} + #{$highlight-hover-outline-width}
+        );
+        top: -($highlight-hover-outline-offset + $highlight-hover-outline-width);
+        transform: none;
+      }
     }
   }
 

--- a/src/ui-components/FilteredSelect.svelte
+++ b/src/ui-components/FilteredSelect.svelte
@@ -87,6 +87,8 @@
   export let labelFieldName;
   export let searchFieldName = labelFieldName;
 
+  export let postMarkup = (str) => str;
+
   let text;
   let listItems = [];
   let filteredListItems;
@@ -307,7 +309,7 @@
           on:click={() => selectListItem(listItem)}
           on:pointerenter={() => (activeListItemIndex = i)}
         >
-          {@html listItem.markedUp || listItem.label}
+          {@html postMarkup(listItem.markedUp || listItem.label)}
         </li>
       {/each}
     {:else}

--- a/src/ui-components/FilteredSelect.svelte
+++ b/src/ui-components/FilteredSelect.svelte
@@ -224,7 +224,7 @@
     );
 
     if (filteredText) {
-      const searchParts = filteredText.split(" ");
+      const searchParts = filteredText.split(" ").slice(0, 8);
 
       filteredListItems = listItems
         .filter((listItem) =>

--- a/src/ui-components/FilteredSelect.svelte
+++ b/src/ui-components/FilteredSelect.svelte
@@ -124,6 +124,7 @@
   const normalizeText = (str) =>
     str
       .toLowerCase()
+      .replace(/\s+/g, " ")
       .replace(unDecomposableRegex, (m) => unDecomposableMap[m])
       .normalize("NFD")
       .replace(/[\u0300-\u036f]/g, "")

--- a/src/ui-components/FilteredSelect.svelte
+++ b/src/ui-components/FilteredSelect.svelte
@@ -23,12 +23,16 @@
     }
   }
 
-  input {
+  span.input {
+    background: white;
     cursor: pointer;
-    font: inherit;
+    display: inline-block;
     height: 100%;
+    line-height: calc(2.25em - 10px);
+    overflow: hidden;
     padding: 5px 2.5em 5px 11px;
     text-overflow: ellipsis;
+    white-space: nowrap;
     width: 100%;
   }
 
@@ -89,7 +93,6 @@
 
   export let postMarkup = (str) => str;
 
-  let text;
   let listItems = [];
   let filteredListItems;
 
@@ -204,7 +207,7 @@
     if (open) return;
     open = true;
     await tick();
-    text = "";
+    input.innerHTML = "";
     filteredListItems = listItems;
     activateListItem(items.indexOf(selectedItem));
   };
@@ -214,9 +217,9 @@
     filteredListItems = listItems;
     activeListItemIndex = 0;
 
-    if (!text) return;
+    if (!input.innerHTML) return;
     const filteredText = normalizeText(
-      text.replace(/[&/\\#,+()$~%.'":*?<>{}]/g, " "),
+      input.innerHTML.replace(/[&/\\#,+()$~%.'":*?<>{}]/g, " "),
     );
 
     if (filteredText) {
@@ -246,7 +249,10 @@
   };
 
   const onSelectedItemChanged = () => {
-    text = labelFieldName ? selectedItem[labelFieldName] : selectedItem;
+    if (input)
+      input.innerHTML = postMarkup(
+        labelFieldName ? selectedItem[labelFieldName] : selectedItem,
+      );
   };
 
   /* eslint-disable no-unused-expressions, no-sequences */
@@ -255,14 +261,11 @@
 </script>
 
 <div class="filtered-select">
-  <input
-    type="text"
-    autocomplete="off"
-    autocorrect="off"
-    autocapitalize="off"
+  <span
+    class="input"
     spellcheck="false"
+    contenteditable="true"
     bind:this={input}
-    bind:value={text}
     on:input={search}
     on:focus={activateDropdown}
     on:click={activateDropdown}
@@ -295,6 +298,7 @@
 
         case "Enter":
           selectListItem();
+          input.blur();
           break;
 
         default:

--- a/src/ui-components/FilteredSelect.svelte
+++ b/src/ui-components/FilteredSelect.svelte
@@ -219,7 +219,7 @@
 
     if (!input.innerHTML) return;
     const filteredText = normalizeText(
-      input.innerHTML.replace(/[&/\\#,+()$~%.'":*?<>{}]/g, " "),
+      input.innerHTML.replace(/[&/\\#,+()$~%.'":*?<>{}]|nbsp;/g, " "),
     );
 
     if (filteredText) {

--- a/src/ui-components/FlexCollapsible.svelte
+++ b/src/ui-components/FlexCollapsible.svelte
@@ -20,7 +20,6 @@
     &:hover {
       &:not(.hidden) {
         box-shadow: 2px -3px 3px rgba(0, 0, 0, 0.4);
-        z-index: z($main-context, sidebars);
 
         &.left {
           box-shadow: -2px -3px 3px rgba(0, 0, 0, 0.4);


### PR DESCRIPTION
This PR fixes a couple of incidental issues (the first two commits), and then adds some rich styling options to the dropdown list items and the input field itself.  It does this by proving a `postMarkup()` hook that allows parent components to alter the display of the various elements *after* they've been filtered and marked up for matches.  In order to make this possible for the input box too, the `<input type="text"/>` element has been replaced with a `<span contenteditable="true"/>`.

This gives lots of flexibility, and from a purely aesthetic point of view I like the way it looks now.  However, the way I've split up the label number is probably controversial/flat-out wrong.  The numbers don't appear to conflict at all, but I assume that's just a fluke?  Anyway, I assume we'll probably need to adjust this somehow (or do it in a slightly different way altogether).  Do you have a clear steer to offer on this, or does this need to be a conversation involving the PIs?

Edit: There are also a couple where the `label` field in the catalogue has only a number, which currently results in an empty `[]` at the end of the line.  In the unlikely event that the current arrangement is acceptable, I'll fix that.