### PR TITLE
Split SVG holes overlay into partitions, only display sections that overlap with viewer extent

### DIFF
--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -125,6 +125,7 @@
   let ppi;
   let svgPartitions;
   let visibleSvgs = [];
+  let entireViewportRectangle;
 
   const createMark = (hole) => {
     const {
@@ -220,6 +221,13 @@
   const partitionHolesOverlaySvgs = () => {
     if (!holeData) return;
 
+    entireViewportRectangle = viewport.imageToViewportRectangle(
+      0,
+      0,
+      imageWidth,
+      imageLength,
+    );
+
     svgPartitions = new IntervalTree();
 
     // Calculate the maximum image length visible at maximum zoom (out)
@@ -276,12 +284,6 @@
     svgs.forEach((svg) => {
       if (visibleSvgs.includes(svg)) return;
       visibleSvgs.push(svg);
-      const entireViewportRectangle = viewport.imageToViewportRectangle(
-        0,
-        0,
-        imageWidth,
-        imageLength,
-      );
       viewport.viewer.addOverlay(svg, entireViewportRectangle);
     });
   };

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -253,11 +253,11 @@
       const holes = holesByTickInterval
         .search(firstTick, lastTick)
         // eslint-disable-next-line no-loop-func
-        .filter(({ y: offsetY, h: height }) => {
-          const yCoord = $scrollDownwards
-            ? offsetY
-            : imageLength - offsetY - height;
-          return yCoord >= firstPixelRow && yCoord < lastPixelRow;
+        .filter(({ y: offsetY }) => {
+          const yCoord = $scrollDownwards ? offsetY : imageLength - offsetY;
+          return $scrollDownwards
+            ? yCoord >= firstPixelRow && yCoord < lastPixelRow
+            : yCoord > firstPixelRow && yCoord <= lastPixelRow;
         });
       if (holes) {
         const svg = createHolesOverlaySvg(holes);

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -259,9 +259,23 @@
             ? yCoord >= firstPixelRow && yCoord < lastPixelRow
             : yCoord > firstPixelRow && yCoord <= lastPixelRow;
         });
-      if (holes) {
+
+      if (holes.length) {
+        const ext = $scrollDownwards
+          ? clamp(Math.max(...holes.map(({ y, h }) => y + h)), 0, imageLength)
+          : clamp(
+              // eslint-disable-next-line no-loop-func
+              Math.min(...holes.map(({ y, h }) => imageLength - y - h)),
+              0,
+              imageLength,
+            );
+
         const svg = createHolesOverlaySvg(holes);
-        svgPartitions.insert(firstPixelRow, lastPixelRow, svg);
+        if ($scrollDownwards) {
+          svgPartitions.insert(firstPixelRow, Math.max(lastPixelRow, ext), svg);
+        } else {
+          svgPartitions.insert(Math.min(firstPixelRow, ext), lastPixelRow, svg);
+        }
       }
     }
   };

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -219,7 +219,7 @@
     return svg;
   };
 
-  const createHolesOverlaySvgs = () => {
+  const partitionHolesOverlaySvgs = () => {
     if (!holeData) return;
 
     svgPartitions = new IntervalTree();
@@ -474,7 +474,7 @@
     // create the holes overlay SVG and "rewind" to the beginning of the
     //  performance when the viewport updates for the first time
     openSeadragon.addOnceHandler("update-viewport", () => {
-      createHolesOverlaySvgs();
+      partitionHolesOverlaySvgs();
       updateViewportFromTick(0);
     });
 

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -250,7 +250,15 @@
         : Math.max(firstHolePx - firstPixelRow - partitionLength, 0);
       const lastTick = firstTick + partitionLength;
 
-      const holes = holesByTickInterval.search(firstTick, lastTick);
+      const holes = holesByTickInterval
+        .search(firstTick, lastTick)
+        // eslint-disable-next-line no-loop-func
+        .filter(({ y: offsetY, h: height }) => {
+          const yCoord = $scrollDownwards
+            ? offsetY
+            : imageLength - offsetY - height;
+          return yCoord >= firstPixelRow && yCoord < lastPixelRow;
+        });
       if (holes) {
         const svg = createHolesOverlaySvg(holes);
         svgPartitions.insert(firstPixelRow, lastPixelRow, svg);

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -243,9 +243,7 @@
         firstPixelRow + partitionLength,
         imageLength,
       );
-
       const svg = createHolesOverlaySvg(firstPixelRow, lastPixelRow);
-
       svgPartitions.insert(firstPixelRow, lastPixelRow, svg);
     }
   };
@@ -257,7 +255,6 @@
       viewport.viewportToImageRectangle(viewport.getBounds());
 
     const lastImagePixel = firstImagePixel + viewportImageLength;
-
     const svgs = svgPartitions.search(firstImagePixel, lastImagePixel);
 
     // Remove any currently displayed SVG overlays that don't overlap with the

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -171,6 +171,8 @@
     const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     const g = document.createElementNS("http://www.w3.org/2000/svg", "g");
 
+    const padding = 10;
+
     svg.setAttribute("width", imageWidth);
     svg.setAttribute("height", imageLength);
     svg.setAttribute("viewBox", `0 0 ${imageWidth} ${imageLength}`);
@@ -185,7 +187,6 @@
         color: holeColor,
         type: holeType,
       } = hole;
-      const padding = 10;
 
       const yCoord = $scrollDownwards
         ? offsetY - padding
@@ -259,18 +260,15 @@
 
     // Remove any currently displayed SVG overlays that don't overlap with the
     // viewer window
-    visibleSvgs.forEach((visibleSvg) => {
-      if (!svgs.includes(visibleSvg)) {
-        visibleSvgs.splice(visibleSvgs.indexOf(visibleSvg), 1);
-        viewport.viewer.removeOverlay(visibleSvg);
-      }
+    visibleSvgs = visibleSvgs.filter((visibleSvg) => {
+      if (svgs.includes(visibleSvg)) return true;
+      viewport.viewer.removeOverlay(visibleSvg);
+      return false;
     });
 
     // Add SVG overlays that newly overlap with the viewer window
     svgs.forEach((svg) => {
-      if (visibleSvgs.includes(svg)) {
-        return;
-      }
+      if (visibleSvgs.includes(svg)) return;
       visibleSvgs.push(svg);
       const entireViewportRectangle = viewport.imageToViewportRectangle(
         0,

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -230,15 +230,10 @@
 
     svgPartitions = new IntervalTree();
 
-    // Calculate the maximum image length visible at maximum zoom (out)
-    const maxViewportImageLength =
-      viewport.viewportToImageRectangle(viewport.getBounds()).height *
-      (maxZoomLevel / viewport.getZoom());
-
-    // Regularize the length of the SVG partitions
-    const partitionLength = Math.ceil(
-      imageLength / Math.ceil(imageLength / maxViewportImageLength),
-    );
+    // This should be small enough that few <rect/>s that are not in the viewer
+    // are drawn and scrolled, but not so small that the interval lookup
+    // becomes onerous
+    const partitionLength = 1000;
 
     for (
       let firstPixelRow = $scrollDownwards ? firstHolePx : lastHolePx;


### PR DESCRIPTION
This change has been confirmed to alleviate the playback slowdowns experienced on relatively recent Mac OS machines running Chromium browsers when playing rolls with complicated overlays (i.e., lots of holes). Firefox on Mac OS does not exhibit this difficulty in shifting large SVGs (at least on the machines available for testing), so it's not affected.

It should be noted that unfortunately, performance issues persist on other platforms, regardless of whether or not the roll has a large SVG overlay: Mac OS Safari, browsers of any type on middling Windows systems, and non-premium Android and iOS devices.

Also, I couldn't figure out whether it's practicable to limit the footprint of each SVG partition, via `viewBox` settings or something else, so that it doesn't span the entire image extent, but given that the holes rectangles are only present on its particular bit of the roll, and the rest is just blank space, I assume that this shouldn't really affect the shift/redraw performance.