### PR TITLE
Settings Persistence

### DIFF
--- a/src/components/AdvancedSettings.svelte
+++ b/src/components/AdvancedSettings.svelte
@@ -70,7 +70,7 @@
   let el;
   const themes = ["cardinal", "blue", "green", "grey"];
 
-  $: document.body.className = $userSettings.theme;
+  $: document.documentElement.setAttribute("data-theme", $userSettings.theme);
 </script>
 
 <div

--- a/src/layouts/base.astro
+++ b/src/layouts/base.astro
@@ -10,10 +10,15 @@ const {title} = Astro.props;
     <title>{title}</title>
     <style global lang="scss">
       @import "../styles/base";
+      @import "../styles/theme";
       @import "../styles/loader";
       @import "../styles/hole-highlighting";
       @import "../styles/overlay-buttons";
     </style>
+    <script>
+      const { theme } = JSON.parse(window.localStorage.getItem("userSettings")) || {};
+      theme && document.documentElement.setAttribute("data-theme", theme);
+    </script>
   </head>
   <body>
     <slot/>

--- a/src/stores.js
+++ b/src/stores.js
@@ -97,9 +97,9 @@ export const playbackProgress = createStore(0);
 export const activeNotes = createSetStore();
 
 // User Settings
-export const userSettings = createStore({
 export const showKeyboard = createPersistedStore("showKeyboard", true);
 export const overlayKeyboard = createPersistedStore("overlayKeyboard", false);
+export const userSettings = createPersistedStore("userSettings", {
   theme: "cardinal",
   activeNoteDetails: false,
   showNoteVelocities: false,

--- a/src/styles/base.scss
+++ b/src/styles/base.scss
@@ -36,31 +36,6 @@ body {
   min-height: 100vh;
   text-rendering: optimizeSpeed;
   transition: background 0.2s ease;
-
-  --background-color: #{$cloud};
-  --background-darker: #{darken($cloud, 15%)};
-  --primary-accent: #{$cardinal};
-  --primary-accent-semiopaque: #{transparentize($cardinal, 0.5)};
-  --background-angle: 75deg;
-
-  &.blue {
-    --background-color: aliceblue;
-    --background-darker: hsl(208, 100%, 90%);
-    --primary-accent: steelblue;
-    --primary-accent-semiopaque: #{transparentize(steelblue, 0.5)};
-  }
-
-  &.green {
-    --primary-accent: darkolivegreen;
-    --primary-accent-semiopaque: #{transparentize(darkolivegreen, 0.5)};
-  }
-
-  &.grey {
-    --background-color: gainsboro;
-    --background-darker: hsl(0, 0%, 71%);
-    --primary-accent: darkslategrey;
-    --primary-accent-semiopaque: #{transparentize(darkslategrey, 0.5)};
-  }
 }
 
 a {

--- a/src/styles/theme.scss
+++ b/src/styles/theme.scss
@@ -1,0 +1,28 @@
+@import "./globals";
+
+:root {
+  --background-color: #{$cloud};
+  --background-darker: #{darken($cloud, 15%)};
+  --primary-accent: #{$cardinal};
+  --primary-accent-semiopaque: #{transparentize($cardinal, 0.5)};
+  --background-angle: 75deg;
+}
+
+[data-theme="blue"] {
+  --background-color: aliceblue;
+  --background-darker: hsl(208, 100%, 90%);
+  --primary-accent: steelblue;
+  --primary-accent-semiopaque: #{transparentize(steelblue, 0.5)};
+}
+
+[data-theme="green"] {
+  --primary-accent: darkolivegreen;
+  --primary-accent-semiopaque: #{transparentize(darkolivegreen, 0.5)};
+}
+
+[data-theme="grey"] {
+  --background-color: gainsboro;
+  --background-darker: hsl(0, 0%, 71%);
+  --primary-accent: darkslategrey;
+  --primary-accent-semiopaque: #{transparentize(darkslategrey, 0.5)};
+}


### PR DESCRIPTION
This PR should make it easy to persist application state and other settings in browser `localStorage`, which should be adequate for our purposes.  It's a prerequisite, really, for being able to merge #90 (which will be rebased and combined with this and the work from #91 shortly), but also, now that we're live at pianolatron.stanford.edu I'd really like to put up a splash screen with a notice, and that will be real obnoxious without a way to "don't show this again" it.