### PR TITLE
Add configurable delta values for keyboard controls

### DIFF
--- a/src/Pianolatron.svelte
+++ b/src/Pianolatron.svelte
@@ -110,6 +110,7 @@
 
   let rollViewer;
   let updateTickByViewportIncrement;
+  let panHorizontal;
 
   const rollListItems = catalog.map((item) => {
     const [number, label] = item.label.split(" ");
@@ -267,7 +268,8 @@
   $: playbackProgress.update(() =>
     clamp($currentTick / midiSamplePlayer?.totalTicks, 0, 1),
   );
-  $: if (rollViewer) ({ updateTickByViewportIncrement } = rollViewer);
+  $: if (rollViewer)
+    ({ updateTickByViewportIncrement, panHorizontal } = rollViewer);
 </script>
 
 <div id="app">
@@ -320,7 +322,12 @@
     loadingSamples.then(() => (appWaiting = false)).catch(() => {});
   }}
 />
-<KeyboardShortcuts {playPauseApp} {stopApp} {updateTickByViewportIncrement} />
+<KeyboardShortcuts
+  {playPauseApp}
+  {stopApp}
+  {updateTickByViewportIncrement}
+  {panHorizontal}
+/>
 <KeyboardShortcutEditor />
 <Notification />
 {#if $showWelcomeScreen}<Welcome />{/if}

--- a/src/components/BasicSettings.svelte
+++ b/src/components/BasicSettings.svelte
@@ -7,7 +7,7 @@
     tempoCoefficient,
     playbackProgress,
   } from "../stores";
-  import { controlsConfig } from "../config/controls-config";
+  import { defaultControlsConfig as controlsConfig } from "../config/controls-config";
   import SliderControl from "../ui-components/SliderControl.svelte";
 
   export let skipToPercentage;

--- a/src/components/KeyboardShortcutDeltaEditorRow.svelte
+++ b/src/components/KeyboardShortcutDeltaEditorRow.svelte
@@ -1,8 +1,5 @@
 <style lang="scss">
   dd {
-    align-items: center;
-    display: flex;
-
     span {
       width: 4ch;
       text-align: right;

--- a/src/components/KeyboardShortcutDeltaEditorRow.svelte
+++ b/src/components/KeyboardShortcutDeltaEditorRow.svelte
@@ -1,0 +1,77 @@
+<style lang="scss">
+  dd {
+    align-items: center;
+    display: flex;
+
+    span {
+      width: 4ch;
+      text-align: right;
+    }
+
+    :global(input[type="range"]) {
+      height: 100%;
+      margin: 0 1em;
+      width: 7em;
+    }
+  }
+
+  button {
+    background: none;
+    border: none;
+    cursor: pointer;
+    margin: 0;
+    padding: 0;
+
+    :global(svg) {
+      stroke: grey;
+    }
+
+    &:not([disabled]):hover :global(svg) {
+      stroke: black;
+    }
+
+    &[disabled] {
+      cursor: default;
+      opacity: 0.5;
+    }
+  }
+</style>
+
+<script>
+  import { createEventDispatcher } from "svelte";
+  import Icon from "../ui-components/Icon.svelte";
+  import RangeSlider from "../ui-components/RangeSlider.svelte";
+  import { tooltip } from "../lib/tooltip-action";
+
+  export let shortcut;
+  export let meta;
+  export let controlConfigValue;
+  export let isChanged;
+
+  const dispatch = createEventDispatcher();
+  const updateDelta = () => dispatch("update", controlConfigValue);
+  const resetShortcut = () => dispatch("reset");
+</script>
+
+<dt use:tooltip={meta.help}>{meta.description}</dt>
+<dd>
+  ±<span>{controlConfigValue}</span>
+  <RangeSlider
+    bind:value={controlConfigValue}
+    min="0"
+    max="1"
+    step="0.01"
+    name={shortcut}
+    on:input={updateDelta}
+  />
+
+  {#key isChanged}
+    <button
+      use:tooltip={isChanged ? "Reset to Default" : undefined}
+      disabled={!isChanged}
+      on:click={resetShortcut}
+    >
+      <Icon name="reset" height="20" width="20" />
+    </button>
+  {/key}
+</dd>

--- a/src/components/KeyboardShortcutEditor.svelte
+++ b/src/components/KeyboardShortcutEditor.svelte
@@ -54,29 +54,38 @@
   }
 
   p.error-message {
-    border-radius: 5px;
-    border: 1px solid red;
     color: red;
     padding: 0.25em;
+    margin: 0.5em 0 0;
+  }
+
+  .panels {
+    display: flex;
+    overflow-x: hidden;
+    overflow-y: auto;
+    padding-top: 4px;
+    position: relative;
   }
 
   dl {
     display: grid;
+    flex: none;
     gap: 0 0.25em;
     grid-auto-rows: min-content;
     grid-template-columns: auto auto;
-    height: 400px;
     justify-content: space-between;
-    overflow-x: hidden;
-    overflow-y: auto;
-    padding-top: 4px;
+    width: 100%;
+
+    &:not(:first-child) {
+      margin-left: -100%;
+    }
   }
 
   p.reset {
     display: flex;
     align-items: center;
     justify-content: flex-end;
-    margin: 1em 0;
+    margin: 0.5em 0 0;
   }
 
   button {
@@ -94,6 +103,19 @@
       stroke: black;
     }
   }
+
+  dl,
+  p.reset,
+  p.error-message {
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.4s ease;
+
+    &.shown {
+      opacity: 1;
+      pointer-events: all;
+    }
+  }
 </style>
 
 <script context="module">
@@ -105,7 +127,7 @@
 </script>
 
 <script>
-  import { fade, slide } from "svelte/transition";
+  import { fade } from "svelte/transition";
   import PanelSwitcher from "./PanelSwitcher.svelte";
   import KeyboardShortcutEditorRow from "./KeyboardShortcutEditorRow.svelte";
   import Icon from "../ui-components/Icon.svelte";
@@ -199,27 +221,35 @@
       </button>
     </header>
     <p>Click the edit button to reassign a control button.</p>
-    {#if errorMessage}
-      <p class="error-message" transition:slide>{errorMessage}</p>
-    {/if}
     <PanelSwitcher bind:selectedPanel {panels} class="panel-switcher" />
-    <dl>
-      {#each panels[selectedPanel].shortcuts as shortcut}
-        <KeyboardShortcutEditorRow
-          shortcut={$keyMap[shortcut]}
-          meta={keyMapMeta[shortcut]}
-          on:update={({ detail }) => updateKeyBinding(shortcut, detail)}
-          on:reset={() => updateKeyBinding(shortcut, defaultKeyMap[shortcut])}
-        />
+    <div class="panels">
+      {#each Object.keys(panels) as panel}
+        <dl class:shown={selectedPanel === panel}>
+          {#each panels[panel].shortcuts as shortcut}
+            <KeyboardShortcutEditorRow
+              shortcut={$keyMap[shortcut]}
+              meta={keyMapMeta[shortcut]}
+              on:update={({ detail }) => updateKeyBinding(shortcut, detail)}
+              on:reset={() =>
+                updateKeyBinding(shortcut, defaultKeyMap[shortcut])}
+            />
+          {/each}
+        </dl>
       {/each}
-    </dl>
-    {#if Object.values($keyMap).some((shortcut) => shortcut.isChanged)}
-      <p class="reset" transition:slide>
-        Reset to defaults: <button on:click={resetShortcuts}>
-          <Icon name="reset" height="24" width="24" />
-        </button>
-      </p>
-    {/if}
+    </div>
+    <p class="error-message" class:shown={errorMessage}>
+      {errorMessage}
+    </p>
+    <p
+      class="reset"
+      class:shown={Object.values($keyMap).some(
+        (shortcut) => shortcut.isChanged,
+      )}
+    >
+      Reset to defaults: <button on:click={resetShortcuts}>
+        <Icon name="reset" height="24" width="24" />
+      </button>
+    </p>
   </div>
 {/if}
 <svelte:window

--- a/src/components/KeyboardShortcutEditor.svelte
+++ b/src/components/KeyboardShortcutEditor.svelte
@@ -74,6 +74,7 @@
     grid-auto-rows: min-content;
     grid-template-columns: auto auto;
     justify-content: space-between;
+    padding: 0 4px;
     width: 100%;
 
     &:not(:first-child) {
@@ -92,6 +93,12 @@
     border-width: 0 0 1px 0;
     grid-column: 1 / 3;
     width: 80%;
+  }
+
+  :global(hr.section) {
+    border-color: rgba(0, 0, 0, 0.4);
+    margin: 2em 0 4px -4px;
+    width: calc(100% + 8px);
   }
 
   p.error-message {
@@ -168,6 +175,7 @@
         "SOFT",
         "SUSTAIN",
         "ACCENT",
+        "---",
         "PLAY_PAUSE",
         "REWIND",
         "FORWARD",
@@ -188,8 +196,7 @@
         "TREBLE_VOLUME_AUGMENTED_DELTA",
         "---",
         "RIGHT_HAND_AUGMENT",
-        "---",
-        "---",
+        "===",
         "BASS_VOLUME_UP",
         "BASS_VOLUME_DOWN",
         "BASS_VOLUME_DELTA",
@@ -322,6 +329,8 @@
               />
             {:else if shortcut === "---"}
               <hr />
+            {:else if shortcut === "==="}
+              <hr class="section" />
             {/if}
           {/each}
         </dl>

--- a/src/components/KeyboardShortcutEditor.svelte
+++ b/src/components/KeyboardShortcutEditor.svelte
@@ -1,20 +1,43 @@
 <style lang="scss">
-  div {
+  .shortcut-editor {
     background-color: var(--background-color);
     border-radius: 4px;
     box-shadow: 0 3px 6px rgb(0, 0, 0, 0.3);
+    display: flex;
+    flex-direction: column;
     left: 50%;
     max-height: 80%;
-    max-width: 100%;
-    min-width: 400px;
+    max-width: 100vw;
+    min-width: min(400px, 100vw);
     padding: 1em;
     position: absolute;
     top: 42%;
     transform: translate(-50%, -50%);
     width: 400px;
     z-index: z($main-context, notifications);
-    display: flex;
-    flex-direction: column;
+
+    :global(.panel-switcher) {
+      border-bottom: 1px solid rgba(0, 0, 0, 0.4);
+    }
+
+    :global(.panel-switcher label) {
+      background-color: var(--primary-accent);
+      border-bottom: 0;
+      border-radius: 0.25em 0.25em 0 0;
+      border-width: 1px;
+      color: white;
+      opacity: 0.8;
+      padding-bottom: 4px;
+    }
+
+    :global(.panel-switcher label:last-child) {
+      margin-right: 4px;
+    }
+    :global(.panel-switcher input:checked + label) {
+      background-color: var(--background-color);
+      color: black;
+      transform: translateY(2px);
+    }
   }
 
   header {
@@ -39,11 +62,14 @@
 
   dl {
     display: grid;
-    grid-template-columns: auto auto;
-    justify-content: space-between;
     gap: 0 0.25em;
-    overflow-y: auto;
+    grid-auto-rows: min-content;
+    grid-template-columns: auto auto;
+    height: 400px;
+    justify-content: space-between;
     overflow-x: hidden;
+    overflow-y: auto;
+    padding-top: 4px;
   }
 
   p.reset {
@@ -80,6 +106,7 @@
 
 <script>
   import { fade, slide } from "svelte/transition";
+  import PanelSwitcher from "./PanelSwitcher.svelte";
   import KeyboardShortcutEditorRow from "./KeyboardShortcutEditorRow.svelte";
   import Icon from "../ui-components/Icon.svelte";
   import {
@@ -91,6 +118,47 @@
   import { keyMap } from "./KeyboardShortcuts.svelte";
 
   let errorMessage;
+  let selectedPanel = "playback";
+
+  const panels = {
+    playback: {
+      text: "Playback Controls",
+      shortcuts: [
+        "SOFT",
+        "SUSTAIN",
+        "ACCENT",
+        "PLAY_PAUSE",
+        "REWIND",
+        "FORWARD",
+        "BACKWARD",
+      ],
+    },
+    volumeAndTempo: {
+      text: "Volume & Tempo",
+      shortcuts: [
+        "VOLUME_UP",
+        "VOLUME_DOWN",
+        "BASS_VOLUME_UP",
+        "BASS_VOLUME_DOWN",
+        "TREBLE_VOLUME_UP",
+        "TREBLE_VOLUME_DOWN",
+        "TEMPO_UP",
+        "TEMPO_DOWN",
+        "LEFT_HAND_AUGMENT",
+        "RIGHT_HAND_AUGMENT",
+      ],
+    },
+  };
+
+  panels.others = {
+    text: "Others",
+    shortcuts: Object.keys($keyMap).filter(
+      (shortcut) =>
+        !Array.prototype
+          .concat(...Object.values(panels).map((p) => p.shortcuts))
+          .includes(shortcut),
+    ),
+  };
 
   const updateKeyBinding = (shortcut, detail) => {
     errorMessage = undefined;
@@ -123,7 +191,7 @@
 </script>
 
 {#if $showKeybindingsConfig}
-  <div transition:fade>
+  <div class="shortcut-editor" transition:fade>
     <header>
       Keyboard Controls
       <button on:click={toggleKeybindingsConfig}>
@@ -134,8 +202,9 @@
     {#if errorMessage}
       <p class="error-message" transition:slide>{errorMessage}</p>
     {/if}
+    <PanelSwitcher bind:selectedPanel {panels} class="panel-switcher" />
     <dl>
-      {#each Object.keys($keyMap) as shortcut}
+      {#each panels[selectedPanel].shortcuts as shortcut}
         <KeyboardShortcutEditorRow
           shortcut={$keyMap[shortcut]}
           meta={keyMapMeta[shortcut]}

--- a/src/components/KeyboardShortcutEditor.svelte
+++ b/src/components/KeyboardShortcutEditor.svelte
@@ -7,13 +7,11 @@
     flex-direction: column;
     left: 50%;
     max-height: 80%;
-    max-width: 100vw;
-    min-width: min(400px, 100vw);
     padding: 1em;
     position: absolute;
     top: 42%;
     transform: translate(-50%, -50%);
-    width: 400px;
+    width: min(600px, 100vw);
     z-index: z($main-context, notifications);
 
     :global(.panel-switcher) {

--- a/src/components/KeyboardShortcutEditor.svelte
+++ b/src/components/KeyboardShortcutEditor.svelte
@@ -59,8 +59,7 @@
 
   .panels {
     display: flex;
-    overflow-x: hidden;
-    overflow-y: auto;
+    overflow: hidden;
     padding-top: 4px;
     position: relative;
   }
@@ -125,6 +124,7 @@
     &.shown {
       opacity: 1;
       pointer-events: all;
+      overflow-y: auto;
     }
   }
 </style>

--- a/src/components/KeyboardShortcutEditor.svelte
+++ b/src/components/KeyboardShortcutEditor.svelte
@@ -47,14 +47,17 @@
     text-decoration: underline;
   }
 
-  p {
-    margin-bottom: 1em;
+  footer {
+    display: flex;
+
+    p {
+      flex: 1;
+      margin: 1em 0 0;
+    }
   }
 
-  p.error-message {
-    color: red;
-    padding: 0.25em;
-    margin: 0.5em 0 0;
+  p {
+    margin-bottom: 1em;
   }
 
   .panels {
@@ -91,11 +94,14 @@
     width: 80%;
   }
 
+  p.error-message {
+    color: red;
+  }
+
   p.reset {
     display: flex;
     align-items: center;
     justify-content: flex-end;
-    margin: 0.5em 0 0;
   }
 
   button {
@@ -305,22 +311,24 @@
         </dl>
       {/each}
     </div>
-    <p class="error-message" class:shown={errorMessage}>
-      {errorMessage}
-    </p>
-    <p
-      class="reset"
-      class:shown={Object.values($keyMap).some(
-        (shortcut) => shortcut.isChanged,
-      ) ||
-        Object.values($controlsConfig).some(
-          (shortcut) => shortcut.isChanged?.length,
-        )}
-    >
-      Reset to defaults: <button on:click={resetShortcuts}>
-        <Icon name="reset" height="24" width="24" />
-      </button>
-    </p>
+    <footer>
+      <p class="error-message" class:shown={errorMessage}>
+        {errorMessage}
+      </p>
+      <p
+        class="reset"
+        class:shown={Object.values($keyMap).some(
+          (shortcut) => shortcut.isChanged,
+        ) ||
+          Object.values($controlsConfig).some(
+            (shortcut) => shortcut.isChanged?.length,
+          )}
+      >
+        Reset to defaults: <button on:click={resetShortcuts}>
+          <Icon name="reset" height="24" width="24" />
+        </button>
+      </p>
+    </footer>
   </div>
 {/if}
 <svelte:window

--- a/src/components/KeyboardShortcutEditor.svelte
+++ b/src/components/KeyboardShortcutEditor.svelte
@@ -234,7 +234,21 @@
     }
 
     $keyMap[shortcut].code = detail.code;
-    $keyMap[shortcut].key = alternativeIndicatorText[detail.code] || detail.key;
+
+    const { keyboard } = navigator;
+    if (keyboard && typeof keyboard.getLayoutMap === "function") {
+      // Only available on Chromium-based browsers at time of writing
+      // https://developer.mozilla.org/en-US/docs/Web/API/Keyboard/getLayoutMap
+      // https://caniuse.com/mdn-api_keyboard_getlayoutmap
+      keyboard.getLayoutMap().then((keyboardLayoutMap) => {
+        const keyString = keyboardLayoutMap.get(detail.code);
+        $keyMap[shortcut].key =
+          keyString || alternativeIndicatorText[detail.code] || detail.key;
+      });
+    } else {
+      $keyMap[shortcut].key =
+        alternativeIndicatorText[detail.code] || detail.key;
+    }
 
     $keyMap[shortcut].isChanged = detail.key !== defaultKeyMap[shortcut].key;
   };

--- a/src/components/KeyboardShortcutEditor.svelte
+++ b/src/components/KeyboardShortcutEditor.svelte
@@ -121,8 +121,7 @@
   }
 
   dl,
-  p.reset,
-  p.error-message {
+  p.reset {
     opacity: 0;
     pointer-events: none;
     transition: opacity 0.4s ease;
@@ -312,9 +311,11 @@
       {/each}
     </div>
     <footer>
-      <p class="error-message" class:shown={errorMessage}>
-        {errorMessage}
-      </p>
+      {#if errorMessage}
+        <p class="error-message" transition:fade>
+          {errorMessage}
+        </p>
+      {/if}
       <p
         class="reset"
         class:shown={Object.values($keyMap).some(

--- a/src/components/KeyboardShortcutEditor.svelte
+++ b/src/components/KeyboardShortcutEditor.svelte
@@ -79,6 +79,12 @@
     }
   }
 
+  :global(dd, dt) {
+    display: flex;
+    align-items: center;
+    margin: 2px 0;
+  }
+
   p.reset {
     display: flex;
     align-items: center;

--- a/src/components/KeyboardShortcutEditor.svelte
+++ b/src/components/KeyboardShortcutEditor.svelte
@@ -85,6 +85,13 @@
     margin: 2px 0;
   }
 
+  :global(hr) {
+    border-color: rgba(255, 255, 255, 0.8);
+    border-width: 0 0 1px 0;
+    grid-column: 1 / 3;
+    width: 80%;
+  }
+
   p.reset {
     display: flex;
     align-items: center;
@@ -169,22 +176,22 @@
         "VOLUME_DOWN",
         "VOLUME_DELTA",
         "VOLUME_AUGMENTED_DELTA",
-
+        "---",
         "TREBLE_VOLUME_UP",
         "TREBLE_VOLUME_DOWN",
         "TREBLE_VOLUME_DELTA",
         "TREBLE_VOLUME_AUGMENTED_DELTA",
-
+        "---",
         "BASS_VOLUME_UP",
         "BASS_VOLUME_DOWN",
         "BASS_VOLUME_DELTA",
         "BASS_VOLUME_AUGMENTED_DELTA",
-
+        "---",
         "TEMPO_UP",
         "TEMPO_DOWN",
         "TEMPO_DELTA",
         "TEMPO_AUGMENTED_DELTA",
-
+        "---",
         "LEFT_HAND_AUGMENT",
         "RIGHT_HAND_AUGMENT",
       ],
@@ -279,7 +286,7 @@
                 on:reset={() =>
                   updateKeyBinding(shortcut, defaultKeyMap[shortcut])}
               />
-            {:else}
+            {:else if shortcut in deltaControls}
               <KeyboardShortcutDeltaEditorRow
                 controlConfigValue={$controlsConfig[
                   deltaControls[shortcut].control
@@ -291,6 +298,8 @@
                 on:update={({ detail }) => updateDelta(shortcut, detail)}
                 on:reset={() => updateDelta(shortcut)}
               />
+            {:else if shortcut === "---"}
+              <hr />
             {/if}
           {/each}
         </dl>

--- a/src/components/KeyboardShortcutEditor.svelte
+++ b/src/components/KeyboardShortcutEditor.svelte
@@ -187,6 +187,9 @@
         "TREBLE_VOLUME_DELTA",
         "TREBLE_VOLUME_AUGMENTED_DELTA",
         "---",
+        "RIGHT_HAND_AUGMENT",
+        "---",
+        "---",
         "BASS_VOLUME_UP",
         "BASS_VOLUME_DOWN",
         "BASS_VOLUME_DELTA",
@@ -198,7 +201,6 @@
         "TEMPO_AUGMENTED_DELTA",
         "---",
         "LEFT_HAND_AUGMENT",
-        "RIGHT_HAND_AUGMENT",
       ],
     },
   };

--- a/src/components/KeyboardShortcutEditor.svelte
+++ b/src/components/KeyboardShortcutEditor.svelte
@@ -293,6 +293,7 @@
               />
             {:else if shortcut in deltaControls}
               <KeyboardShortcutDeltaEditorRow
+                {shortcut}
                 controlConfigValue={$controlsConfig[
                   deltaControls[shortcut].control
                 ][deltaControls[shortcut].deltaType]}

--- a/src/components/KeyboardShortcutEditor.svelte
+++ b/src/components/KeyboardShortcutEditor.svelte
@@ -224,10 +224,18 @@
     const delta = detail || defaultControlsConfig[control][deltaType];
     $controlsConfig[control][deltaType] = delta;
 
+    // $controlsConfig[control] is a single object per control (e.g. volume),
+    //  with .delta and .augmentedDelta keys.  To keep track of which of these
+    //  has been modified from the default, .isChanged (if it exists) is an
+    //  array of either or both of the strings "delta" and "augmentedDelta".
+
+    // clear the .isChanged array for this deltaType
     $controlsConfig[control].isChanged = (
       $controlsConfig[control].isChanged || []
     ).filter((_deltaType) => _deltaType !== deltaType);
 
+    // and then add it if the new value for this deltaType is different
+    //  from the default value
     if (delta !== defaultControlsConfig[control][deltaType]) {
       $controlsConfig[control].isChanged = [
         ...$controlsConfig[control].isChanged,

--- a/src/components/KeyboardShortcutEditorRow.svelte
+++ b/src/components/KeyboardShortcutEditorRow.svelte
@@ -1,14 +1,6 @@
 <style lang="scss">
-  dt {
-    display: flex;
-    align-items: center;
-  }
-
   dd {
-    display: flex;
-    align-items: center;
     justify-content: flex-end;
-    margin: 0.2em 0;
 
     span {
       color: grey;

--- a/src/components/KeyboardShortcuts.svelte
+++ b/src/components/KeyboardShortcuts.svelte
@@ -21,6 +21,8 @@
     sustainOnOff,
     accentOnOff,
   } from "../stores";
+  import { controlsStores } from "../config/controls-config";
+
   import { clamp, easingInterval, enforcePrecision } from "../lib/utils";
 
   export let playPauseApp;
@@ -35,8 +37,9 @@
   const rightHandControls = ["trebleVolume", "volume"];
 
   const updateStore = (control, increment) => {
-    const { store, min, max, delta, augmentedDelta, precision } =
+    const { min, max, delta, augmentedDelta, precision } =
       $controlsConfig[control];
+    const store = controlsStores[control];
 
     let d =
       (leftHandControls.includes(control) && leftHandAugment) ||

--- a/src/components/KeyboardShortcuts.svelte
+++ b/src/components/KeyboardShortcuts.svelte
@@ -24,9 +24,22 @@
   export let updateTickByViewportIncrement;
 
   let actionInterval;
+  let leftHandAugment = false;
+  let rightHandAugment = false;
 
-  const updateStore = ({ store, min, max, delta, precision }, increment) => {
-    const d = (increment ? 1 : -1) * delta;
+  const leftHandControls = ["tempo", "bassVolume"];
+  const rightHandControls = ["trebleVolume", "volume"];
+
+  const updateStore = (control, increment) => {
+    const { store, min, max, delta, augmentedDelta, precision } =
+      controlsConfig[control];
+
+    let d =
+      (leftHandControls.includes(control) && leftHandAugment) ||
+      (rightHandControls.includes(control) && rightHandAugment)
+        ? augmentedDelta
+        : delta;
+    d *= increment ? 1 : -1;
     store.set(enforcePrecision(clamp(get(store) + d, min, max), precision));
   };
 
@@ -44,14 +57,17 @@
     SUSTAIN: () => ($sustainOnOff = true),
     ACCENT: () => ($accentOnOff = true),
 
-    VOLUME_UP: () => increment(controlsConfig.volume),
-    VOLUME_DOWN: () => decrement(controlsConfig.volume),
-    BASS_VOLUME_UP: () => increment(controlsConfig.bassVolume),
-    BASS_VOLUME_DOWN: () => decrement(controlsConfig.bassVolume),
-    TREBLE_VOLUME_UP: () => increment(controlsConfig.trebleVolume),
-    TREBLE_VOLUME_DOWN: () => decrement(controlsConfig.trebleVolume),
-    TEMPO_UP: () => increment(controlsConfig.tempo),
-    TEMPO_DOWN: () => decrement(controlsConfig.tempo),
+    VOLUME_UP: () => increment("volume"),
+    VOLUME_DOWN: () => decrement("volume"),
+    BASS_VOLUME_UP: () => increment("bassVolume"),
+    BASS_VOLUME_DOWN: () => decrement("bassVolume"),
+    TREBLE_VOLUME_UP: () => increment("trebleVolume"),
+    TREBLE_VOLUME_DOWN: () => decrement("trebleVolume"),
+    TEMPO_UP: () => increment("tempo"),
+    TEMPO_DOWN: () => decrement("tempo"),
+
+    LEFT_HAND_AUGMENT: () => (leftHandAugment = true),
+    RIGHT_HAND_AUGMENT: () => (rightHandAugment = true),
 
     PLAY_PAUSE: playPauseApp,
     REWIND: stopApp,
@@ -76,6 +92,9 @@
     SOFT: () => ($softOnOff = false),
     SUSTAIN: () => ($sustainOnOff = false),
     ACCENT: () => ($accentOnOff = false),
+
+    LEFT_HAND_AUGMENT: () => (leftHandAugment = false),
+    RIGHT_HAND_AUGMENT: () => (rightHandAugment = false),
   };
 </script>
 

--- a/src/components/KeyboardShortcuts.svelte
+++ b/src/components/KeyboardShortcuts.svelte
@@ -28,6 +28,7 @@
   export let playPauseApp;
   export let stopApp;
   export let updateTickByViewportIncrement;
+  export let panHorizontal;
 
   let actionInterval;
   let leftHandAugment = false;
@@ -93,6 +94,9 @@
       keydownRepeatAction(() =>
         updateTickByViewportIncrement(/* up = */ false),
       ),
+    PAN_LEFT: () => keydownRepeatAction(() => panHorizontal(/* left = */ true)),
+    PAN_RIGHT: () =>
+      keydownRepeatAction(() => panHorizontal(/* left = */ false)),
   };
 
   const keyupCommandMap = {

--- a/src/components/KeyboardShortcuts.svelte
+++ b/src/components/KeyboardShortcuts.svelte
@@ -1,7 +1,7 @@
 <script context="module">
   import { createPersistedStore } from "../lib/stores";
   import { defaultKeyMap } from "../config/keyboard-shortcut-config";
-  import { controlsConfig as defaultControlsConfig } from "../config/controls-config";
+  import { defaultControlsConfig } from "../config/controls-config";
 
   export const keyMap = createPersistedStore(
     "keyMap",

--- a/src/components/KeyboardShortcuts.svelte
+++ b/src/components/KeyboardShortcuts.svelte
@@ -1,11 +1,16 @@
 <script context="module">
   import { createPersistedStore } from "../lib/stores";
   import { defaultKeyMap } from "../config/keyboard-shortcut-config";
+  import { controlsConfig as defaultControlsConfig } from "../config/controls-config";
 
   export const keyMap = createPersistedStore(
     "keyMap",
     JSON.parse(JSON.stringify(defaultKeyMap)),
   );
+
+  export const controlsConfig = createPersistedStore("controlConfig", {
+    ...defaultControlsConfig,
+  });
 </script>
 
 <script>
@@ -16,7 +21,6 @@
     sustainOnOff,
     accentOnOff,
   } from "../stores";
-  import { controlsConfig } from "../config/controls-config";
   import { clamp, easingInterval, enforcePrecision } from "../lib/utils";
 
   export let playPauseApp;
@@ -32,7 +36,7 @@
 
   const updateStore = (control, increment) => {
     const { store, min, max, delta, augmentedDelta, precision } =
-      controlsConfig[control];
+      $controlsConfig[control];
 
     let d =
       (leftHandControls.includes(control) && leftHandAugment) ||

--- a/src/components/KeyboardShortcuts.svelte
+++ b/src/components/KeyboardShortcuts.svelte
@@ -25,17 +25,8 @@
 
   let actionInterval;
 
-  const updateStore = (
-    // config object
-    { store, min, max, delta, shiftDelta, ctrlDelta, precision },
-    // event
-    { shiftKey, ctrlKey },
-    increment,
-  ) => {
-    const d =
-      (increment ? 1 : -1) *
-      ((shiftKey && shiftDelta) || (ctrlKey && ctrlDelta) || delta);
-
+  const updateStore = ({ store, min, max, delta, precision }, increment) => {
+    const d = (increment ? 1 : -1) * delta;
     store.set(enforcePrecision(clamp(get(store) + d, min, max), precision));
   };
 
@@ -53,15 +44,14 @@
     SUSTAIN: () => ($sustainOnOff = true),
     ACCENT: () => ($accentOnOff = true),
 
-    VOLUME_UP: (event) => increment(controlsConfig.volume, event),
-    VOLUME_DOWN: (event) => decrement(controlsConfig.volume, event),
-    BASS_VOLUME_UP: (event) => increment(controlsConfig.bassVolume, event),
-    BASS_VOLUME_DOWN: (event) => decrement(controlsConfig.bassVolume, event),
-    TREBLE_VOLUME_UP: (event) => increment(controlsConfig.trebleVolume, event),
-    TREBLE_VOLUME_DOWN: (event) =>
-      decrement(controlsConfig.trebleVolume, event),
-    TEMPO_UP: (event) => increment(controlsConfig.tempo, event),
-    TEMPO_DOWN: (event) => decrement(controlsConfig.tempo, event),
+    VOLUME_UP: () => increment(controlsConfig.volume),
+    VOLUME_DOWN: () => decrement(controlsConfig.volume),
+    BASS_VOLUME_UP: () => increment(controlsConfig.bassVolume),
+    BASS_VOLUME_DOWN: () => decrement(controlsConfig.bassVolume),
+    TREBLE_VOLUME_UP: () => increment(controlsConfig.trebleVolume),
+    TREBLE_VOLUME_DOWN: () => decrement(controlsConfig.trebleVolume),
+    TEMPO_UP: () => increment(controlsConfig.tempo),
+    TEMPO_DOWN: () => decrement(controlsConfig.tempo),
 
     PLAY_PAUSE: playPauseApp,
     REWIND: stopApp,

--- a/src/components/PanelSwitcher.svelte
+++ b/src/components/PanelSwitcher.svelte
@@ -33,25 +33,26 @@
 <script>
   import Icon from "../ui-components/Icon.svelte";
 
-  const panels = [
-    ["controls", "sliders"],
-    ["settings", "cog"],
-    ["audio", "piano"],
-  ];
+  export let panels;
   export let selectedPanel;
 </script>
 
-<div>
-  {#each panels as [panel, icon]}
+<div class={$$props.class}>
+  {#each Object.entries(panels) as [panel, label]}
     <input
       type="radio"
-      name="panel-switcher"
+      name={Math.random().toString(16).slice(2)}
       bind:group={selectedPanel}
       value={panel}
       id={panel}
     />
     <label for={panel}>
-      <Icon name={icon} height="24" width="24" />
+      {#if label.icon}
+        <Icon name={label.icon} height="24" width="24" />
+      {/if}
+      {#if label.text}
+        {label.text}
+      {/if}
     </label>
   {/each}
 </div>

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -480,6 +480,12 @@
       updateVisibleSvgPartitions();
     });
 
+    // disable OSD's own vertical panning keyboard interactions
+    viewport.viewer.addHandler("canvas-key", (event) => {
+      event.preventDefault = true;
+      event.preventVerticalPan = true;
+    });
+
     // re-implement some default OSD interactions to apply our own constraints
     //  and sidestep some interaction effects
     openSeadragon.addHandler("canvas-drag", (event) => {

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -108,6 +108,7 @@
   const defaultZoomLevel = 1;
   const minZoomLevel = 0.1;
   const maxZoomLevel = 4;
+  const horizontalPanIncrement = 40;
 
   let openSeadragon;
   let viewport;
@@ -379,6 +380,18 @@
     );
   };
 
+  const panHorizontal = (left = true) => {
+    viewport.panBy(
+      viewport.deltaPointsFromPixels(
+        new OpenSeadragon.Point(
+          left ? -horizontalPanIncrement : horizontalPanIncrement,
+          0,
+        ),
+      ),
+    );
+    viewport.applyConstraints();
+  };
+
   onMount(() => {
     openSeadragon = OpenSeadragon({
       id: "roll-viewer",
@@ -563,7 +576,7 @@
     : parseInt($rollMetadata.IMAGE_LENGTH, 10) -
       parseInt($rollMetadata.LAST_HOLE, 10);
 
-  export { updateTickByViewportIncrement };
+  export { updateTickByViewportIncrement, panHorizontal };
 </script>
 
 <div

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -480,10 +480,9 @@
       updateVisibleSvgPartitions();
     });
 
-    // disable OSD's own vertical panning keyboard interactions
+    // disable OSD's own keyboard interactions
     viewport.viewer.addHandler("canvas-key", (event) => {
-      event.preventDefault = true;
-      event.preventVerticalPan = true;
+      event.preventDefaultAction = true;
     });
 
     // re-implement some default OSD interactions to apply our own constraints

--- a/src/components/TabbedPanel.svelte
+++ b/src/components/TabbedPanel.svelte
@@ -55,15 +55,16 @@
     controls: {
       component: BasicSettings,
       props: { skipToPercentage },
+      icon: "sliders",
     },
-    settings: { component: AdvancedSettings },
-    audio: { component: AudioSettings },
+    settings: { component: AdvancedSettings, icon: "cog" },
+    audio: { component: AudioSettings, icon: "piano" },
   };
 
   let selectedPanel = "controls";
 </script>
 
-<PanelSwitcher bind:selectedPanel />
+<PanelSwitcher bind:selectedPanel {panels} />
 <div>
   <svelte:component
     this={panels[selectedPanel].component}

--- a/src/config/controls-config.js
+++ b/src/config/controls-config.js
@@ -11,6 +11,7 @@ export const controlsConfig = {
     min: 0,
     max: 4,
     delta: 0.1,
+    augmentedDelta: 0.4,
     precision: 2,
   },
   bassVolume: {
@@ -18,6 +19,7 @@ export const controlsConfig = {
     min: 0,
     max: 4,
     delta: 0.1,
+    augmentedDelta: 0.4,
     precision: 2,
   },
   trebleVolume: {
@@ -25,6 +27,7 @@ export const controlsConfig = {
     min: 0,
     max: 4,
     delta: 0.1,
+    augmentedDelta: 0.4,
     precision: 2,
   },
   tempo: {
@@ -32,6 +35,7 @@ export const controlsConfig = {
     min: 0.1,
     max: 3,
     delta: 0.05,
+    augmentedDelta: 0.1,
     precision: 2,
   },
 };

--- a/src/config/controls-config.js
+++ b/src/config/controls-config.js
@@ -11,8 +11,6 @@ export const controlsConfig = {
     min: 0,
     max: 4,
     delta: 0.1,
-    shiftDelta: 0.4,
-    ctrlDelta: 0.05,
     precision: 2,
   },
   bassVolume: {
@@ -20,8 +18,6 @@ export const controlsConfig = {
     min: 0,
     max: 4,
     delta: 0.1,
-    shiftDelta: 0.4,
-    ctrlDelta: 0.05,
     precision: 2,
   },
   trebleVolume: {
@@ -29,8 +25,6 @@ export const controlsConfig = {
     min: 0,
     max: 4,
     delta: 0.1,
-    shiftDelta: 0.4,
-    ctrlDelta: 0.05,
     precision: 2,
   },
   tempo: {
@@ -38,8 +32,6 @@ export const controlsConfig = {
     min: 0.1,
     max: 3,
     delta: 0.05,
-    shiftDelta: 0.1,
-    ctrlDelta: 0.01,
     precision: 2,
   },
 };

--- a/src/config/controls-config.js
+++ b/src/config/controls-config.js
@@ -5,7 +5,7 @@ import {
   tempoCoefficient,
 } from "../stores";
 
-export const controlsConfig = {
+export const defaultControlsConfig = {
   volume: {
     min: 0,
     max: 4,

--- a/src/config/controls-config.js
+++ b/src/config/controls-config.js
@@ -7,7 +7,6 @@ import {
 
 export const controlsConfig = {
   volume: {
-    store: volumeCoefficient,
     min: 0,
     max: 4,
     delta: 0.1,
@@ -15,7 +14,6 @@ export const controlsConfig = {
     precision: 2,
   },
   bassVolume: {
-    store: bassVolumeCoefficient,
     min: 0,
     max: 4,
     delta: 0.1,
@@ -23,7 +21,6 @@ export const controlsConfig = {
     precision: 2,
   },
   trebleVolume: {
-    store: trebleVolumeCoefficient,
     min: 0,
     max: 4,
     delta: 0.1,
@@ -31,11 +28,17 @@ export const controlsConfig = {
     precision: 2,
   },
   tempo: {
-    store: tempoCoefficient,
     min: 0.1,
     max: 3,
     delta: 0.05,
     augmentedDelta: 0.1,
     precision: 2,
   },
+};
+
+export const controlsStores = {
+  volume: volumeCoefficient,
+  bassVolume: bassVolumeCoefficient,
+  trebleVolume: trebleVolumeCoefficient,
+  tempo: tempoCoefficient,
 };

--- a/src/config/keyboard-shortcut-config.js
+++ b/src/config/keyboard-shortcut-config.js
@@ -107,14 +107,7 @@ export const keyMapMeta = {
   },
 };
 
-export const unusableKeys = [
-  "Escape",
-  "ControlLeft",
-  "ControlRight",
-  "ShiftLeft",
-  "ShiftRight",
-  "CapsLock",
-];
+export const unusableKeys = ["Escape", "CapsLock"];
 
 export const alternativeIndicatorText = {
   Space: "＿",
@@ -126,4 +119,8 @@ export const alternativeIndicatorText = {
   ArrowDown: "↓",
   ArrowLeft: "←",
   ArrowRight: "→",
+  ControlLeft: " (L)Ctrl",
+  ControlRight: "(R)Ctrl",
+  ShiftLeft: "(L)Shift",
+  ShiftRight: "(R)Shift",
 };

--- a/src/config/keyboard-shortcut-config.js
+++ b/src/config/keyboard-shortcut-config.js
@@ -74,11 +74,11 @@ export const keyMapMeta = {
 
   LEFT_HAND_AUGMENT: {
     description: "Left-hand Augment",
-    help: "Hold this key to use larger jumps when using Tempo or Bass Volume keys",
+    help: "Hold this key to use the “augmented” increments when using Tempo or Bass Volume keys",
   },
   RIGHT_HAND_AUGMENT: {
     description: "Right-hand Augment",
-    help: "Hold this key to use larger jumps when using Volume or Treble Volume keys",
+    help: "Hold this key to use the “augmented” increments when using Volume or Treble Volume keys",
   },
 
   PLAY_PAUSE: {

--- a/src/config/keyboard-shortcut-config.js
+++ b/src/config/keyboard-shortcut-config.js
@@ -124,3 +124,54 @@ export const alternativeIndicatorText = {
   ShiftLeft: "(L)Shift",
   ShiftRight: "(R)Shift",
 };
+
+export const deltaControls = {
+  VOLUME_DELTA: {
+    control: "volume",
+    deltaType: "delta",
+    description: "Volume Increment",
+    help: "Amount to increase/decrease volume by when using the Volume Up/Down keys",
+  },
+  VOLUME_AUGMENTED_DELTA: {
+    control: "volume",
+    deltaType: "augmentedDelta",
+    description: "Volume Increment (Augmented)",
+    help: "Amount to increase/decrease volume by when holding the left-hand augment key and using the Volume Up/Down keys",
+  },
+  TREBLE_VOLUME_DELTA: {
+    control: "trebleVolume",
+    deltaType: "delta",
+    description: "Treble Volume Increment",
+    help: "Amount to increase/decrease treble volume by when using the Treble Volume Up/Down keys",
+  },
+  TREBLE_VOLUME_AUGMENTED_DELTA: {
+    control: "trebleVolume",
+    deltaType: "augmentedDelta",
+    description: "Treble Volume Increment (Augmented)",
+    help: "Amount to increase/decrease treble volume by when holding the left-hand augment key and using the Treble Volume Up/Down keys",
+  },
+  BASS_VOLUME_DELTA: {
+    control: "bassVolume",
+    deltaType: "delta",
+    description: "Bass Volume Increment",
+    help: "Amount to increase/decrease bass volume by when using the Bass Volume Up/Down keys",
+  },
+  BASS_VOLUME_AUGMENTED_DELTA: {
+    control: "bassVolume",
+    deltaType: "augmentedDelta",
+    description: "Bass Volume Increment (Augmented)",
+    help: "Amount to increase/decrease bass volume by when holding the left-hand augment key and using the Bass Volume Up/Down keys",
+  },
+  TEMPO_DELTA: {
+    control: "tempo",
+    deltaType: "delta",
+    description: "Tempo Increment",
+    help: "Amount to increase/decrease tempo by when using the Tempo Up/Down keys",
+  },
+  TEMPO_AUGMENTED_DELTA: {
+    control: "tempo",
+    deltaType: "augmentedDelta",
+    description: "Tempo Increment (Augmented)",
+    help: "Amount to increase/decrease tempo by when holding the right-hand augment key and using the Tempo Up/Down keys",
+  },
+};

--- a/src/config/keyboard-shortcut-config.js
+++ b/src/config/keyboard-shortcut-config.js
@@ -13,6 +13,9 @@ export const defaultKeyMap = {
   TEMPO_UP: { code: "KeyT", key: "t" },
   TEMPO_DOWN: { code: "KeyR", key: "r" },
 
+  LEFT_HAND_AUGMENT: { code: "KeyW", key: "w" },
+  RIGHT_HAND_AUGMENT: { code: "BracketLeft", key: "[" },
+
   PLAY_PAUSE: { code: "Digit7", key: "7" },
   REWIND: { code: "Backspace", key: "⌫" },
   FORWARD: { code: "Digit8", key: "8" },
@@ -67,6 +70,15 @@ export const keyMapMeta = {
   TEMPO_DOWN: {
     description: "Tempo Down",
     help: `Decrease the tempo`,
+  },
+
+  LEFT_HAND_AUGMENT: {
+    description: "Left-hand Augment",
+    help: "Hold this key to use larger jumps when using Tempo or Bass Volume keys",
+  },
+  RIGHT_HAND_AUGMENT: {
+    description: "Right-hand Augment",
+    help: "Hold this key to use larger jumps when using Volume or Treble Volume keys",
   },
 
   PLAY_PAUSE: {

--- a/src/config/keyboard-shortcut-config.js
+++ b/src/config/keyboard-shortcut-config.js
@@ -22,6 +22,8 @@ export const defaultKeyMap = {
   BACKWARD: { code: "Digit6", key: "6" },
   PAN_UP: { code: "ArrowUp", key: "↑" },
   PAN_DOWN: { code: "ArrowDown", key: "↓" },
+  PAN_LEFT: { code: "ArrowLeft", key: "←" },
+  PAN_RIGHT: { code: "ArrowRight", key: "→" },
 };
 
 export const keyMapMeta = {
@@ -104,6 +106,14 @@ export const keyMapMeta = {
   PAN_DOWN: {
     description: "Pan Downwards",
     help: "Pan the roll downwards (hold to accelerate)",
+  },
+  PAN_LEFT: {
+    description: "Pan Left",
+    help: "Pan the roll leftwards (hold to accelerate)",
+  },
+  PAN_RIGHT: {
+    description: "Pan Right",
+    help: "Pan the roll rightwards (hold to accelerate)",
   },
 };
 

--- a/src/config/keyboard-shortcut-config.js
+++ b/src/config/keyboard-shortcut-config.js
@@ -37,44 +37,36 @@ export const keyMapMeta = {
 
   VOLUME_UP: {
     description: "Volume Up",
-    help: `Increase the main volume
-        Use SHIFT for a larger increment, and CTRL for finer-grained control`,
+    help: `Increase the main volume`,
   },
   VOLUME_DOWN: {
     description: "Volume Down",
-    help: `Decrease the main volume
-        Use SHIFT for a larger increment, and CTRL for finer-grained control`,
+    help: `Decrease the main volume`,
   },
   BASS_VOLUME_UP: {
     description: "Bass Volume Up",
-    help: `Increase the bass volume
-        Use SHIFT for a larger increment, and CTRL for finer-grained control`,
+    help: `Increase the bass volume`,
   },
   BASS_VOLUME_DOWN: {
     description: "Bass Volume Down",
-    help: `Decrease the bass volume
-        Use SHIFT for a larger increment, and CTRL for finer-grained control`,
+    help: `Decrease the bass volume`,
   },
   TREBLE_VOLUME_UP: {
     description: "Treble Volume Up",
-    help: `Increase the treble volume
-        Use SHIFT for a larger increment, and CTRL for finer-grained control`,
+    help: `Increase the treble volume`,
   },
   TREBLE_VOLUME_DOWN: {
     description: "Treble Volume Down",
-    help: `Decrease the treble volume
-        Use SHIFT for a larger increment, and CTRL for finer-grained control`,
+    help: `Decrease the treble volume`,
   },
 
   TEMPO_UP: {
     description: "Tempo Up",
-    help: `Increase the tempo
-        Use SHIFT for a larger increment, and CTRL for finer-grained control`,
+    help: `Increase the tempo`,
   },
   TEMPO_DOWN: {
     description: "Tempo Down",
-    help: `Decrease the tempo
-        Use SHIFT for a larger increment, and CTRL for finer-grained control`,
+    help: `Decrease the tempo`,
   },
 
   PLAY_PAUSE: {

--- a/src/config/keyboard-shortcut-config.js
+++ b/src/config/keyboard-shortcut-config.js
@@ -119,10 +119,14 @@ export const alternativeIndicatorText = {
   ArrowDown: "↓",
   ArrowLeft: "←",
   ArrowRight: "→",
-  ControlLeft: " (L)Ctrl",
-  ControlRight: "(R)Ctrl",
-  ShiftLeft: "(L)Shift",
-  ShiftRight: "(R)Shift",
+  ControlLeft: "L_Ctrl",
+  ControlRight: "R_Ctrl",
+  ShiftLeft: "L_Shift",
+  ShiftRight: "R_Shift",
+  AltLeft: "L_Alt",
+  AltRight: "R_Alt",
+  MetaLeft: "L_Meta",
+  MetaRight: "R_Meta",
 };
 
 export const deltaControls = {

--- a/src/config/keyboard-shortcut-config.js
+++ b/src/config/keyboard-shortcut-config.js
@@ -137,6 +137,8 @@ export const alternativeIndicatorText = {
   AltRight: "R_Alt",
   MetaLeft: "L_Meta",
   MetaRight: "R_Meta",
+  OSLeft: "L ⌘",
+  OSRight: "R ⌘",
 };
 
 export const deltaControls = {

--- a/src/lib/stores.js
+++ b/src/lib/stores.js
@@ -17,7 +17,12 @@ export const createPersistedStore = (key, defaultValue) => {
   let initialValue =
     typeof defaultValue === "object" ? { ...defaultValue } : defaultValue;
   try {
-    if (persistedValue) initialValue = JSON.parse(persistedValue);
+    if (persistedValue) {
+      initialValue =
+        typeof defaultValue === "object"
+          ? Object.assign(initialValue, JSON.parse(persistedValue))
+          : JSON.parse(persistedValue);
+    }
   } catch {
     // pass
   }

--- a/src/styles/base.scss
+++ b/src/styles/base.scss
@@ -51,7 +51,7 @@ h1 {
   font-family: $primary-typeface;
 }
 
-footer {
+body > footer {
   bottom: 0;
   display: flex;
   gap: 2em;

--- a/src/ui-components/RangeSlider.svelte
+++ b/src/ui-components/RangeSlider.svelte
@@ -57,7 +57,6 @@
   [type="range"] {
     -webkit-appearance: none;
     background: transparent;
-    height: 1px;
     margin: math.div($thumb-height, 2) 0;
     width: $track-width;
 

--- a/src/ui-components/RangeSlider.svelte
+++ b/src/ui-components/RangeSlider.svelte
@@ -172,6 +172,28 @@
   export let step;
   export let name;
   export let value;
+  export let mousewheel = true;
+
+  const clamp = (_value) => Math.min(Math.max(_value, min), max);
+
+  const handleWheel = ({ deltaY }) => {
+    if (!mousewheel) return;
+    const precision = (step.toString().split(".")[1] || "").length;
+    if (deltaY > 0) {
+      value = clamp((Number(value) + Number(step)).toFixed(precision));
+    } else {
+      value = clamp((Number(value) - Number(step)).toFixed(precision));
+    }
+  };
 </script>
 
-<input type="range" bind:value on:input on:change {min} {max} {step} {name} />
+<input
+  type="range"
+  bind:value
+  on:input
+  on:change
+  on:mousewheel={handleWheel}
+  {max}
+  {step}
+  {name}
+/>

--- a/src/ui-components/RangeSlider.svelte
+++ b/src/ui-components/RangeSlider.svelte
@@ -193,6 +193,7 @@
   on:input
   on:change
   on:mousewheel={handleWheel}
+  {min}
   {max}
   {step}
   {name}

--- a/src/ui-components/SliderControl.svelte
+++ b/src/ui-components/SliderControl.svelte
@@ -25,22 +25,19 @@
   export let step;
   export let name;
   export let mousewheel = true;
-
-  const clamp = (_value) => Math.min(Math.max(_value, min), max);
-
-  const handleWheel = ({ deltaY }) => {
-    if (!mousewheel) return;
-    const precision = (step.toString().split(".")[1] || "").length;
-    if (deltaY > 0) {
-      value = clamp((Number(value) + Number(step)).toFixed(precision));
-    } else {
-      value = clamp((Number(value) - Number(step)).toFixed(precision));
-    }
-  };
 </script>
 
-<div on:mousewheel={handleWheel}>
+<div>
   <span><slot name="label">{name}</slot></span>
   <span><slot name="value">{value}</slot></span>
-  <RangeSlider bind:value on:input on:change {min} {max} {step} {name} />
+  <RangeSlider
+    bind:value
+    {min}
+    {max}
+    {step}
+    {name}
+    {mousewheel}
+    on:input
+    on:change
+  />
 </div>


### PR DESCRIPTION
This PR drops the <kbd>Ctrl</kbd> and <kbd>Shift</kbd> modifiers for volume and tempo key controls, and adds a single configurable "augment" key command for bass volume and tempo ("left hand" -- defaults to <kbd>w</kbd>) and volume and treble volume ("right-hand" -- defaults to <kbd>[</kbd>).

To make the increment values (`delta`, `augmentedDelta`) configurable, slider controls have been added to the "Keyboard Controls" dialog, and since that has become a little crowded now, it's been split into a tabbed arrangement.  I hope you'll agree it's a passable solution to an awkward problem.  A few bits and pieces of the stores, controls, and config had to be shuffled to make this work nicely and it took a fair bit of iterating to get it all working properly, but I think it's ready for destruction testing now :)