### PR TITLE
Roll Panning Dynamics and a fix for redundant brackets

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -96,13 +96,13 @@
   let startPlayback;
   let resetPlayback;
 
-  const rollListItems = catalog.map((item) => ({
-    ...item,
-    _label: `${item.label.match(/^[\d.]+/)} ${item.title} [${item.label.replace(
-      /^[\d.]+\s?/,
-      "",
-    )}]`,
-  }));
+  const rollListItems = catalog.map((item) => {
+    const [number, label] = item.label.split(" ");
+    return {
+      ...item,
+      _label: `${number} ${item.title}${label ? ` [${label}]` : ""}`,
+    };
+  });
 
   const slide = (node, { delay = 0, duration = 300 }) => {
     const o = parseInt(getComputedStyle(node).height, 10);

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -333,7 +333,7 @@
   const panByIncrement = (up = true) => {
     const viewportBounds = viewport.getBounds();
     const imgBounds = viewport.viewportToImageRectangle(viewportBounds);
-    const delta = up ? imgBounds.height / 10 : -imgBounds.height / 10;
+    const delta = up ? imgBounds.height / 100 : -imgBounds.height / 100;
     const centerY = imgBounds.y + imgBounds.height / 2;
     skipToTick(
       scrollDownwards

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -333,7 +333,7 @@
   const panByIncrement = (up = true) => {
     const viewportBounds = viewport.getBounds();
     const imgBounds = viewport.viewportToImageRectangle(viewportBounds);
-    const delta = up ? imgBounds.height / 100 : -imgBounds.height / 100;
+    const delta = up ? imgBounds.height / 50 : -imgBounds.height / 50;
     const centerY = imgBounds.y + imgBounds.height / 2;
     skipToTick(
       scrollDownwards

--- a/src/components/RollViewerControls.svelte
+++ b/src/components/RollViewerControls.svelte
@@ -101,7 +101,7 @@
     disabled={false}
     on:mousedown={() => {
       panByIncrement(false);
-      panInterval = setInterval(() => panByIncrement(false), 100);
+      panInterval = setInterval(() => panByIncrement(false), 10);
     }}
   >
     <svg
@@ -124,7 +124,7 @@
     disabled={false}
     on:mousedown={() => {
       panByIncrement(true);
-      panInterval = setInterval(() => panByIncrement(true), 100);
+      panInterval = setInterval(() => panByIncrement(true), 10);
     }}
   >
     <svg

--- a/src/components/RollViewerControls.svelte
+++ b/src/components/RollViewerControls.svelte
@@ -30,7 +30,10 @@
 
   onMount(() => {
     openSeadragon.addHandler("zoom", onZoom);
-    return () => openSeadragon.removeHandler("zoom", onZoom);
+    return () => {
+      openSeadragon.removeHandler("zoom", onZoom);
+      panInterval?.clear();
+    };
   });
 </script>
 

--- a/src/components/RollViewerControls.svelte
+++ b/src/components/RollViewerControls.svelte
@@ -146,4 +146,4 @@
     </svg>
   </button>
 </div>
-<svelte:window on:mouseup={() => panInterval.clear()} />
+<svelte:window on:mouseup={() => panInterval?.clear()} />

--- a/src/components/RollViewerControls.svelte
+++ b/src/components/RollViewerControls.svelte
@@ -3,6 +3,8 @@
   import { fade } from "svelte/transition";
   import OpenSeadragon from "openseadragon";
 
+  import { easingInterval } from "../utils";
+
   export let openSeadragon;
   export let maxZoomLevel;
   export let minZoomLevel;
@@ -101,7 +103,7 @@
     disabled={false}
     on:mousedown={() => {
       panByIncrement(false);
-      panInterval = setInterval(() => panByIncrement(false), 10);
+      panInterval = easingInterval(200, () => panByIncrement(false));
     }}
   >
     <svg
@@ -124,7 +126,7 @@
     disabled={false}
     on:mousedown={() => {
       panByIncrement(true);
-      panInterval = setInterval(() => panByIncrement(true), 10);
+      panInterval = easingInterval(200, () => panByIncrement(true));
     }}
   >
     <svg
@@ -144,4 +146,4 @@
     </svg>
   </button>
 </div>
-<svelte:window on:mouseup={() => clearInterval(panInterval)} />
+<svelte:window on:mouseup={() => panInterval.clear()} />

--- a/src/utils.js
+++ b/src/utils.js
@@ -4,3 +4,25 @@ export const enforcePrecision = (value, precision) => {
 };
 
 export const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+
+export const easingInterval = (interval, fn) => {
+  let timeoutId;
+
+  const wrapped = () => {
+    fn();
+    // eslint-disable-next-line no-param-reassign
+    interval = Math.max(Math.floor(interval / 1.2), 10);
+    timeoutId = setTimeout(wrapped, interval);
+  };
+
+  timeoutId = setTimeout(wrapped, interval);
+
+  return {
+    clear: () => {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+        timeoutId = null;
+      }
+    },
+  };
+};


### PR DESCRIPTION
Dual PR (sorry!  -- commits are clean!):

* Drops brackets when a label number is available but no label name (though presumably there's a cataloging error here?)
* Adjusts the dynamics of the vertical panning buttons to facilitate fine-grained (< hole-by-hole) panning while still allowing their use for navigation.

I'd fiddled with the latter and arrived at these values, but am open to feedback and further suggestions for what (else?) to do with this.