### PR TITLE
Fix weird Safari RollSelector searchbar bug

### DIFF
--- a/src/ui-components/FilteredSelect.svelte
+++ b/src/ui-components/FilteredSelect.svelte
@@ -252,7 +252,7 @@
     if (!input.innerHTML) return;
 
     const filteredText = normalizeText(
-      input.innerHTML.replace(/[&/\\#,+()$~%.'":*?<>{}]|nbsp;/g, " "),
+      input.innerHTML.replace(/<br>|[&/\\#,+()$~%.'":*?<>{}]|nbsp;/g, " "),
     );
 
     if (filteredText) {


### PR DESCRIPTION
When using Safari on Mac OS or iOS, there's an odd bug whereby entering text in the roll selector searchbar and then deleting all of it somehow prompts Safari to leave an invisible `<br>` tag in the input field, which then results in all of the roll names with "br" in them being highlighted until the selector is closed and reopened.

This is one possible fix; there may be better ones.

![Screen Shot 2021-09-16 at 11 02 25 PM](https://user-images.githubusercontent.com/7329112/133732407-b8466025-c248-4c25-89eb-4e51fd75c524.png)
