### PR TITLE
Flip overlay flags to the left when near right edge of viewer

### DIFF
--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -46,6 +46,12 @@
 
     :global(mark) {
       background-color: transparent;
+      --left-flag-position: calc(
+        100% + #{$highlight-hover-outline-offset} + #{$highlight-hover-outline-width}
+      );
+      --right-flag-position: calc(
+        100% + #{$highlight-hover-outline-offset} + #{$highlight-hover-outline-width}
+      );
 
       &:hover {
         background-color: transparent;
@@ -82,9 +88,8 @@
       content: attr(data-info);
       display: block;
       font-weight: bold;
-      left: calc(
-        100% + #{$highlight-hover-outline-offset} + #{$highlight-hover-outline-width}
-      );
+      left: var(--left-flag-position);
+      right: var(--right-flag-position);
       padding: 8px ($highlight-hover-outline-width + 4px) 8px 4px;
       position: absolute;
       text-shadow: 0px 0px 8px black;
@@ -190,6 +195,15 @@
       width,
       height,
     );
+    const imgBounds = viewport.viewportToImageRectangle(viewport.getBounds());
+    const markFractionalPosition =
+      parseFloat(offsetX + width / 2 - imgBounds.x) /
+      parseFloat(imgBounds.width);
+    if (markFractionalPosition > 0.8) {
+      mark.style.setProperty("--left-flag-position", "auto");
+    } else {
+      mark.style.setProperty("--right-flag-position", "auto");
+    }
     viewport.viewer.addOverlay(mark, viewportRectangle);
     return mark;
   };

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -46,12 +46,6 @@
 
     :global(mark) {
       background-color: transparent;
-      --left-flag-position: calc(
-        100% + #{$highlight-hover-outline-offset} + #{$highlight-hover-outline-width}
-      );
-      --right-flag-position: calc(
-        100% + #{$highlight-hover-outline-offset} + #{$highlight-hover-outline-width}
-      );
 
       &:hover {
         background-color: transparent;
@@ -88,13 +82,21 @@
       content: attr(data-info);
       display: block;
       font-weight: bold;
-      left: var(--left-flag-position);
-      right: var(--right-flag-position);
+      left: calc(
+        100% + #{$highlight-hover-outline-offset} + #{$highlight-hover-outline-width}
+      );
       padding: 8px ($highlight-hover-outline-width + 4px) 8px 4px;
       position: absolute;
       text-shadow: 0px 0px 8px black;
       top: -($highlight-hover-outline-offset + $highlight-hover-outline-width);
       transform: none;
+    }
+
+    :global(mark.flag-left:hover[data-info]::after) {
+      left: auto;
+      right: calc(
+        100% + #{$highlight-hover-outline-offset} + #{$highlight-hover-outline-width}
+      );
     }
 
     :global(canvas) {
@@ -199,11 +201,7 @@
     const markFractionalPosition =
       parseFloat(offsetX + width / 2 - imgBounds.x) /
       parseFloat(imgBounds.width);
-    if (markFractionalPosition > 0.8) {
-      mark.style.setProperty("--left-flag-position", "auto");
-    } else {
-      mark.style.setProperty("--right-flag-position", "auto");
-    }
+    mark.classList.toggle("flag-left", markFractionalPosition > 0.8);
     viewport.viewer.addOverlay(mark, viewportRectangle);
     return mark;
   };

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -97,6 +97,7 @@
       right: calc(
         100% + #{$highlight-hover-outline-offset} + #{$highlight-hover-outline-width}
       );
+      padding: 8px 4px 8px ($highlight-hover-outline-width + 4px);
     }
 
     :global(canvas) {


### PR DESCRIPTION
This keeps the overlay flags from getting clipped by the right edge of the viewer. Just allowing the flags to overflow the viewer is problematic both aesthetically and technically. The threshold is set arbitrarily at 80% of the width for now; it could be something like 50%, but I think it's slightly preferable aesthetically for the note hole flags to all point the same way at the default zoom level, and this happens when threshold = 80%.

This doesn't address the possibility that the active overlays (the labels that can appear _above_ the holes on playback) might be clipped, but that rarely if ever happens due to their positioning.