### PR TITLE
Enable tooltips for menu selector, roll navigation and piano show/hide control

### DIFF
--- a/src/components/KeyboardControls.svelte
+++ b/src/components/KeyboardControls.svelte
@@ -43,6 +43,7 @@
     label="Show/Hide Piano Keyboard"
     height="24"
     width="24"
+    alt="Show/Hide Piano Keyboard"
   />
   {#if !outside}
     <IconButton
@@ -53,6 +54,7 @@
       label="Overlay Piano Keyboard on Roll Image"
       height="24"
       width="24"
+      alt="Overlay Piano Keyboard on Roll Image"
     />
   {/if}
 </div>

--- a/src/components/PanelSwitcher.svelte
+++ b/src/components/PanelSwitcher.svelte
@@ -48,7 +48,7 @@
     />
     <label for={panel}>
       {#if label.icon}
-        <Icon name={label.icon} height="24" width="24" />
+        <Icon name={label.icon} height="24" width="24" alt={label.alt} />
       {/if}
       {#if label.text}
         {label.text}

--- a/src/components/RollViewerControls.svelte
+++ b/src/components/RollViewerControls.svelte
@@ -54,6 +54,7 @@
     label="Zoom In"
     height="24"
     width="24"
+    alt="Zoom In"
   />
   <IconButton
     class="overlay"
@@ -65,6 +66,7 @@
     label="Zoom Out"
     height="24"
     width="24"
+    alt="Zoom Out"
   />
   <IconButton
     class="overlay"
@@ -77,6 +79,7 @@
     label="Zoom to Roll Width"
     height="24"
     width="24"
+    alt="Zoom to Roll Width"
   />
   <IconButton
     class="overlay"
@@ -88,6 +91,7 @@
     label="Pan Up"
     height="24"
     width="24"
+    alt="Pan Up"
   />
   <IconButton
     class="overlay"
@@ -99,6 +103,7 @@
     label="Pan Down"
     height="24"
     width="24"
+    alt="Pan Down"
   />
   <IconButton
     class="overlay"
@@ -108,6 +113,7 @@
     label="Pan Left"
     height="24"
     width="24"
+    alt="Pan Left"
   />
   <IconButton
     class="overlay"
@@ -119,6 +125,7 @@
     label="Pan Right"
     height="24"
     width="24"
+    alt="Pan Right"
   />
 </div>
 <svelte:window on:mouseup={() => actionInterval?.clear()} />

--- a/src/components/TabbedPanel.svelte
+++ b/src/components/TabbedPanel.svelte
@@ -57,10 +57,11 @@
       component: BasicSettings,
       props: { skipToPercentage },
       icon: "sliders",
+      alt: "Settings",
     },
-    settings: { component: AdvancedSettings, icon: "cog" },
-    audio: { component: AudioSettings, icon: "piano" },
-    midi: { component: MidiSettings, icon: "midi" },
+    settings: { component: AdvancedSettings, icon: "cog", alt: "Advanced" },
+    audio: { component: AudioSettings, icon: "piano", alt: "Audio" },
+    midi: { component: MidiSettings, icon: "midi", alt: "MIDI" },
   };
 
   let selectedPanel = "controls";

--- a/src/ui-components/Icon.svelte
+++ b/src/ui-components/Icon.svelte
@@ -3,6 +3,7 @@
   export let width = "1rem";
   export let height = "1rem";
   export let customAttribs = {};
+  export let alt = "";
 
   const defaultAttribs = {
     viewBox: "0 0 24 24",
@@ -169,13 +170,15 @@
     },
   };
   const { attribs, svg } = icons[name];
+  const htmlContent = `<title>${alt}</title>${svg}`;
 </script>
 
 <svg
+  role="img"
   {height}
   {width}
   {...defaultAttribs}
   {...attribs}
   {...customAttribs}
-  {...$$props}>{@html svg}</svg
+  {...$$props}>{@html htmlContent}</svg
 >

--- a/src/ui-components/IconButton.svelte
+++ b/src/ui-components/IconButton.svelte
@@ -69,6 +69,7 @@
   on:click
   on:mousedown
   bind:this={ref}
+  title={alt}
 >
   <Icon
     name={iconName}

--- a/src/ui-components/IconButton.svelte
+++ b/src/ui-components/IconButton.svelte
@@ -56,6 +56,8 @@
   export let iconName;
   export let label;
 
+  export let alt = "";
+
   export let ref = undefined;
 </script>
 
@@ -68,5 +70,12 @@
   on:mousedown
   bind:this={ref}
 >
-  <Icon name={iconName} {height} {width} aria-hidden="true" focusable="false" />
+  <Icon
+    name={iconName}
+    {height}
+    {width}
+    aria-hidden="true"
+    focusable="false"
+    {alt}
+  />
 </button>


### PR DESCRIPTION
I'm not sure if this overlaps with other UI-related branches that are in the works, but anyway I think casual users would appreciate some basic tooltip hints/explanations about what functionality groupings are meant to live under each of the menu icon buttons at top right. The roll navigation buttons and piano pop-out/in/under icon buttons are quite a bit more self explanatory, but I still suspect that mouse-users would be positively inclined towards tooltips on these.

This implementation is meant to coexist with the use of the PopperJS tooltips for the key bindings menu -- that is, not supplying an icon's `alt` property must means that no default tooltip will be shown, clearing the stage for a PopperJS tooltip. It's also somewhat orthogonal to any specifically ARIA-oriented functionality, for better or worse.