### PR TITLE
Pan Animation Handling

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -63,6 +63,7 @@
     rollMetadata,
     showKeyboard,
     overlayKeyboard,
+    animatePan,
   } from "./stores";
   import { clamp } from "./utils";
   import SamplePlayer from "./components/SamplePlayer.svelte";
@@ -129,6 +130,7 @@
 
   const skipToTick = (tick) => {
     if (tick < 0) pausePlayback();
+    $animatePan = true;
     $currentTick = tick;
     updatePlayer(() => midiSamplePlayer.skipToTick($currentTick));
   };

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -155,7 +155,7 @@
     rollMetadata,
     currentTick,
     userSettings,
-    playingNow,
+    animatePan,
   } from "../stores";
   import { clamp, getNoteLabel } from "../utils";
   import RollViewerControls from "./RollViewerControls.svelte";
@@ -271,7 +271,7 @@
       lineViewport.y,
     );
 
-    viewport.panTo(lineCenter, $playingNow);
+    viewport.panTo(lineCenter, !$animatePan);
   };
 
   const highlightHoles = (tick) => {

--- a/src/components/SamplePlayer.svelte
+++ b/src/components/SamplePlayer.svelte
@@ -17,7 +17,6 @@
     useMidiTempoEventsOnOff,
     activeNotes,
     currentTick,
-    playingNow,
   } from "../stores";
 
   let tempoMap;
@@ -121,7 +120,6 @@
   };
 
   const resetPlayback = () => {
-    playingNow.set(false);
     currentTick.reset();
     midiSamplePlayer.stop();
     activeNotes.reset();
@@ -131,7 +129,6 @@
   };
 
   const pausePlayback = () => {
-    playingNow.set(false);
     midiSamplePlayer.pause();
     stopAllNotes();
   };
@@ -139,7 +136,6 @@
   const startPlayback = () => {
     if ($currentTick < 0) resetPlayback();
     updatePlayer();
-    playingNow.set(true);
     midiSamplePlayer.play();
   };
 

--- a/src/stores.js
+++ b/src/stores.js
@@ -60,7 +60,18 @@ export const activeShortcutKeys = createStore({
 export const currentTick = createStore(0);
 export const playbackProgress = createStore(0);
 export const activeNotes = createSetStore();
-export const playingNow = createStore(false);
+export const animatePan = (() => {
+  const { set: _set, subscribe } = writable(false);
+  let timeoutId;
+  return {
+    set: (val) => {
+      _set(val);
+      clearTimeout(timeoutId);
+      timeoutId = setTimeout(() => _set(false), 200);
+    },
+    subscribe,
+  };
+})();
 
 // User Settings
 export const showKeyboard = createStore(true);

--- a/src/stores.js
+++ b/src/stores.js
@@ -67,7 +67,7 @@ export const animatePan = (() => {
     set: (val) => {
       _set(val);
       clearTimeout(timeoutId);
-      timeoutId = setTimeout(() => _set(false), 200);
+      timeoutId = setTimeout(() => _set(false), 780);
     },
     subscribe,
   };


### PR DESCRIPTION
This PR replaces the `$playingNow` store with an `$animatePan` store.  The logic is that we don't actually need to disable the panning animation while "navigating", even if that navigation happens during playback.  The approach here is to make `$animatePan` a custom store that resets itself to false after a given interval (set to approximately the animation time) *after* the last `skipToTick` call (effectively making the store behave like a singleton so that it handles the panning buttons and other elements that repeatedly fire events and update `$currentTick`).