### PR TITLE
Correct subtle shortcomings of piano playback capabilities

### DIFF
--- a/src/components/SamplePlayer.svelte
+++ b/src/components/SamplePlayer.svelte
@@ -39,7 +39,7 @@
     velocities: 4,
     release: true,
     pedal: true,
-    maxPolyphony: 64,
+    maxPolyphony: Infinity,
     volume: {
       strings: -15,
       harmonics: -10,

--- a/src/lib/tonejs-piano.js
+++ b/src/lib/tonejs-piano.js
@@ -350,7 +350,7 @@ class Pedal extends PianoComponent {
    * Indicates if the pedal is down at the given time
    */
   isDown(time) {
-    return time > this._downTime;
+    return time >= this._downTime;
   }
 }
 


### PR DESCRIPTION
The first commit seems to be the simplest possible fix for the bug whereby pausing a roll with the sustain pedal down, then rewinding the roll, results in the pedal appearing up in the UI, but the ToneJS piano still considers it to be down. Any notes subsequently played, including by restarting the roll playback, will be erroneously sustained until the first "pedal up" event in the playback, or until the user manually toggles the sustain pedal.

The use of `>` rather than `>=` seems to be a legitimate if subtle bug in the ToneJS piano. At least, there seems to be no benefit to only considering a pedal to be down if a time quantum has passed since it was registered as down; it can cause bugs like the one described above, whereas using `>=` appears to have no negative effects.

The second commit avoids the possibility of the piano "running out of notes" if the sustain pedal is held down for so long that the `maxPolyphony` value, if it's set to a discrete integer, causes newly played keys to be ignored (see https://pianolatron.stanford.edu/?druid=yx536mq2915 at about 95%). The implementation does not actually preallocate `maxPolyphony` buffers or anything like that, and the dangers of allowing an arbitrary number of notes to be played simultaneously (resulting in an arbitrary number of ToneJS sample buffers being in memory) seem low  -- the worst that can happen is that the browser crashes, and unless we're willing to entertain the possibility of a malicious roll perpetrating a "note overflow attack", I think it's worth the risk.