### PR TITLE
Fixes and updates

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,10 +17,11 @@ module.exports = {
     },
   ],
   rules: {
-    "no-underscore-dangle": "off",
-    "no-return-assign": ["error", "except-parens"],
     "no-cond-assign": ["error", "except-parens"],
     "no-param-reassign": ["error", { props: false }],
+    "no-return-assign": ["error", "except-parens"],
+    "no-undef-init": "off",
+    "no-underscore-dangle": "off",
     // see https://github.com/sveltejs/eslint-plugin-svelte3/blob/master/OTHER_PLUGINS.md#eslint-plugin-import
     "import/first": "off",
     "import/no-mutable-exports": "off",

--- a/src/Pianolatron.svelte
+++ b/src/Pianolatron.svelte
@@ -67,7 +67,7 @@
     playExpressionsOnOff,
     rollPedalingOnOff,
   } from "./stores";
-  import { clamp } from "./lib/utils";
+  import { annotateHoleData, clamp } from "./lib/utils";
   import SamplePlayer from "./components/SamplePlayer.svelte";
   import RollSelector from "./components/RollSelector.svelte";
   import RollDetails from "./components/RollDetails.svelte";
@@ -87,6 +87,7 @@
   let metadataReady;
   let currentRoll;
   let previousRoll;
+  let holeData;
   let holesByTickInterval = new IntervalTree();
 
   let samplePlayer;
@@ -121,7 +122,7 @@
   };
 
   const buildHolesIntervalTree = () => {
-    const { FIRST_HOLE, holeData } = $rollMetadata;
+    const { FIRST_HOLE } = $rollMetadata;
 
     const firstHolePx = parseInt(FIRST_HOLE, 10);
 
@@ -197,8 +198,9 @@
     Promise.all([mididataReady, metadataReady, pianoReady]).then(
       ([, metadataJson]) => {
         $rollMetadata = { ...$rollMetadata, ...metadataJson };
-        if (metadataJson.holeData)
-          buildHolesIntervalTree(metadataJson.holeData);
+        holeData = metadataJson.holeData;
+        annotateHoleData(holeData, $rollMetadata.ROLL_TYPE);
+        buildHolesIntervalTree();
         $playExpressionsOnOff = $isReproducingRoll;
         $rollPedalingOnOff = $isReproducingRoll;
         appReady = true;
@@ -277,6 +279,7 @@
         <RollViewer
           bind:this={rollViewer}
           imageUrl={currentRoll.image_url}
+          {holeData}
           {holesByTickInterval}
           {skipToTick}
         />

--- a/src/Pianolatron.svelte
+++ b/src/Pianolatron.svelte
@@ -77,7 +77,10 @@
   import KeyboardShortcuts from "./components/KeyboardShortcuts.svelte";
   import KeyboardShortcutEditor from "./components/KeyboardShortcutEditor.svelte";
   import TabbedPanel from "./components/TabbedPanel.svelte";
-  import Notification, { notify } from "./ui-components/Notification.svelte";
+  import Notification, {
+    notify,
+    clearNotification,
+  } from "./ui-components/Notification.svelte";
   import FlexCollapsible from "./ui-components/FlexCollapsible.svelte";
 
   import catalog from "./config/catalog.json";
@@ -160,6 +163,7 @@
 
   const resetApp = () => {
     mididataReady = false;
+    clearNotification();
     appReady = false;
     pausePlayback();
     resetPlayback();

--- a/src/Pianolatron.svelte
+++ b/src/Pianolatron.svelte
@@ -227,7 +227,7 @@
         notify({
           title: "DRUID not found!",
           message:
-            "Please check the specified DRUID, or <a href='/'>click here to continue</a>.",
+            "Please check the specified DRUID, or select a roll to continue.",
           type: "error",
           closable: false,
         });

--- a/src/Pianolatron.svelte
+++ b/src/Pianolatron.svelte
@@ -87,6 +87,7 @@
   let metadataReady;
   let currentRoll;
   let previousRoll;
+  let metadata;
   let holeData;
   let holesByTickInterval = new IntervalTree();
 
@@ -197,7 +198,7 @@
 
     Promise.all([mididataReady, metadataReady, pianoReady]).then(
       ([, metadataJson]) => {
-        $rollMetadata = { ...$rollMetadata, ...metadataJson };
+        metadata = (({ holeData: _, ...obj }) => obj)(metadataJson);
         holeData = metadataJson.holeData;
         annotateHoleData(holeData, $rollMetadata.ROLL_TYPE);
         buildHolesIntervalTree();
@@ -265,7 +266,7 @@
     <FlexCollapsible id="left-sidebar" width="20vw">
       <RollSelector bind:currentRoll {rollListItems} />
       {#if appReady}
-        <RollDetails />
+        <RollDetails {metadata} />
         {#if !holesByTickInterval.count}
           <p>
             Note:<br />Hole visualization data is not available for this roll at

--- a/src/components/RollDetails.svelte
+++ b/src/components/RollDetails.svelte
@@ -22,7 +22,7 @@
 </style>
 
 <script>
-  import { rollMetadata } from "../stores";
+  export let metadata;
 
   const unavailable = "<span>Unavailable</span>";
 </script>
@@ -30,26 +30,26 @@
 <dl>
   <dt>Title</dt>
   <dd>
-    {@html $rollMetadata.TITLE || $rollMetadata.title || unavailable}
+    {@html metadata.title || unavailable}
   </dd>
   <dt>Performer</dt>
   <dd>
-    {@html $rollMetadata.PERFORMER || $rollMetadata.performer || unavailable}
+    {@html metadata.performer || unavailable}
   </dd>
   <dt>Composer</dt>
   <dd>
-    {@html $rollMetadata.COMPOSER || $rollMetadata.composer || unavailable}
+    {@html metadata.composer || unavailable}
   </dd>
   <dt>Label</dt>
   <dd>
-    {@html $rollMetadata.LABEL || $rollMetadata.label || unavailable}
+    {@html metadata.label || unavailable}
   </dd>
   <dt>PURL</dt>
   <dd>
-    <a href={$rollMetadata.PURL}>{@html $rollMetadata.PURL || unavailable}</a>
+    <a href={metadata.PURL}>{@html metadata.PURL || unavailable}</a>
   </dd>
   <dt>Call No</dt>
   <dd>
-    {@html $rollMetadata.CALLNUM || unavailable}
+    {@html metadata.CALLNUM || unavailable}
   </dd>
 </dl>

--- a/src/components/RollSelector.svelte
+++ b/src/components/RollSelector.svelte
@@ -1,5 +1,5 @@
 <style lang="scss">
-  :global(.filtered-select small) {
+  :global(small) {
     color: grey;
     display: inline-block;
     text-align: right;
@@ -8,6 +8,10 @@
     &:first-child {
       width: 5ch;
     }
+  }
+
+  :global(.place-holder) {
+    color: grey;
   }
 </style>
 
@@ -24,6 +28,7 @@
   labelFieldName="_label"
   searchFieldName="_label"
   facetFieldName="type"
+  placeHolder="<span class='place-holder'>Select a roll...</span>"
   postMarkup={(str) =>
     str.replace(/^(?:[\d.]|<\/?mark>)+|\[[^\]]+\]$/g, "<small>$&</small>")}
 />

--- a/src/components/RollSelector.svelte
+++ b/src/components/RollSelector.svelte
@@ -15,7 +15,7 @@
   import FilteredSelect from "../ui-components/FilteredSelect.svelte";
 
   export let rollListItems;
-  export let currentRoll = null;
+  export let currentRoll;
 </script>
 
 <FilteredSelect

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -95,43 +95,13 @@
     rollPedalingOnOff,
     playbackProgress,
   } from "../stores";
-  import {
-    clamp,
-    mapToRange,
-    normalizeInRange,
-    getHoleLabel,
-    getHoleType,
-  } from "../lib/utils";
+  import { clamp, getHoleLabel } from "../lib/utils";
   import RollViewerControls from "./RollViewerControls.svelte";
 
   export let imageUrl;
+  export let holeData;
   export let holesByTickInterval;
   export let skipToTick;
-
-  // This is the "coolwarm" color map -- blue to red
-  // RdYlBu (reversed) sort of works, but the yellows are too ambiguous
-  // (values in H, S, L)
-  const holeColorMap = [
-    "232, 53%, 49%",
-    "229, 64%, 58%",
-    "225, 78%, 66%",
-    "223, 91%, 73%",
-    "221, 98%, 79%",
-    "219, 95%, 83%",
-    "217, 73%, 86%",
-    "21, 28%, 86%",
-    "20, 69%, 83%",
-    "18, 85%, 79%",
-    "16, 85%, 73%",
-    "13, 80%, 67%",
-    "9, 70%, 59%",
-    "2, 59%, 51%",
-    "348, 96%, 36%",
-  ];
-
-  const defaultHoleColor = "60, 100%, 50%"; // yellow (default)
-  const controlHoleColor = "120, 73%, 75%"; // light green
-  const pedalHoleColor = "39, 100%, 50%"; // orange;
 
   const defaultZoomLevel = 1;
   const minZoomLevel = 0.1;
@@ -150,45 +120,6 @@
   let trackerbarHeight;
   let animationEaseInterval;
   let osdNavDisplayRegion;
-
-  const annotateHoleData = (holeData) => {
-    const velocities = holeData.map(({ v }) => v).filter((v) => v);
-    const minNoteVelocity = velocities.length ? Math.min(...velocities) : 64;
-    const maxNoteVelocity = velocities.length ? Math.max(...velocities) : 64;
-
-    const getNoteHoleColor = ({ v: velocity }) =>
-      holeColorMap[
-        Math.round(
-          mapToRange(
-            normalizeInRange(velocity, minNoteVelocity, maxNoteVelocity),
-            0,
-            holeColorMap.length - 1,
-          ),
-        )
-      ];
-
-    holeData.forEach((hole) => {
-      switch (getHoleType(hole, $rollMetadata.ROLL_TYPE)) {
-        case "pedal":
-          hole.color = pedalHoleColor;
-          hole.type = "pedal";
-          break;
-
-        case "control":
-          hole.color = controlHoleColor;
-          hole.type = "control";
-          break;
-
-        case "note":
-          hole.color = getNoteHoleColor(hole);
-          hole.type = "note";
-          break;
-
-        default:
-          hole.color = defaultHoleColor;
-      }
-    });
-  };
 
   const createMark = (hole) => {
     const {
@@ -232,7 +163,6 @@
   };
 
   const createHolesOverlaySvg = () => {
-    const { holeData } = $rollMetadata;
     if (!holeData) return;
 
     const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
@@ -388,7 +318,7 @@
     );
   };
 
-  onMount(async () => {
+  onMount(() => {
     openSeadragon = OpenSeadragon({
       id: "roll-viewer",
       showNavigationControl: false,
@@ -552,7 +482,6 @@
 
   $: updateViewportFromTick($currentTick);
   $: highlightHoles($currentTick);
-  $: annotateHoleData($rollMetadata.holeData);
   $: imageLength = parseInt($rollMetadata.IMAGE_LENGTH, 10);
   $: imageWidth = parseInt($rollMetadata.IMAGE_WIDTH, 10);
   $: avgHoleWidth = parseInt($rollMetadata.AVG_HOLE_WIDTH, 10);

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -576,8 +576,9 @@
     }
 
     viewport.zoomTo(
-      Math.min(
+      clamp(
         viewport.getZoom() * (event.deltaY > 0 ? 0.9 : 1.1),
+        minZoomLevel,
         maxZoomLevel,
       ),
     );

--- a/src/lib/tonejs-piano.js
+++ b/src/lib/tonejs-piano.js
@@ -59,8 +59,36 @@ const velocitiesMap = {
  * All the notes of audio samples
  */
 const allNotes = [
-  21, 24, 27, 30, 33, 36, 39, 42, 45, 48, 51, 54, 57, 60, 63, 66, 69, 72, 75,
-  78, 81, 84, 87, 90, 93, 96, 99, 102, 105, 108,
+  21,
+  24,
+  27,
+  30,
+  33,
+  36,
+  39,
+  42,
+  45,
+  48,
+  51,
+  54,
+  57,
+  60,
+  63,
+  66,
+  69,
+  72,
+  75,
+  78,
+  81,
+  84,
+  87,
+  90,
+  93,
+  96,
+  99,
+  102,
+  105,
+  108,
 ];
 
 function getNotesInRange(min, max) {
@@ -71,8 +99,29 @@ function getNotesInRange(min, max) {
  * All the notes of audio samples
  */
 const harmonics = [
-  21, 24, 27, 30, 33, 36, 39, 42, 45, 48, 51, 54, 57, 60, 63, 66, 69, 72, 75,
-  78, 81, 84, 87,
+  21,
+  24,
+  27,
+  30,
+  33,
+  36,
+  39,
+  42,
+  45,
+  48,
+  51,
+  54,
+  57,
+  60,
+  63,
+  66,
+  69,
+  72,
+  75,
+  78,
+  81,
+  84,
+  87,
 ];
 function getHarmonicsInRange(min, max) {
   return harmonics.filter((note) => min <= note && note <= max);

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -93,3 +93,67 @@ export const easingInterval = (
     },
   };
 };
+
+// This is the "coolwarm" color map -- blue to red
+// RdYlBu (reversed) sort of works, but the yellows are too ambiguous
+// (values in H, S, L)
+const holeColorMap = [
+  "232, 53%, 49%",
+  "229, 64%, 58%",
+  "225, 78%, 66%",
+  "223, 91%, 73%",
+  "221, 98%, 79%",
+  "219, 95%, 83%",
+  "217, 73%, 86%",
+  "21, 28%, 86%",
+  "20, 69%, 83%",
+  "18, 85%, 79%",
+  "16, 85%, 73%",
+  "13, 80%, 67%",
+  "9, 70%, 59%",
+  "2, 59%, 51%",
+  "348, 96%, 36%",
+];
+
+const defaultHoleColor = "60, 100%, 50%"; // yellow (default)
+const controlHoleColor = "120, 73%, 75%"; // light green
+const pedalHoleColor = "39, 100%, 50%"; // orange;
+
+export const annotateHoleData = (holeData, rollType) => {
+  const velocities = holeData.map(({ v }) => v).filter((v) => v);
+  const minNoteVelocity = velocities.length ? Math.min(...velocities) : 64;
+  const maxNoteVelocity = velocities.length ? Math.max(...velocities) : 64;
+
+  const getNoteHoleColor = ({ v: velocity }) =>
+    holeColorMap[
+      Math.round(
+        mapToRange(
+          normalizeInRange(velocity, minNoteVelocity, maxNoteVelocity),
+          0,
+          holeColorMap.length - 1,
+        ),
+      )
+    ];
+
+  holeData.forEach((hole) => {
+    switch (getHoleType(hole, rollType)) {
+      case "pedal":
+        hole.color = pedalHoleColor;
+        hole.type = "pedal";
+        break;
+
+      case "control":
+        hole.color = controlHoleColor;
+        hole.type = "control";
+        break;
+
+      case "note":
+        hole.color = getNoteHoleColor(hole);
+        hole.type = "note";
+        break;
+
+      default:
+        hole.color = defaultHoleColor;
+    }
+  });
+};

--- a/src/styles/loader.scss
+++ b/src/styles/loader.scss
@@ -10,6 +10,7 @@
   color: var(--primary-accent);
   font-size: 1.4em;
   text-shadow: 1px 2px white;
+  pointer-events: none;
 
   div {
     width: 100px;

--- a/src/ui-components/FilteredSelect.svelte
+++ b/src/ui-components/FilteredSelect.svelte
@@ -126,6 +126,8 @@
   export let searchFieldName = labelFieldName;
   export let facetFieldName;
 
+  export let placeHolder = "Select an item...";
+
   export let postMarkup = (str) => str;
 
   let listItems = [];
@@ -287,10 +289,15 @@
   };
 
   const onSelectedItemChanged = () => {
-    if (input)
-      input.innerHTML = postMarkup(
-        labelFieldName ? selectedItem[labelFieldName] : selectedItem,
-      );
+    if (input) {
+      if (selectedItem) {
+        input.innerHTML = postMarkup(
+          labelFieldName ? selectedItem[labelFieldName] : selectedItem,
+        );
+      } else {
+        input.innerHTML = placeHolder;
+      }
+    }
   };
 
   const activateDropdown = async () => {
@@ -369,8 +376,8 @@
 
         default:
       }
-    }}
-  />
+    }}>{@html placeHolder}</span
+  >
   <div class="dropdown" class:open bind:this={dropdown}>
     <div class="facets">
       {#if facets}

--- a/src/ui-components/FilteredSelect.svelte
+++ b/src/ui-components/FilteredSelect.svelte
@@ -120,7 +120,7 @@
   import { clamp } from "../lib/utils";
 
   export let items = [];
-  export let selectedItem;
+  export let selectedItem = undefined;
 
   export let labelFieldName;
   export let searchFieldName = labelFieldName;

--- a/src/ui-components/FilteredSelect.svelte
+++ b/src/ui-components/FilteredSelect.svelte
@@ -224,8 +224,10 @@
     const activeListItem = list.querySelector(".selected");
 
     if (activeListItem) {
-      const { top: listItemTop, bottom: listItemBottom } =
-        activeListItem.getBoundingClientRect();
+      const {
+        top: listItemTop,
+        bottom: listItemBottom,
+      } = activeListItem.getBoundingClientRect();
       const { top: listTop, bottom: listBottom } = list.getBoundingClientRect();
 
       if (listItemBottom > listBottom) activeListItem.scrollIntoView(false);

--- a/src/ui-components/Notification.svelte
+++ b/src/ui-components/Notification.svelte
@@ -63,6 +63,7 @@
 
   const NotificationStore = writable();
   export const notify = (detail) => NotificationStore.set(detail);
+  export const clearNotification = NotificationStore.set;
 </script>
 
 {#if $NotificationStore}
@@ -74,7 +75,7 @@
       <p>{@html $NotificationStore.message}</p>
     </section>
     {#if $NotificationStore.closable !== false}
-      <div class="close" on:click={() => NotificationStore.set()}>&times;</div>
+      <div class="close" on:click={clearNotification}>&times;</div>
     {/if}
   </div>
 {/if}


### PR DESCRIPTION
This PR includes:

1. a fix for mousewheel zooming (this one has been on a couple of branches but hasn't gone in yet -- it should go in here)
2. a fix for the race condition whereby `annotateHoleData()` could be called before the hole data was available (which is blocking deployment of #101 and #100, I think)
3. a fix for the notification not showing when an invalid DRUID is supplied via http get params, which was introduced in #93 

Along with (3), the notification itself has been tweaked and access to the roll selector widget has been made available, so that rather than just having to reload the page without the defective DRUID param, a user can just pick a roll directly from that page load.

(2) was originally intended to be merged along with a more thorough overhaul of the way the hole data is passed around the application in concert with the expressionizer implementation.  The commits here are just the first step of that, but if they go in now we can deploy the other code that's waiting on this part.