### PR TITLE
Misc. Fixes and Updates

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -199,24 +199,13 @@
         if (params.has("druid") && params.get("druid") !== currentRoll.druid) {
           const url = new URL(window.location);
           url.searchParams.set("druid", currentRoll.druid);
-          window.history.pushState({}, "", url);
+          window.history.pushState({ roll: currentRoll }, "", url);
         }
       },
     );
   };
 
-  onMount(async () => {
-    ({
-      midiSamplePlayer,
-      pianoReady,
-      updatePlayer,
-      startNote,
-      stopNote,
-      pausePlayback,
-      startPlayback,
-      resetPlayback,
-    } = samplePlayer);
-
+  const setCurrentRollFromUrl = () => {
     const params = new URLSearchParams(window.location.search);
     if (params.has("druid")) {
       const druid = params.get("druid");
@@ -236,6 +225,21 @@
       currentRoll =
         rollListItems[Math.floor(Math.random() * rollListItems.length)];
     }
+  };
+
+  onMount(async () => {
+    ({
+      midiSamplePlayer,
+      pianoReady,
+      updatePlayer,
+      startNote,
+      stopNote,
+      pausePlayback,
+      startPlayback,
+      resetPlayback,
+    } = samplePlayer);
+
+    setCurrentRollFromUrl();
   });
 
   $: if (currentRoll !== previousRoll) loadRoll(currentRoll);
@@ -293,3 +297,8 @@
 <SamplePlayer bind:this={samplePlayer} />
 <KeyboardShortcuts />
 <Notification />
+
+<svelte:window
+  on:popstate={({ state }) =>
+    state?.roll ? (currentRoll = state.roll) : setCurrentRollFromUrl()}
+/>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -197,8 +197,9 @@
         previousRoll = currentRoll;
         const params = new URLSearchParams(window.location.search);
         if (params.has("druid") && params.get("druid") !== currentRoll.druid) {
-          params.set("druid", currentRoll.druid);
-          window.location.search = params.toString();
+          const url = new URL(window.location);
+          url.searchParams.set("druid", currentRoll.druid);
+          window.history.pushState({}, "", url);
         }
       },
     );

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -220,7 +220,17 @@
     if (params.has("druid")) {
       const druid = params.get("druid");
       const roll = rollListItems.find((r) => r.druid === druid);
-      if (roll !== undefined) currentRoll = roll;
+      if (roll !== undefined) {
+        currentRoll = roll;
+      } else {
+        notify({
+          title: "DRUID not found!",
+          message:
+            "Please check the specified DRUID, or <a href='/'>click here to continue</a>.",
+          type: "error",
+          closable: false,
+        });
+      }
     } else {
       currentRoll =
         rollListItems[Math.floor(Math.random() * rollListItems.length)];

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -302,6 +302,7 @@
       maxZoomLevel,
       constrainDuringPan: true,
       preserveImageSizeOnResize: true,
+      gestureSettingsMouse: { clickToZoom: false },
     });
 
     ({ viewport } = openSeadragon);

--- a/src/ui-components/FilteredSelect.svelte
+++ b/src/ui-components/FilteredSelect.svelte
@@ -411,4 +411,7 @@
       closeDropdown();
     }
   }}
+  on:keydown|stopPropagation={({ key }) => {
+    if (open && key === "Escape") closeDropdown();
+  }}
 />

--- a/src/ui-components/FilteredSelect.svelte
+++ b/src/ui-components/FilteredSelect.svelte
@@ -408,6 +408,7 @@
 <svelte:window
   on:click={({ target, defaultPrevented }) => {
     if (
+      open &&
       !(dropdown.contains(target) || input.contains(target)) &&
       !defaultPrevented
     )

--- a/src/ui-components/FilteredSelect.svelte
+++ b/src/ui-components/FilteredSelect.svelte
@@ -406,12 +406,9 @@
 </div>
 
 <svelte:window
-  on:click={({ target, defaultPrevented }) => {
-    if (
-      open &&
-      !(dropdown.contains(target) || input.contains(target)) &&
-      !defaultPrevented
-    )
+  on:click={({ target }) => {
+    if (open && !(dropdown.contains(target) || input.contains(target))) {
       closeDropdown();
+    }
   }}
 />

--- a/src/ui-components/Notification.svelte
+++ b/src/ui-components/Notification.svelte
@@ -42,6 +42,7 @@
     margin: 0;
     padding: 0.25em;
   }
+
   .close {
     align-items: center;
     border-left: 1px solid rgba(0, 0, 0, 0.2);
@@ -67,6 +68,8 @@
       {/if}
       <p>{$NotificationStore.message}</p>
     </section>
-    <div class="close" on:click={() => NotificationStore.set()}>&times;</div>
+    {#if $NotificationStore.closable !== false}
+      <div class="close" on:click={() => NotificationStore.set()}>&times;</div>
+    {/if}
   </div>
 {/if}

--- a/src/ui-components/Notification.svelte
+++ b/src/ui-components/Notification.svelte
@@ -17,6 +17,11 @@
       border-left-width: 6px;
       color: white;
 
+      :global(a) {
+        color: white;
+        font-weight: bold;
+      }
+
       .close {
         color: white;
         border-left-color: rgba(255, 255, 255, 0.5);
@@ -66,7 +71,7 @@
       {#if $NotificationStore.title}
         <header>{$NotificationStore.title}</header>
       {/if}
-      <p>{$NotificationStore.message}</p>
+      <p>{@html $NotificationStore.message}</p>
     </section>
     {#if $NotificationStore.closable !== false}
       <div class="close" on:click={() => NotificationStore.set()}>&times;</div>


### PR DESCRIPTION
The Aristotelian _teloi_ for these changes are:
1. To display a notification if a malformed or otherwise unavailable DRUID is provided in the querystring.
2. To have the app behave more like a proper SPA when updating the querystring (and therefore the URL) either from the dropdown or using the browser back/forward buttons.

To achieve the former, it was necessary to allow for the creation of "unclosable" notifications, which in turn necessitated some updates to handling of `window.onClick` events in the `<RollSelector/>` and `<RollViewer/`> components.  To allow the latter, some additional routing logic and fallbacks were required.

There are two (well, at least two ;)) possibly problematic parts of this PR that I'd like to draw attention to:
1. To close the `<RollSelector/>` dropdown when "clicking outside", there is a `window.onClick` event that tests if the click is outside the roll selector component.  Previously this had a check for `event.defaultPrevented`, but this was causing it not to fire when clicking on the roll viewer (I think OSD calls `event.preventDefault()` on everything).  While not strictly necessary to accommodate (1) above, I've removed this check for a better UX.  Tbh, however, I'm not sure why it was there in the first place, so it's possible some other part of the UX is degraded by removing it.  I couldn't find (or think of) anything, but if you come across anything funky, it might be to do with that.
2. Connected with the preceding point, clicking on the roll image when the dropdown is open closes the dropdown as expected, but was also causing OSD to zoom in, which was icky.  After some brief consideration, I simply disabled `clickToZoom` on OSD.  This is perhaps a bit heavy-handed, but the alternatives are quite involved, and for my part at least I like it better with `clickToZoom` off.  There are plenty of other ways to zoom in (`clickToZoom` only ever zoomed *in* anyway).  However, I appreciate this may be controversial and need to be reverted.