### PR TITLE
Keyboard Commands Update

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -300,7 +300,7 @@
   {/if}
 </div>
 <SamplePlayer bind:this={samplePlayer} />
-<KeyboardShortcuts />
+<KeyboardShortcuts {playPauseApp} {stopApp} />
 <Notification />
 
 <svelte:window

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -99,6 +99,9 @@
   let startPlayback;
   let resetPlayback;
 
+  let rollViewer;
+  let updateTickByViewportIncrement;
+
   const rollListItems = catalog.map((item) => {
     const [number, label] = item.label.split(" ");
     return {
@@ -251,6 +254,7 @@
   $: playbackProgress.update(() =>
     clamp($currentTick / midiSamplePlayer?.totalTicks, 0, 1),
   );
+  $: if (rollViewer) ({ updateTickByViewportIncrement } = rollViewer);
 </script>
 
 <div id="app">
@@ -270,6 +274,7 @@
     {#if appReady}
       <div id="roll">
         <RollViewer
+          bind:this={rollViewer}
           imageUrl={currentRoll.image_url}
           {holesByTickInterval}
           {skipToTick}
@@ -300,7 +305,7 @@
   {/if}
 </div>
 <SamplePlayer bind:this={samplePlayer} />
-<KeyboardShortcuts {playPauseApp} {stopApp} />
+<KeyboardShortcuts {playPauseApp} {stopApp} {updateTickByViewportIncrement} />
 <Notification />
 
 <svelte:window

--- a/src/components/BasicSettings.svelte
+++ b/src/components/BasicSettings.svelte
@@ -49,7 +49,11 @@
     />
   </div>
   <div class="control">
-    <span>Bass Volume:</span>
+    <span
+      >Bass Volume:
+      <kbd class:depressed={$activeShortcutKeys.bassVolumeDown}>e</kbd>↓
+      <kbd class:depressed={$activeShortcutKeys.bassVolumeUp}>4</kbd>↑</span
+    >
     <span>{$bassVolumeCoefficient}</span>
     <RangeSlider
       min="0"
@@ -60,7 +64,11 @@
     />
   </div>
   <div class="control">
-    <span>Treble Volume:</span>
+    <span
+      >Treble Volume:
+      <kbd class:depressed={$activeShortcutKeys.trebleVolumeDown}>p</kbd>↓
+      <kbd class:depressed={$activeShortcutKeys.trebleVolumeUp}>0</kbd>↑
+    </span>
     <span>{$trebleVolumeCoefficient}</span>
     <RangeSlider
       min="0"

--- a/src/components/BasicSettings.svelte
+++ b/src/components/BasicSettings.svelte
@@ -36,8 +36,8 @@
   <div class="control">
     <span
       >Volume:
-      <kbd class:depressed={$activeShortcutKeys.volumeDown}>[</kbd>↓
-      <kbd class:depressed={$activeShortcutKeys.volumeUp}>]</kbd>↑</span
+      <kbd class:depressed={$activeShortcutKeys.volumeDown}>o</kbd>↓
+      <kbd class:depressed={$activeShortcutKeys.volumeUp}>i</kbd>↑</span
     >
     <span>{$volumeCoefficient}</span>
     <RangeSlider
@@ -81,8 +81,8 @@
   <div class="control">
     <span
       >Tempo:
-      <kbd class:depressed={$activeShortcutKeys.tempoDown}>w</kbd>↓
-      <kbd class:depressed={$activeShortcutKeys.tempoUp}>e</kbd>↑</span
+      <kbd class:depressed={$activeShortcutKeys.tempoDown}>r</kbd>↓
+      <kbd class:depressed={$activeShortcutKeys.tempoUp}>t</kbd>↑</span
     >
     <span>{($tempoCoefficient * 100).toFixed(0)}%</span>
     <RangeSlider

--- a/src/components/KeyboardShortcuts.svelte
+++ b/src/components/KeyboardShortcuts.svelte
@@ -19,19 +19,19 @@
   let actionInterval;
 
   const keyMap = Object.freeze({
-    SOFT: "KeyQ",
-    SUSTAIN: "KeyC",
-    ACCENT: "Comma",
+    SOFT: "KeyB",
+    SUSTAIN: "Space",
+    ACCENT: "KeyN",
 
-    VOLUME_UP: "BracketRight",
-    VOLUME_DOWN: "BracketLeft",
+    VOLUME_UP: "KeyO",
+    VOLUME_DOWN: "KeyI",
     BASS_VOLUME_UP: "Digit4",
     BASS_VOLUME_DOWN: "KeyE",
     TREBLE_VOLUME_UP: "Digit0",
     TREBLE_VOLUME_DOWN: "KeyP",
 
-    TEMPO_UP: "KeyE",
-    TEMPO_DOWN: "KeyW",
+    TEMPO_UP: "KeyT",
+    TEMPO_DOWN: "KeyR",
 
     PLAY_PAUSE: "Digit7",
     REWIND: "Delete",

--- a/src/components/KeyboardShortcuts.svelte
+++ b/src/components/KeyboardShortcuts.svelte
@@ -5,6 +5,8 @@
     sustainOnOff,
     accentOnOff,
     volumeCoefficient,
+    bassVolumeCoefficient,
+    trebleVolumeCoefficient,
     tempoCoefficient,
     activeShortcutKeys,
   } from "../stores";
@@ -14,8 +16,14 @@
     SOFT: "KeyQ",
     SUSTAIN: "KeyC",
     ACCENT: "Comma",
+
     VOLUME_UP: "BracketRight",
     VOLUME_DOWN: "BracketLeft",
+    BASS_VOLUME_UP: "Digit4",
+    BASS_VOLUME_DOWN: "KeyE",
+    TREBLE_VOLUME_UP: "Digit0",
+    TREBLE_VOLUME_DOWN: "KeyP",
+
     TEMPO_UP: "KeyE",
     TEMPO_DOWN: "KeyW",
   });
@@ -23,6 +31,24 @@
   const config = {
     volume: {
       store: volumeCoefficient,
+      min: 0,
+      max: 4,
+      delta: 0.1,
+      shiftDelta: 0.4,
+      ctrlDelta: 0.05,
+      precision: 2,
+    },
+    bassVolume: {
+      store: bassVolumeCoefficient,
+      min: 0,
+      max: 4,
+      delta: 0.1,
+      shiftDelta: 0.4,
+      ctrlDelta: 0.05,
+      precision: 2,
+    },
+    trebleVolume: {
+      store: trebleVolumeCoefficient,
       min: 0,
       max: 4,
       delta: 0.1,
@@ -89,6 +115,30 @@
         decrement(config.volume, event);
         break;
 
+      case keyMap.BASS_VOLUME_UP:
+        event.preventDefault();
+        $activeShortcutKeys.bassVolumeUp = true;
+        increment(config.bassVolume, event);
+        break;
+
+      case keyMap.BASS_VOLUME_DOWN:
+        event.preventDefault();
+        $activeShortcutKeys.bassVolumeDown = true;
+        decrement(config.bassVolume, event);
+        break;
+
+      case keyMap.TREBLE_VOLUME_UP:
+        event.preventDefault();
+        $activeShortcutKeys.trebleVolumeUp = true;
+        increment(config.trebleVolume, event);
+        break;
+
+      case keyMap.TREBLE_VOLUME_DOWN:
+        event.preventDefault();
+        $activeShortcutKeys.trebleVolumeDown = true;
+        decrement(config.trebleVolume, event);
+        break;
+
       case keyMap.TEMPO_UP:
         event.preventDefault();
         $activeShortcutKeys.tempoUp = true;
@@ -124,6 +174,22 @@
 
       case keyMap.VOLUME_DOWN:
         $activeShortcutKeys.volumeDown = false;
+        break;
+
+      case keyMap.BASS_VOLUME_UP:
+        $activeShortcutKeys.bassVolumeUp = false;
+        break;
+
+      case keyMap.BASS_VOLUME_DOWN:
+        $activeShortcutKeys.bassVolumeDown = false;
+        break;
+
+      case keyMap.TREBLE_VOLUME_UP:
+        $activeShortcutKeys.trebleVolumeUp = false;
+        break;
+
+      case keyMap.TREBLE_VOLUME_DOWN:
+        $activeShortcutKeys.trebleVolumeDown = false;
         break;
 
       case keyMap.TEMPO_UP:

--- a/src/components/KeyboardShortcuts.svelte
+++ b/src/components/KeyboardShortcuts.svelte
@@ -12,6 +12,9 @@
   } from "../stores";
   import { clamp, enforcePrecision } from "../utils";
 
+  export let playPauseApp;
+  export let stopApp;
+
   const keyMap = Object.freeze({
     SOFT: "KeyQ",
     SUSTAIN: "KeyC",
@@ -26,6 +29,9 @@
 
     TEMPO_UP: "KeyE",
     TEMPO_DOWN: "KeyW",
+
+    PLAY_PAUSE: "Digit7",
+    REWIND: "Delete",
   });
 
   const config = {
@@ -103,6 +109,18 @@
         accentOnOff.set(true);
         break;
 
+      case keyMap.PLAY_PAUSE:
+        event.preventDefault();
+        $activeShortcutKeys.playPause = true;
+        playPauseApp();
+        break;
+
+      case keyMap.REWIND:
+        event.preventDefault();
+        $activeShortcutKeys.rewind = true;
+        stopApp();
+        break;
+
       case keyMap.VOLUME_UP:
         event.preventDefault();
         $activeShortcutKeys.volumeUp = true;
@@ -166,6 +184,14 @@
 
       case keyMap.ACCENT:
         accentOnOff.set(false);
+        break;
+
+      case keyMap.PLAY_PAUSE:
+        $activeShortcutKeys.playPause = false;
+        break;
+
+      case keyMap.REWIND:
+        $activeShortcutKeys.rewind = false;
         break;
 
       case keyMap.VOLUME_UP:

--- a/src/components/KeyboardShortcuts.svelte
+++ b/src/components/KeyboardShortcuts.svelte
@@ -42,7 +42,9 @@
   };
 
   const updateStore = (
+    // config object
     { store, min, max, delta, shiftDelta, ctrlDelta, precision },
+    // event
     { shiftKey, ctrlKey },
     increment,
   ) => {

--- a/src/components/PlaybackControls.svelte
+++ b/src/components/PlaybackControls.svelte
@@ -31,15 +31,26 @@
 </style>
 
 <script>
-  import { softOnOff, sustainOnOff, accentOnOff } from "../stores";
+  import {
+    softOnOff,
+    sustainOnOff,
+    accentOnOff,
+    activeShortcutKeys,
+  } from "../stores";
 
   export let playPauseApp;
   export let stopApp;
 </script>
 
 <div id="playback-controls">
-  <button type="button" on:click={playPauseApp}>Play/Pause</button>
-  <button type="button" on:click={stopApp}>Rewind</button>
+  <button type="button" on:click={playPauseApp}
+    >Play/Pause
+    <kbd class:depressed={$activeShortcutKeys.playPause}>7</kbd></button
+  >
+  <button type="button" on:click={stopApp}
+    >Rewind
+    <kbd class:depressed={$activeShortcutKeys.rewind}>Del</kbd></button
+  >
   <button
     type="button"
     class:pedal-on={$softOnOff}

--- a/src/components/PlaybackControls.svelte
+++ b/src/components/PlaybackControls.svelte
@@ -57,7 +57,7 @@
     aria-pressed={$softOnOff}
     on:click={() => ($softOnOff = !$softOnOff)}
     >Soft
-    <kbd class:depressed={$softOnOff}>q</kbd></button
+    <kbd class:depressed={$softOnOff}>b</kbd></button
   >
   <button
     type="button"
@@ -65,7 +65,7 @@
     aria-pressed={$sustainOnOff}
     on:click={() => ($sustainOnOff = !$sustainOnOff)}
     >Sustain
-    <kbd class:depressed={$sustainOnOff}>c</kbd></button
+    <kbd class:depressed={$sustainOnOff}>Space</kbd></button
   >
   <br />
   <button
@@ -75,7 +75,7 @@
     aria-pressed={$accentOnOff}
     on:mousedown={() => ($accentOnOff = true)}
     >Accent
-    <kbd class:depressed={$accentOnOff}>,</kbd></button
+    <kbd class:depressed={$accentOnOff}>n</kbd></button
   >
 </div>
 <svelte:window on:mouseup={() => ($accentOnOff = false)} />

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -562,6 +562,8 @@
     ? parseInt($rollMetadata.FIRST_HOLE, 10)
     : parseInt($rollMetadata.IMAGE_LENGTH, 10) -
       parseInt($rollMetadata.FIRST_HOLE, 10);
+
+  export { updateTickByViewportIncrement };
 </script>
 
 <div

--- a/src/components/RollViewerControls.svelte
+++ b/src/components/RollViewerControls.svelte
@@ -25,10 +25,10 @@
 
   const onZoom = () => (currentZoom = viewport.getZoom());
 
-  const mousedownAction = (fn, immediate = true) => () => {
+  const mousedownRepeatAction = (fn, immediate = true) => {
     actionInterval?.clear();
     if (immediate) fn();
-    actionInterval = easingInterval(() => fn());
+    actionInterval = easingInterval(fn);
   };
 
   onMount(() => {
@@ -43,7 +43,7 @@
 <div class="overlay-buttons top-center" transition:fade>
   <button
     disabled={currentZoom >= maxZoomLevel}
-    on:mousedown={mousedownAction(() =>
+    on:mousedown={mousedownRepeatAction(() =>
       viewport.zoomTo(Math.min(viewport.getZoom() * 1.1, maxZoomLevel)),
     )}
   >
@@ -64,7 +64,7 @@
   </button>
   <button
     disabled={currentZoom <= minZoomLevel}
-    on:mousedown={mousedownAction(() =>
+    on:mousedown={mousedownRepeatAction(() =>
       viewport.zoomTo(Math.max(viewport.getZoom() * 0.9, minZoomLevel)),
     )}
   >
@@ -107,7 +107,7 @@
   </button>
   <button
     disabled={false}
-    on:mousedown={mousedownAction(() =>
+    on:mousedown={mousedownRepeatAction(() =>
       updateTickByViewportIncrement(/* up = */ false),
     )}
   >
@@ -129,7 +129,7 @@
   </button>
   <button
     disabled={false}
-    on:mousedown={mousedownAction(() =>
+    on:mousedown={mousedownRepeatAction(() =>
       updateTickByViewportIncrement(/* up = */ true),
     )}
   >

--- a/src/stores.js
+++ b/src/stores.js
@@ -57,6 +57,10 @@ export const useMidiTempoEventsOnOff = createStore(true);
 export const activeShortcutKeys = createStore({
   volumeUp: false,
   volumeDown: false,
+  bassVolumeUp: false,
+  bassVolumeDown: false,
+  trebleVolumeUp: false,
+  trebleVolumeDown: false,
   tempoUp: false,
   tempoDown: false,
 });

--- a/src/stores.js
+++ b/src/stores.js
@@ -63,6 +63,8 @@ export const activeShortcutKeys = createStore({
   trebleVolumeDown: false,
   tempoUp: false,
   tempoDown: false,
+  playPause: false,
+  rewind: false,
 });
 
 // Playback State

--- a/src/styles/base.scss
+++ b/src/styles/base.scss
@@ -141,14 +141,14 @@ kbd {
   justify-content: center;
   line-height: 10px;
   margin-right: 0.4em;
-  padding: 3px 5px;
+  padding: 5px;
   text-align: center;
   vertical-align: text-bottom;
-  width: 20px;
+  min-width: 20px;
 
   &.depressed {
     box-shadow: inset 0 -1px 0 0 #cdcde6, inset 0 0 1px 1px #fff,
       0 0q 2px 1px rgb(30 35 90 / 40%);
-    padding-top: 4px;
+    padding-top: 6px;
   }
 }


### PR DESCRIPTION
This PR updates the keyboard command keystrokes to Kumaran's suggested defaults, and creates new keyboard commands where appropriate.  The only bit that's not done is the
```
Tempo increment bigger: W
Tempo increment smaller: Q

Volume increment bigger: [
Volume increment smaller: ]
```
bit, because I'm not 100% sure what to do with that (including -- but not limited to -- from a UI perspective).  Three levels, as now, but with some kind of a toggle switch for each slider?  Does the volume increment apply to bass and treble adjustments too?

Another rough edge:  I'm not entirely sure how/whether to deal with multiple keystrokes mapping to the same commands.  This comes up in two places in the immediate instance:
* the `keyCode`s for numbers are different when the events originate from a numberpad as opposed to the top row of a QWERTY keyboard -- Kumaran's requests make it fairly clear he has the top row in mind, so that's what's assigned here, but <kbd>6</kbd>,<kbd>7</kbd>,<kbd>8</kbd>,<kbd>0</kbd> etc. on the numpad don't work the same way;
* <kbd>6</kbd> and <kbd>8</kbd> pan forward and back in a way that it seems appropriate that the up and down arrows should too.

Mapping multiple keys to the same output is straightforward enough at this point, but gets a lot more complicated with the configurator-ifier thing.

Anyway, thoughts welcome.