### PR TITLE
Upgrade OpenSeadragon to v3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "CanvasSpliner": "jonathanlurie/CanvasSpliner",
     "midi-player-js": "^2.0.16",
     "node-interval-tree": "^1.3.3",
-    "openseadragon": "^2.4.2",
+    "openseadragon": "^3.0.0",
     "svelte-preprocess": "^4.8.0",
     "svelte": "^3.42.4",
     "tone": "^14.7.77",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4515,10 +4515,10 @@ open@^8.2.1:
     is-docker "^2.1.1"
     is-wsl "^2.2.0"
 
-openseadragon@^2.4.2:
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/openseadragon/-/openseadragon-2.4.2.tgz#f25d833d0ab9941599d65a3e2b44bec546c9f15c"
-  integrity sha512-398KbZwRtOYA6OmeWRY4Q0737NTacQ9Q6whmr9Lp1MNQO3p0eBz5LIASRne+4gwequcSM1vcHcjfy3dIndQziw==
+openseadragon@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/openseadragon/-/openseadragon-3.0.0.tgz#efaf47514eac24637e27482217d2e9fc3a3441de"
+  integrity sha512-IIl90uMZ8mi+W4IWJ0W6/xyz2SCcHeEMT6U5dcAN7UYJYAXWLYbmu3diWzoz4KE0JvMXbXC5wjRoACdTVrgaog==
 
 optionator@^0.9.1:
   version "0.9.1"


### PR DESCRIPTION
This doesn't seem to cause any problems, at least on Firefox and Chrome for MacOS. It's possible that the update brings some performance improvements, but if so, they're subtle.
This could be folded into a PR with upgrades of other components, if applicable, but is also OK to go in on its own.

The version release notes:
https://github.com/openseadragon/openseadragon/releases/tag/v3.0.0