### PR TITLE
Fix emulated tempo bug

### DIFF
--- a/src/components/SamplePlayer.svelte
+++ b/src/components/SamplePlayer.svelte
@@ -201,7 +201,7 @@
 
   midiSamplePlayer.on(
     "midiEvent",
-    ({ name, value, number, noteNumber, velocity, data }) => {
+    ({ name, value, number, noteNumber, velocity }) => {
       if (name === "Note on") {
         if (velocity === 0) {
           stopNote(noteNumber);
@@ -216,8 +216,6 @@
         } else if (number === SOFT_PEDAL) {
           softOnOff.set(!!value);
         }
-      } else if (name === "Set Tempo" && $useMidiTempoEventsOnOff) {
-        midiSamplePlayer.setTempo(data * $tempoCoefficient);
       }
     },
   );

--- a/src/components/SamplePlayer.svelte
+++ b/src/components/SamplePlayer.svelte
@@ -62,6 +62,8 @@
   };
 
   const setPlayerStateAtTick = (tick = $currentTick) => {
+    if (midiSamplePlayer.tracks[0])
+      midiSamplePlayer.tracks[0].enabled = $useMidiTempoEventsOnOff;
     midiSamplePlayer.setTempo(getTempoAtTick(tick) * $tempoCoefficient);
 
     if (pedalingMap && $rollPedalingOnOff) {


### PR DESCRIPTION
This PR is to address the issue with toggling roll acceleration emulation not working properly.  The issue was that the `"Set tempo"` events that `midiplayer-js` fires occur **after** the tempo has already been altered.  This means that a) there's no need to listen for these events and manually adjust the tempo in response to them; and b) ignoring these events when `$useMidiTempoEventsOnOff === false` has no effect.  Fortunately our MIDI files have the tempo events on the first MIDI track which otherwise contains only metadata (i.e. no notes) -- so we can simply toggle this track to enable/disable tempo events from the MIDI with no side-effects.

After a lot of testing and re-testing, I just removed dozens of lines of debugging code from this branch and it boils down to three lines in and three lines out :)