### PR TITLE
Avoid inconsistent sustain state caused by considering a pedal to be up at the moment it goes down 

### DIFF
--- a/src/lib/tonejs-piano.js
+++ b/src/lib/tonejs-piano.js
@@ -350,7 +350,7 @@ class Pedal extends PianoComponent {
    * Indicates if the pedal is down at the given time
    */
   isDown(time) {
-    return time > this._downTime;
+    return time >= this._downTime;
   }
 }
 


### PR DESCRIPTION
This seems to be the simplest possible fix for the bug whereby pausing a roll with the sustain pedal down, then rewinding the roll, results in the pedal appearing up in the UI, but the ToneJS piano still considers it to be down. Any notes subsequently played, including by restarting the roll playback, will be erroneously sustained until the first "pedal up" event in the playback, or until the user manually toggles the sustain pedal.

The use of `>` rather than `>=` seems to be a legitimate if subtle bug in the ToneJS piano. At least, there seems to be no benefit to only considering a pedal to be down if a time quantum has passed since it was registered as down; it can cause bugs like the one described above, whereas using `>=` appears to have no negative effects.