### PR TITLE
Misc. Updates

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 node_modules/**
 src/assets/**
+build/**

--- a/src/components/PlaybackControls.svelte
+++ b/src/components/PlaybackControls.svelte
@@ -39,7 +39,7 @@
 
 <div id="playback-controls">
   <button type="button" on:click={playPauseApp}>Play/Pause</button>
-  <button type="button" on:click={stopApp}>Stop</button>
+  <button type="button" on:click={stopApp}>Rewind</button>
   <button
     type="button"
     class:pedal-on={$softOnOff}

--- a/src/components/RollSelector.svelte
+++ b/src/components/RollSelector.svelte
@@ -17,8 +17,8 @@
 
   const listItems = catalog.map((item) => ({
     ...item,
-    _label: `${item.label.match(/^\d+/)} ${item.title} [${item.label.replace(
-      /^\d*\s?/,
+    _label: `${item.label.match(/^[\d.]+/)} ${item.title} [${item.label.replace(
+      /^[\d.]+\s?/,
       "",
     )}]`,
   }));
@@ -32,5 +32,5 @@
   labelFieldName="_label"
   searchFieldName="_label"
   facetFieldName="type"
-  postMarkup={(str) => str.replace(/^\d+|\[[^\]]+\]$/g, "<small>$&</small>")}
+  postMarkup={(str) => str.replace(/^[\d.]+|\[[^\]]+\]$/g, "<small>$&</small>")}
 />

--- a/src/styles/base.scss
+++ b/src/styles/base.scss
@@ -131,8 +131,11 @@ kbd {
     0 1px 2px 1px rgb(30 35 90 / 40%);
   color: black;
   display: inline-block;
+  font-family: "Courier New";
+  font-size: 12px;
   height: 18px;
   justify-content: center;
+  line-height: 10px;
   margin-right: 0.4em;
   padding: 3px 5px;
   text-align: center;

--- a/src/ui-components/FilteredSelect.svelte
+++ b/src/ui-components/FilteredSelect.svelte
@@ -216,13 +216,6 @@
     return markedUp;
   };
 
-  const selectListItem = (
-    listItem = filteredListItems[activeListItemIndex],
-  ) => {
-    selectedItem = listItem.item;
-    open = false;
-  };
-
   const activateListItem = async (index) => {
     activeListItemIndex = clamp(index, 0, filteredListItems.length - 1);
 
@@ -240,16 +233,6 @@
       if (listItemBottom > listBottom) activeListItem.scrollIntoView(false);
       if (listItemTop < listTop) activeListItem.scrollIntoView();
     }
-  };
-
-  const activateDropdown = async () => {
-    if (open) return;
-    open = true;
-    await tick();
-    input.innerHTML = "";
-    activeFacet = undefined;
-    filteredListItems = listItems;
-    activateListItem(items.indexOf(selectedItem));
   };
 
   const search = async () => {
@@ -310,6 +293,32 @@
       );
   };
 
+  const activateDropdown = async () => {
+    if (open) return;
+    open = true;
+    await tick();
+    input.innerHTML = "";
+    activeFacet = undefined;
+    filteredListItems = listItems;
+    activateListItem(items.indexOf(selectedItem));
+    input.focus();
+  };
+
+  const closeDropdown = () => {
+    open = false;
+    onSelectedItemChanged();
+    input.blur();
+  };
+
+  const toggleDropdown = () => (open ? closeDropdown() : activateDropdown());
+
+  const selectListItem = (
+    listItem = filteredListItems[activeListItemIndex],
+  ) => {
+    selectedItem = listItem.item;
+    closeDropdown();
+  };
+
   /* eslint-disable no-unused-expressions, no-sequences */
   $: items, prepareListItems();
   $: selectedItem, onSelectedItemChanged();
@@ -323,7 +332,7 @@
     bind:this={input}
     on:input={search}
     on:focus={activateDropdown}
-    on:click={activateDropdown}
+    on:mousedown|preventDefault={toggleDropdown}
     on:keydown|stopPropagation={({ key }) => {
       switch (key) {
         case "ArrowDown":
@@ -347,13 +356,12 @@
           break;
 
         case "Escape":
-          if (open) open = false;
-          onSelectedItemChanged();
+          closeDropdown();
           break;
 
         case "Enter":
           selectListItem();
-          input.blur();
+          closeDropdown();
           break;
 
         default:
@@ -402,9 +410,7 @@
     if (
       !(dropdown.contains(target) || input.contains(target)) &&
       !defaultPrevented
-    ) {
-      open = false;
-      onSelectedItemChanged();
-    }
+    )
+      closeDropdown();
   }}
 />


### PR DESCRIPTION
This is a collection of miscellaneous updates that I would like to get in before tomorrow's meeting.

* The `<RollSelector/>` dropdown should close if you click on the input field while it's open.
* `build/**` should be excluded from the prettier check in `yarn lint`.
* I've tried forcing the fixed-width font for `<kbd/>` elements (i.e. the keyboard shortcut indicators).  I noticed the look badly out of alignment on Macs, and suppose this is the result of different systems selecting a different typeface for `monospace`, so I've tried forcing it to use "Courier New" on all systems.
* "Stop" is changed to "Rewind" -- temporary thing, but the commit's been sitting on a random local branch for weeks, so it might as well go in here.