### PR TITLE
Apply user tempo coefficient at MIDI tempo change events

### DIFF
--- a/src/components/SamplePlayer.svelte
+++ b/src/components/SamplePlayer.svelte
@@ -230,7 +230,7 @@
 
   midiSamplePlayer.on(
     "midiEvent",
-    ({ name, value, number, noteNumber, velocity }) => {
+    ({ name, value, number, noteNumber, velocity, data }) => {
       if (name === "Note on") {
         if (velocity === 0) {
           stopNote(noteNumber);
@@ -245,6 +245,8 @@
         } else if (number === SOFT_PEDAL) {
           softOnOff.set(!!value);
         }
+      } else if (name === "Set Tempo" && $useMidiTempoEventsOnOff) {
+        midiSamplePlayer.setTempo(data * $tempoCoefficient);
       }
     },
   );


### PR DESCRIPTION
This PR just rolls back [this commit](https://github.com/sul-cidr/pianolatron/commit/1e3c5bb05d92ce38072ffea34f4a4df33770e442) from PR #65. It turns out we do need to manually duplicate the MIDI-encoded tempo adjustment events, because if we just let the events be applied as is, they won't incorporate the user-specified tempo coefficient (set via the Tempo slider), with the result that every time the player reaches a tempo event (these are inserted to mimic roll acceleration), the coefficient will not be applied, leading to an erroneous speedup or slowdown of the playback. 