### PR TITLE
Add more catalog metadata to support enhanced searach and browse

### DIFF
--- a/src/config/catalog.json
+++ b/src/config/catalog.json
@@ -1,3842 +1,5762 @@
 [
   {
+    "arranger": "",
+    "composer": "",
     "druid": "my670qk6863",
-    "image_url": "https://stacks.stanford.edu/image/iiif/my670qk6863%2Fmy670qk6863_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/my670qk6863/my670qk6863_0001/info.json",
     "number": "2673",
+    "performer": "Adam, Eugenie",
     "publisher": "Welte-Mignon",
     "title": "Adam - Hymns",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Hymns"
   },
   {
+    "arranger": "",
+    "composer": "Adam, Adolphe",
     "druid": "sj617nc3041",
-    "image_url": "https://stacks.stanford.edu/image/iiif/sj617nc3041%2Fsj617nc3041_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/sj617nc3041/sj617nc3041_0001/info.json",
     "number": "2543",
+    "performer": "Bernick, Hans",
     "publisher": "Welte-Mignon",
     "title": "Adam/Bernick - Si j'étais roi: Ouverture",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Si j'étais roi: Ouverture"
   },
   {
+    "arranger": "",
+    "composer": "Akst, Harry, 1894-1963",
     "druid": "sz948zd1422",
-    "image_url": "https://stacks.stanford.edu/image/iiif/sz948zd1422%2Fsz948zd1422_0002/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/sz948zd1422/sz948zd1422_0002/info.json",
     "number": "4538",
+    "performer": "",
     "publisher": "Princesa",
     "title": "Akst - Dinah: Charlestón",
-    "type": "88-note"
+    "type": "88-note",
+    "work": "Dinah: Charlestón"
   },
   {
+    "arranger": "Albert, Eugen d'",
+    "composer": "Albert, Eugen d'",
     "druid": "ty610zx2946",
-    "image_url": "https://stacks.stanford.edu/image/iiif/ty610zx2946%2Fty610zx2946_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/ty610zx2946/ty610zx2946_0001/info.json",
     "number": "416",
+    "performer": "Albert, Eugen d'",
     "publisher": "Welte-Mignon",
     "title": "Albert/Albert - Tiefland ballade",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Tiefland ballade"
   },
   {
+    "arranger": "",
+    "composer": "Alkan, Charles-Valentin",
     "druid": "mb915gc4689",
-    "image_url": "https://stacks.stanford.edu/image/iiif/mb915gc4689%2Fmb915gc4689_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/mb915gc4689/mb915gc4689_0001/info.json",
     "number": "520",
+    "performer": "Petri, Egon",
     "publisher": "Welte-Mignon",
     "title": "Alkan/Petri - Ancienne melodie de la synagogue a. d. präludien: op. 31",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Ancienne melodie de la synagogue a. d. präludien: op. 31"
   },
   {
+    "arranger": "",
+    "composer": "Alonso, Francisco, 1887-1948",
     "druid": "xn196fs1128",
-    "image_url": "https://stacks.stanford.edu/image/iiif/xn196fs1128%2Fxn196fs1128_0002/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/xn196fs1128/xn196fs1128_0002/info.json",
     "number": "4652",
+    "performer": "",
     "publisher": "Princesa",
     "title": "Alonso - La Parranda: Ronda de las solteras",
-    "type": "88-note"
+    "type": "88-note",
+    "work": "La Parranda: Ronda de las solteras"
   },
   {
+    "arranger": "",
+    "composer": "Alonso, Francisco, 1887-1948",
+    "druid": "nw222vm1898",
+    "image_url": "https://stacks.stanford.edu/image/iiif/nw222vm1898/nw222vm1898_0002/info.json",
+    "number": "4566",
+    "performer": "",
+    "publisher": "Princesa",
+    "title": "Alonso - Las  Castigadoras: Pasodoble",
+    "type": "88-note",
+    "work": "Las  Castigadoras: Pasodoble"
+  },
+  {
+    "arranger": "",
+    "composer": "Alonso, Francisco, 1887-1948",
     "druid": "cy287wz7683",
-    "image_url": "https://stacks.stanford.edu/image/iiif/cy287wz7683%2Fcy287wz7683_0002/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/cy287wz7683/cy287wz7683_0002/info.json",
     "number": "653",
+    "performer": "",
     "publisher": "P.O.C.H.",
     "title": "Alonso - Las Castigadoras: Charlestón",
-    "type": "88-note"
+    "type": "88-note",
+    "work": "Las Castigadoras: Charlestón"
   },
   {
-    "druid": "nw222vm1898",
-    "image_url": "https://stacks.stanford.edu/image/iiif/nw222vm1898%2Fnw222vm1898_0002/info.json",
-    "number": "4566",
-    "publisher": "Princesa",
-    "title": "Alonso - Las Castigadoras: Pasodoble",
-    "type": "88-note"
-  },
-  {
+    "arranger": "",
+    "composer": "Alonso, Francisco, 1887-1948",
     "druid": "pz594dj8436",
-    "image_url": "https://stacks.stanford.edu/image/iiif/pz594dj8436%2Fpz594dj8436_0002/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/pz594dj8436/pz594dj8436_0002/info.json",
     "number": "4391",
+    "performer": "",
     "publisher": "Princesa",
     "title": "Alonso - Las Corsarias: selecciones",
-    "type": "88-note"
+    "type": "88-note",
+    "work": "Las Corsarias: selecciones"
   },
   {
+    "arranger": "",
+    "composer": "Alonso, Francisco, 1887-1948",
     "druid": "tn412mq0486",
-    "image_url": "https://stacks.stanford.edu/image/iiif/tn412mq0486%2Ftn412mq0486_0002/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/tn412mq0486/tn412mq0486_0002/info.json",
     "number": "40076",
+    "performer": "",
     "publisher": "Princesa",
     "title": "Alonso - Por si las moscas: Schotis",
-    "type": "88-note"
+    "type": "88-note",
+    "work": "Por si las moscas: Schotis"
   },
   {
+    "arranger": "",
+    "composer": "Barta, Luis",
     "druid": "rs892mq5364",
-    "image_url": "https://stacks.stanford.edu/image/iiif/rs892mq5364%2Frs892mq5364_0002/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/rs892mq5364/rs892mq5364_0002/info.json",
     "number": "40008",
+    "performer": "",
     "publisher": "Princesa",
     "title": "Barta - Rosa de madrid: schotis",
-    "type": "88-note"
+    "type": "88-note",
+    "work": "Rosa de madrid: schotis"
   },
   {
+    "arranger": "",
+    "composer": "Beethoven, Ludwig van, 1770-1827",
     "druid": "ch984dr4932",
-    "image_url": "https://stacks.stanford.edu/image/iiif/ch984dr4932%2Fch984dr4932_0002/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/ch984dr4932/ch984dr4932_0002/info.json",
     "number": "1894",
+    "performer": "",
     "publisher": "N/A",
     "title": "Beethoven - Cuarteto op. 130: III: Andante con moto ma non troppo",
-    "type": "88-note"
+    "type": "88-note",
+    "work": "Cuarteto op. 130: III: Andante con moto ma non troppo"
   },
   {
+    "arranger": "",
+    "composer": "Beethoven, Ludwig van, 1770-1827",
     "druid": "vz386xg9451",
-    "image_url": "https://stacks.stanford.edu/image/iiif/vz386xg9451%2Fvz386xg9451_0002/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/vz386xg9451/vz386xg9451_0002/info.json",
     "number": "4155",
+    "performer": "",
     "publisher": "Victoria",
     "title": "Beethoven - Sonata op. 31, no 1: Rondó",
-    "type": "88-note"
+    "type": "88-note",
+    "work": "Sonata op. 31, no 1: Rondó"
   },
   {
+    "arranger": "",
+    "composer": "Beethoven, Ludwig van, 1770-1827",
     "druid": "hb523vs3190",
-    "image_url": "https://stacks.stanford.edu/image/iiif/hb523vs3190%2Fhb523vs3190_0002/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/hb523vs3190/hb523vs3190_0002/info.json",
     "number": "4108",
+    "performer": "",
     "publisher": "Victoria",
     "title": "Beethoven - Sonata, op. 2, no 1, en fa menor: minuetto",
-    "type": "88-note"
+    "type": "88-note",
+    "work": "Sonata, op. 2, no 1, en fa menor: minuetto"
   },
   {
+    "arranger": "Liszt, Franz",
+    "composer": "Beethoven, Ludwig van",
     "druid": "bc072xf6791",
-    "image_url": "https://stacks.stanford.edu/image/iiif/bc072xf6791%2Fbc072xf6791_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/bc072xf6791/bc072xf6791_0001/info.json",
     "number": "443",
+    "performer": "Busoni, Ferruccio",
     "publisher": "Welte-Mignon",
     "title": "Beethoven-Liszt/Busoni - Adelaïde: (transcription)",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Adelaïde: (transcription)"
   },
   {
+    "arranger": "",
+    "composer": "Beethoven, Ludwig van",
     "druid": "bq744nq5945",
-    "image_url": "https://stacks.stanford.edu/image/iiif/bq744nq5945%2Fbq744nq5945_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/bq744nq5945/bq744nq5945_0001/info.json",
     "number": "1462",
+    "performer": "Bloomfield-Zeisler, Fannie",
     "publisher": "Welte-Mignon",
     "title": "Beethoven/Bloomfield-Zeisler - Sonata op. 111, c minor: 1st movement",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Sonata op. 111, c minor: 1st movement"
   },
   {
+    "arranger": "",
+    "composer": "Beethoven, Ludwig van",
     "druid": "yt974cv2625",
-    "image_url": "https://stacks.stanford.edu/image/iiif/yt974cv2625%2Fyt974cv2625_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/yt974cv2625/yt974cv2625_0001/info.json",
     "number": "1463",
+    "performer": "Bloomfield-Zeisler, Fannie",
     "publisher": "Welte-Mignon",
     "title": "Beethoven/Bloomfield-Zeisler - Sonate op. 111, c-moll: II. Teil",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Sonate op. 111, c-moll: II. Teil"
   },
   {
+    "arranger": "",
+    "composer": "Beethoven, Ludwig van",
     "druid": "qz671pq0609",
-    "image_url": "https://stacks.stanford.edu/image/iiif/qz671pq0609%2Fqz671pq0609_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/qz671pq0609/qz671pq0609_0001/info.json",
     "number": "372",
+    "performer": "Carreño, Teresa",
     "publisher": "Welte-Mignon",
     "title": "Beethoven/Carreño - Sonate c-dur, op. 53: (Waldstein): 1. Teil",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Sonate c-dur, op. 53: (Waldstein): 1. Teil"
   },
   {
+    "arranger": "",
+    "composer": "Beethoven, Ludwig van",
     "druid": "kg263bn9176",
-    "image_url": "https://stacks.stanford.edu/image/iiif/kg263bn9176%2Fkg263bn9176_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/kg263bn9176/kg263bn9176_0001/info.json",
     "number": "373",
+    "performer": "Carreño, Teresa",
     "publisher": "Welte-Mignon",
     "title": "Beethoven/Carreño - Waldstein sonata: (2nd movement)",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Waldstein sonata: (2nd movement)"
   },
   {
+    "arranger": "",
+    "composer": "Beethoven, Ludwig van",
     "druid": "ph692rh6823",
-    "image_url": "https://stacks.stanford.edu/image/iiif/ph692rh6823%2Fph692rh6823_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/ph692rh6823/ph692rh6823_0001/info.json",
     "number": "2311",
+    "performer": "Del Grande, Carlo",
     "publisher": "Welte-Mignon",
     "title": "Beethoven/Del Grande - Symphonie eroica: I. Satz",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Symphonie eroica: I. Satz"
   },
   {
+    "arranger": "",
+    "composer": "Beethoven, Ludwig van",
     "druid": "dz112ky5575",
-    "image_url": "https://stacks.stanford.edu/image/iiif/dz112ky5575%2Fdz112ky5575_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/dz112ky5575/dz112ky5575_0001/info.json",
     "number": "2312",
+    "performer": "Del Grande, Carlo",
     "publisher": "Welte-Mignon",
     "title": "Beethoven/Del Grande - Symphonie eroica: II. Satz",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Symphonie eroica: II. Satz"
   },
   {
+    "arranger": "",
+    "composer": "Beethoven, Ludwig van",
     "druid": "ht339gy6128",
-    "image_url": "https://stacks.stanford.edu/image/iiif/ht339gy6128%2Fht339gy6128_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/ht339gy6128/ht339gy6128_0001/info.json",
     "number": "2313",
+    "performer": "Del Grande, Carlo",
     "publisher": "Welte-Mignon",
     "title": "Beethoven/Del Grande - Symphonie eroica: III. Satz",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Symphonie eroica: III. Satz"
   },
   {
+    "arranger": "",
+    "composer": "Beethoven, Ludwig van",
     "druid": "ks452px2704",
-    "image_url": "https://stacks.stanford.edu/image/iiif/ks452px2704%2Fks452px2704_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/ks452px2704/ks452px2704_0001/info.json",
     "number": "2314",
+    "performer": "Del Grande, Carlo",
     "publisher": "Welte-Mignon",
     "title": "Beethoven/Del Grande - Symphonie eroica: IV. Satz",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Symphonie eroica: IV. Satz"
   },
   {
+    "arranger": "",
+    "composer": "Beethoven, Ludwig van",
     "druid": "xx766cn9843",
-    "image_url": "https://stacks.stanford.edu/image/iiif/xx766cn9843%2Fxx766cn9843_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/xx766cn9843/xx766cn9843_0001/info.json",
     "number": "1326",
+    "performer": "Fryer, Herbert",
     "publisher": "Welte-Mignon",
     "title": "Beethoven/Fryer - Menuett es-dur",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Menuett es-dur"
   },
   {
+    "arranger": "",
+    "composer": "Beethoven, Ludwig van",
     "druid": "ty382mw3181",
-    "image_url": "https://stacks.stanford.edu/image/iiif/ty382mw3181%2Fty382mw3181_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/ty382mw3181/ty382mw3181_0001/info.json",
     "number": "3026",
+    "performer": "Hofmann, Josef",
     "publisher": "Welte-Mignon",
     "title": "Beethoven/Hofmann - Sonate a-dur, op. 101: I. und II. Teil",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Sonate a-dur, op. 101: I. und II. Teil"
   },
   {
+    "arranger": "",
+    "composer": "Beethoven, Ludwig van",
     "druid": "jk842rg9750",
-    "image_url": "https://stacks.stanford.edu/image/iiif/jk842rg9750%2Fjk842rg9750_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/jk842rg9750/jk842rg9750_0001/info.json",
     "number": "3027",
+    "performer": "Hofmann, Josef",
     "publisher": "Welte-Mignon",
     "title": "Beethoven/Hofmann - Sonate op. 103: III. und IV. Teil",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Sonate op. 103: III. und IV. Teil"
   },
   {
+    "arranger": "",
+    "composer": "Beethoven, Ludwig van",
     "druid": "mw870hc7232",
-    "image_url": "https://stacks.stanford.edu/image/iiif/mw870hc7232%2Fmw870hc7232_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/mw870hc7232/mw870hc7232_0001/info.json",
     "number": "3156",
+    "performer": "Kiek, Georges",
     "publisher": "Welte-Mignon",
     "title": "Beethoven/Kiek - 2nd symphony: Movements 2 & 3",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "2nd symphony: Movements 2 & 3"
   },
   {
+    "arranger": "",
+    "composer": "Beethoven, Ludwig van",
     "druid": "ch718mg2581",
-    "image_url": "https://stacks.stanford.edu/image/iiif/ch718mg2581%2Fch718mg2581_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/ch718mg2581/ch718mg2581_0001/info.json",
     "number": "284",
+    "performer": "Lambrino, Télémaque",
     "publisher": "Welte-Mignon",
     "title": "Beethoven/Lambrino - Menuett (from sonata op. 31 e flat major)",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Menuett (from sonata op. 31 e flat major)"
   },
   {
+    "arranger": "",
+    "composer": "Beethoven, Ludwig van",
     "druid": "wt621xq0875",
-    "image_url": "https://stacks.stanford.edu/image/iiif/wt621xq0875%2Fwt621xq0875_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/wt621xq0875/wt621xq0875_0001/info.json",
     "number": "561",
+    "performer": "Lamond, Frederic",
     "publisher": "Welte-Mignon",
     "title": "Beethoven/Lamond - Sonate pathétique: II. Satz",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Sonate pathétique: II. Satz"
   },
   {
+    "arranger": "",
+    "composer": "Beethoven, Ludwig van",
     "druid": "kr397bv2881",
-    "image_url": "https://stacks.stanford.edu/image/iiif/kr397bv2881%2Fkr397bv2881_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/kr397bv2881/kr397bv2881_0001/info.json",
     "number": "562",
+    "performer": "Lamond, Frederic",
     "publisher": "Welte-Mignon",
     "title": "Beethoven/Lamond - Sonate pathétique: op. 13, 3rd movement",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Sonate pathétique: op. 13, 3rd movement"
   },
   {
+    "arranger": "",
+    "composer": "Beethoven, Ludwig van",
     "druid": "dx555xv9093",
-    "image_url": "https://stacks.stanford.edu/image/iiif/dx555xv9093%2Fdx555xv9093_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/dx555xv9093/dx555xv9093_0001/info.json",
     "number": "1246",
+    "performer": "Paderewski, Ignace Jan",
     "publisher": "Welte-Mignon",
     "title": "Beethoven/Paderewski - Moonlight sonata: C sharp minor: 1st & 2nd movements",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Moonlight sonata: C sharp minor: 1st & 2nd movements"
   },
   {
+    "arranger": "",
+    "composer": "Beethoven, Ludwig van",
     "druid": "xm993qd2681",
-    "image_url": "https://stacks.stanford.edu/image/iiif/xm993qd2681%2Fxm993qd2681_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/xm993qd2681/xm993qd2681_0001/info.json",
     "number": "1247",
+    "performer": "Paderewski, Ignace Jan",
     "publisher": "Welte-Mignon",
     "title": "Beethoven/Paderewski - Sonata c sharp minor: (moonlight): Part 3",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Sonata c sharp minor: (moonlight): Part 3"
   },
   {
+    "arranger": "",
+    "composer": "Beethoven, Ludwig van",
     "druid": "yb187qn0290",
-    "image_url": "https://stacks.stanford.edu/image/iiif/yb187qn0290%2Fyb187qn0290_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/yb187qn0290/yb187qn0290_0001/info.json",
     "number": "1246",
+    "performer": "Paderewski, Ignace Jan",
     "publisher": "Welte-Mignon",
     "title": "Beethoven/Paderewski - Sonate cis-moll: (Mondschein): I. und II. Teil",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Sonate cis-moll: (Mondschein): I. und II. Teil"
   },
   {
+    "arranger": "",
+    "composer": "Beethoven, Ludwig van",
     "druid": "wp877mn0317",
-    "image_url": "https://stacks.stanford.edu/image/iiif/wp877mn0317%2Fwp877mn0317_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/wp877mn0317/wp877mn0317_0001/info.json",
     "number": "1247",
+    "performer": "Paderewski, Ignace Jan",
     "publisher": "Welte-Mignon",
     "title": "Beethoven/Paderewski - Sonate cis-moll: (Mondschein): III. Teil",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Sonate cis-moll: (Mondschein): III. Teil"
   },
   {
+    "arranger": "",
+    "composer": "Beethoven, Ludwig van",
     "druid": "ch918dn4026",
-    "image_url": "https://stacks.stanford.edu/image/iiif/ch918dn4026%2Fch918dn4026_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/ch918dn4026/ch918dn4026_0001/info.json",
     "number": "3270",
+    "performer": "Pembaur, Josef",
     "publisher": "Welte-Mignon",
     "title": "Beethoven/Pembaur - Fantasia op. 77, g minor",
-    "type": "welte-green"
+    "type": "welte-green",
+    "work": "Fantasia op. 77, g minor"
   },
   {
+    "arranger": "",
+    "composer": "Beethoven, Ludwig van",
     "druid": "wk295jd5289",
-    "image_url": "https://stacks.stanford.edu/image/iiif/wk295jd5289%2Fwk295jd5289_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/wk295jd5289/wk295jd5289_0001/info.json",
     "number": "527",
+    "performer": "Petri, Egon",
     "publisher": "Welte-Mignon",
     "title": "Beethoven/Petri - 32 variationen: c-Moll",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "32 variationen: c-Moll"
   },
   {
+    "arranger": "",
+    "composer": "Beethoven, Ludwig van",
     "druid": "pv279zy5193",
-    "image_url": "https://stacks.stanford.edu/image/iiif/pv279zy5193%2Fpv279zy5193_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/pv279zy5193/pv279zy5193_0001/info.json",
     "number": "1505",
+    "performer": "Pückler, Graf Carl von",
     "publisher": "Welte-Mignon",
     "title": "Beethoven/Pückler - Sonata appassionata: II. u. III. Teil",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Sonata appassionata: II. u. III. Teil"
   },
   {
+    "arranger": "",
+    "composer": "Beethoven, Ludwig van",
     "druid": "ns119ny6089",
-    "image_url": "https://stacks.stanford.edu/image/iiif/ns119ny6089%2Fns119ny6089_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/ns119ny6089/ns119ny6089_0001/info.json",
     "number": "184",
+    "performer": "Reinecke, Carl",
     "publisher": "Welte-Mignon",
     "title": "Beethoven/Reinecke - Ecossaisen",
-    "type": "welte-green"
+    "type": "welte-green",
+    "work": "Ecossaisen"
   },
   {
+    "arranger": "",
+    "composer": "Beethoven, Ludwig van",
     "druid": "tt435dd2897",
-    "image_url": "https://stacks.stanford.edu/image/iiif/tt435dd2897%2Ftt435dd2897_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/tt435dd2897/tt435dd2897_0001/info.json",
     "number": "326",
+    "performer": "Reisenauer, Alfred",
     "publisher": "Welte-Mignon",
     "title": "Beethoven/Reisenauer - Rondo capriccioso: G-Dur, op. 129: (Die Wut über den verlorenen Groschen)",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Rondo capriccioso: G-Dur, op. 129 : (Die Wut über den verlorenen Groschen)"
   },
   {
+    "arranger": "",
+    "composer": "Beethoven, Ludwig van",
     "druid": "wb381qd3151",
-    "image_url": "https://stacks.stanford.edu/image/iiif/wb381qd3151%2Fwb381qd3151_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/wb381qd3151/wb381qd3151_0001/info.json",
     "number": "330",
+    "performer": "Reisenauer, Alfred",
     "publisher": "Welte-Mignon",
     "title": "Beethoven/Reisenauer - Rondo op. 51",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Rondo op. 51"
   },
   {
+    "arranger": "",
+    "composer": "Beethoven, Ludwig van",
     "druid": "dp801zr4347",
-    "image_url": "https://stacks.stanford.edu/image/iiif/dp801zr4347%2Fdp801zr4347_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/dp801zr4347/dp801zr4347_0001/info.json",
     "number": "3130",
+    "performer": "Ritter, Franz",
     "publisher": "Welte-Mignon",
     "title": "Beethoven/Ritter - Leonora no. 3 overture",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Leonora no. 3 overture"
   },
   {
+    "arranger": "",
+    "composer": "Beethoven, Ludwig van",
     "druid": "gm170gy7498",
-    "image_url": "https://stacks.stanford.edu/image/iiif/gm170gy7498%2Fgm170gy7498_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/gm170gy7498/gm170gy7498_0001/info.json",
     "number": "239",
+    "performer": "Scharwenka, Xaver",
     "publisher": "Welte-Mignon",
     "title": "Beethoven/Scharwenka - Sonata appassionata, op. 57: Part 1",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Sonata appassionata, op. 57: Part 1"
   },
   {
+    "arranger": "",
+    "composer": "Beethoven, Ludwig van",
     "druid": "bf074nj8801",
-    "image_url": "https://stacks.stanford.edu/image/iiif/bf074nj8801%2Fbf074nj8801_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/bf074nj8801/bf074nj8801_0001/info.json",
     "number": "1443",
+    "performer": "Schelling, Ernest",
     "publisher": "Welte-Mignon",
     "title": "Beethoven/Schelling - Sonata appassionata: op. 57, F Minor: 2nd and 3rd movements",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Sonata appassionata: op. 57, F Minor: 2nd and 3rd movements"
   },
   {
+    "arranger": "",
+    "composer": "Beethoven, Ludwig van",
     "druid": "fz215xr4723",
-    "image_url": "https://stacks.stanford.edu/image/iiif/fz215xr4723%2Ffz215xr4723_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/fz215xr4723/fz215xr4723_0001/info.json",
     "number": "1443",
+    "performer": "Schelling, Ernest",
     "publisher": "Welte-Mignon",
     "title": "Beethoven/Schelling - Sonata appassionata: op. 57, F Minor: 2nd and 3rd movements",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Sonata appassionata: op. 57, F Minor: 2nd and 3rd movements"
   },
   {
+    "arranger": "",
+    "composer": "Beethoven, Ludwig van",
     "druid": "mh156nr8259",
-    "image_url": "https://stacks.stanford.edu/image/iiif/mh156nr8259%2Fmh156nr8259_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/mh156nr8259/mh156nr8259_0001/info.json",
     "number": "1442",
+    "performer": "Schelling, Ernest",
     "publisher": "Welte-Mignon",
     "title": "Beethoven/Schelling - Sonata appassionata: op. 57, F minor: 1st movement",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Sonata appassionata: op. 57, F minor: 1st movement"
   },
   {
+    "arranger": "",
+    "composer": "Berlin, Irving",
     "druid": "pp798fc0175",
-    "image_url": "https://stacks.stanford.edu/image/iiif/pp798fc0175%2Fpp798fc0175_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/pp798fc0175/pp798fc0175_0001/info.json",
     "number": "5667",
+    "performer": "Haass, Hans",
     "publisher": "Welte-Mignon",
     "title": "Berlin/Haass - All alone: waltz",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "All alone: waltz"
   },
   {
+    "arranger": "",
+    "composer": "Berlin, Irving",
     "druid": "bz327kz4744",
-    "image_url": "https://stacks.stanford.edu/image/iiif/bz327kz4744%2Fbz327kz4744_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/bz327kz4744/bz327kz4744_0001/info.json",
     "number": "5634",
+    "performer": "Hare, John",
     "publisher": "Welte-Mignon",
     "title": "Berlin/Hare - What'll i do: waltz",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "What'll i do: waltz"
   },
   {
+    "arranger": "Liszt, Franz",
+    "composer": "Berlioz, Hector",
     "druid": "dr971dy1221",
-    "image_url": "https://stacks.stanford.edu/image/iiif/dr971dy1221%2Fdr971dy1221_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/dr971dy1221/dr971dy1221_0001/info.json",
     "number": "965",
+    "performer": "Landowska, Wanda",
     "publisher": "Welte-Mignon",
     "title": "Berlioz-Liszt/Landowska - Ballet des sylves",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Ballet des sylves"
   },
   {
+    "arranger": "",
+    "composer": "Bizet, Georges",
     "druid": "kt852zf4103",
-    "image_url": "https://stacks.stanford.edu/image/iiif/kt852zf4103%2Fkt852zf4103_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/kt852zf4103/kt852zf4103_0001/info.json",
     "number": "137",
+    "performer": "Adam-Benard, Eugenie",
     "publisher": "Welte-Mignon",
     "title": "Bizet/Adam-Benard - Carmens lied: tralalala",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Carmens lied: tralalala"
   },
   {
+    "arranger": "",
+    "composer": "Bizet, Georges",
     "druid": "tp747vf1137",
-    "image_url": "https://stacks.stanford.edu/image/iiif/tp747vf1137%2Ftp747vf1137_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/tp747vf1137/tp747vf1137_0001/info.json",
     "number": "163",
+    "performer": "Adam-Benard, Eugenie",
     "publisher": "Welte-Mignon",
     "title": "Bizet/Adam-Benard - Lied des don josé und duo aus carmen: 2. Akt (Carmens Tanz)",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Lied des don josé und duo aus carmen: 2. Akt (Carmens Tanz)"
   },
   {
+    "arranger": "",
+    "composer": "Bizet, Georges",
     "druid": "gr034qm4805",
-    "image_url": "https://stacks.stanford.edu/image/iiif/gr034qm4805%2Fgr034qm4805_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/gr034qm4805/gr034qm4805_0001/info.json",
     "number": "1593",
+    "performer": "Francklyn, Bernard",
     "publisher": "Welte-Mignon",
     "title": "Bizet/Francklyn - Carmen: selection",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Carmen: selection"
   },
   {
+    "arranger": "",
+    "composer": "Blaufuss, Walter",
     "druid": "xg976jt9573",
-    "image_url": "https://stacks.stanford.edu/image/iiif/xg976jt9573%2Fxg976jt9573_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/xg976jt9573/xg976jt9573_0001/info.json",
     "number": "5521",
+    "performer": "Dark, Henry",
     "publisher": "Welte-Mignon",
     "title": "Blaufuss/Dark - My isle of golden dreams: waltz",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "My isle of golden dreams: waltz"
   },
   {
+    "arranger": "",
+    "composer": "Borel-Clerc, Charles",
     "druid": "ps108fn1431",
-    "image_url": "https://stacks.stanford.edu/image/iiif/ps108fn1431%2Fps108fn1431_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/ps108fn1431/ps108fn1431_0001/info.json",
     "number": "1288",
+    "performer": "Fichter, Bella",
     "publisher": "Welte-Mignon",
     "title": "Borel-Clerc/Fichter - La Mattchiche",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "La Mattchiche"
   },
   {
+    "arranger": "",
+    "composer": "Brahms, Johannes",
     "druid": "rk591jt8964",
-    "image_url": "https://stacks.stanford.edu/image/iiif/rk591jt8964%2Frk591jt8964_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/rk591jt8964/rk591jt8964_0001/info.json",
     "number": "1148",
+    "performer": "Carreño, Teresa",
     "publisher": "Welte-Mignon",
     "title": "Brahms/Carreño - Sonata f minor, op. 5, 1st movement",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Sonata f minor, op. 5, 1st movement"
   },
   {
+    "arranger": "",
+    "composer": "Brahms, Johannes",
     "druid": "jj589sc7898",
-    "image_url": "https://stacks.stanford.edu/image/iiif/jj589sc7898%2Fjj589sc7898_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/jj589sc7898/jj589sc7898_0001/info.json",
     "number": "497",
+    "performer": "Dohnányi, Ernő",
     "publisher": "Welte-Mignon",
     "title": "Brahms/Dohnányi - Cappriccio op. 76, no. 2",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Cappriccio op. 76, no. 2"
   },
   {
+    "arranger": "",
+    "composer": "Brahms, Johannes",
     "druid": "yw484ky7093",
-    "image_url": "https://stacks.stanford.edu/image/iiif/yw484ky7093%2Fyw484ky7093_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/yw484ky7093/yw484ky7093_0001/info.json",
     "number": "589",
+    "performer": "Galston, Gottfried",
     "publisher": "Welte-Mignon",
     "title": "Brahms/Galston - Waltzes op. 39, 6 and 11",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Waltzes op. 39, 6 and 11"
   },
   {
+    "arranger": "",
+    "composer": "Brahms, Johannes",
     "druid": "tx437pj1389",
-    "image_url": "https://stacks.stanford.edu/image/iiif/tx437pj1389%2Ftx437pj1389_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/tx437pj1389/tx437pj1389_0001/info.json",
     "number": "1108",
+    "performer": "Ney, Elly",
     "publisher": "Welte-Mignon",
     "title": "Brahms/Ney - Sonata f minor, op. 5: 2nd movement",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Sonata f minor, op. 5: 2nd movement"
   },
   {
+    "arranger": "",
+    "composer": "Brahms, Johannes",
     "druid": "dc661yr7679",
-    "image_url": "https://stacks.stanford.edu/image/iiif/dc661yr7679%2Fdc661yr7679_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/dc661yr7679/dc661yr7679_0001/info.json",
     "number": "1085",
+    "performer": "Nikisch, Arthur",
     "publisher": "Welte-Mignon",
     "title": "Brahms/Nikisch - Ungarischer tanz: No. 1",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Ungarischer tanz: No. 1"
   },
   {
+    "arranger": "",
+    "composer": "Brahms, Johannes",
     "druid": "jf938sf5847",
-    "image_url": "https://stacks.stanford.edu/image/iiif/jf938sf5847%2Fjf938sf5847_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/jf938sf5847/jf938sf5847_0001/info.json",
     "number": "2555",
+    "performer": "Paur, Emil",
     "publisher": "Welte-Mignon",
     "title": "Brahms/Paur - Intermezzo op. 76, no. 2",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Intermezzo op. 76, no. 2"
   },
   {
+    "arranger": "",
+    "composer": "Brahms, Johannes",
     "druid": "rk796xd9697",
-    "image_url": "https://stacks.stanford.edu/image/iiif/rk796xd9697%2Frk796xd9697_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/rk796xd9697/rk796xd9697_0001/info.json",
     "number": "1476",
+    "performer": "Samaroff Stokowski, Olga",
     "publisher": "Welte-Mignon",
     "title": "Brahms/Samaroff Stokowski - Ii. rhapsodie",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Ii. rhapsodie"
   },
   {
+    "arranger": "",
+    "composer": "Caballero, M. F. (Manuel Fernández), 1835-1906",
     "druid": "ht999gf1829",
-    "image_url": "https://stacks.stanford.edu/image/iiif/ht999gf1829%2Fht999gf1829_0002/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/ht999gf1829/ht999gf1829_0002/info.json",
     "number": "2191",
+    "performer": "",
     "publisher": "Princesa",
     "title": "Caballero - Gigantes y cabezudos: selección",
-    "type": "88-note"
+    "type": "88-note",
+    "work": "Gigantes y cabezudos: selección"
   },
   {
+    "arranger": "Cady, Harriette",
+    "composer": "",
     "druid": "rv703vf3503",
-    "image_url": "https://stacks.stanford.edu/image/iiif/rv703vf3503%2Frv703vf3503_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/rv703vf3503/rv703vf3503_0001/info.json",
     "number": "3042",
+    "performer": "Ganz, Rudolph",
     "publisher": "Welte-Mignon",
     "title": "Cady/Ganz - Song of the boatmen of the volga =: (Schifferlied auf der Wolga)",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Song of the boatmen of the volga =: (Schifferlied auf der Wolga)"
   },
   {
+    "arranger": "",
+    "composer": "Chaminade, Cécile",
     "druid": "jc718cb5784",
-    "image_url": "https://stacks.stanford.edu/image/iiif/jc718cb5784%2Fjc718cb5784_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/jc718cb5784/jc718cb5784_0001/info.json",
     "number": "2594",
+    "performer": "Bloomfield-Zeisler, Fannie",
     "publisher": "Welte-Mignon",
     "title": "Chaminade/Bloomfield-Zeisler - Le Retour",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Le Retour"
   },
   {
+    "arranger": "",
+    "composer": "Chaminade, Cécile",
     "druid": "cd435bw2771",
-    "image_url": "https://stacks.stanford.edu/image/iiif/cd435bw2771%2Fcd435bw2771_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/cd435bw2771/cd435bw2771_0001/info.json",
     "number": "2539",
+    "performer": "Mero, Yolanda",
     "publisher": "Welte-Mignon",
     "title": "Chaminade/Mero - Arlequine",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Arlequine"
   },
   {
+    "arranger": "",
+    "composer": "Chaminade, Cécile",
     "druid": "rx933wn3761",
-    "image_url": "https://stacks.stanford.edu/image/iiif/rx933wn3761%2Frx933wn3761_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/rx933wn3761/rx933wn3761_0001/info.json",
     "number": "2537",
+    "performer": "Mero, Yolanda",
     "publisher": "Welte-Mignon",
     "title": "Chaminade/Mero - Automne: op. 35, no. 2",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Automne: op. 35, no. 2"
   },
   {
+    "arranger": "",
+    "composer": "Chaminade, Cécile",
     "druid": "cw378sb0125",
-    "image_url": "https://stacks.stanford.edu/image/iiif/cw378sb0125%2Fcw378sb0125_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/cw378sb0125/cw378sb0125_0001/info.json",
     "number": "2538",
+    "performer": "Mero, Yolanda",
     "publisher": "Welte-Mignon",
     "title": "Chaminade/Mero - Elevation: op. 76, no. 2",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Elevation: op. 76, no. 2"
   },
   {
+    "arranger": "",
+    "composer": "Chaminade, Cécile",
     "druid": "tm408mz6807",
-    "image_url": "https://stacks.stanford.edu/image/iiif/tm408mz6807%2Ftm408mz6807_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/tm408mz6807/tm408mz6807_0001/info.json",
     "number": "2538",
+    "performer": "Mero, Yolanda",
     "publisher": "Welte-Mignon",
     "title": "Chaminade/Mero - Elévation: romance sans paroles: op. 76, no. 2",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Elévation: romance sans paroles : op. 76, no. 2"
   },
   {
+    "arranger": "",
+    "composer": "Chaminade, Cécile",
     "druid": "tr243mz6407",
-    "image_url": "https://stacks.stanford.edu/image/iiif/tr243mz6407%2Ftr243mz6407_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/tr243mz6407/tr243mz6407_0001/info.json",
     "number": "2540",
+    "performer": "Mero, Yolanda",
     "publisher": "Welte-Mignon",
     "title": "Chaminade/Mero - La Lisonjera",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "La Lisonjera"
   },
   {
+    "arranger": "",
+    "composer": "Chaminade, Cécile",
     "druid": "zf037wk3650",
-    "image_url": "https://stacks.stanford.edu/image/iiif/zf037wk3650%2Fzf037wk3650_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/zf037wk3650/zf037wk3650_0001/info.json",
     "number": "1127",
+    "performer": "Uzielli, Lazzaro",
     "publisher": "Welte-Mignon",
     "title": "Chaminade/Uzielli - Pierrette: air de ballet, op. 41",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Pierrette: air de ballet, op. 41"
   },
   {
+    "arranger": "",
+    "composer": "Chapí, Ruperto, 1851-1909",
     "druid": "ms604gp1206",
-    "image_url": "https://stacks.stanford.edu/image/iiif/ms604gp1206%2Fms604gp1206_0002/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/ms604gp1206/ms604gp1206_0002/info.json",
     "number": "4466",
+    "performer": "",
     "publisher": "Princesa",
     "title": "Chapí - El Puñao de rosas: selecciones",
-    "type": "88-note"
+    "type": "88-note",
+    "work": "El Puñao de rosas: selecciones"
   },
   {
+    "arranger": "",
+    "composer": "Chapí, Ruperto, 1851-1909",
     "druid": "br351xc9456",
-    "image_url": "https://stacks.stanford.edu/image/iiif/br351xc9456%2Fbr351xc9456_0002/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/br351xc9456/br351xc9456_0002/info.json",
     "number": "1944",
+    "performer": "",
     "publisher": "Princesa",
     "title": "Chapí - La Tempestad: valses sobre varios motivos",
-    "type": "88-note"
+    "type": "88-note",
+    "work": "La Tempestad: valses sobre varios motivos"
   },
   {
+    "arranger": "",
+    "composer": "Chopin, Frédéric, 1810-1849",
     "druid": "wx138dx1211",
-    "image_url": "https://stacks.stanford.edu/image/iiif/wx138dx1211%2Fwx138dx1211_0002/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/wx138dx1211/wx138dx1211_0002/info.json",
     "number": "4108",
+    "performer": "",
     "publisher": "Victoria",
     "title": "Chopin - Nocturno, op. 15, no 1, en fa",
-    "type": "88-note"
+    "type": "88-note",
+    "work": "Nocturno, op. 15, no 1, en fa"
   },
   {
+    "arranger": "Backhaus, Wilhelm",
+    "composer": "Chopin, Frédéric",
     "druid": "zp866tm4852",
-    "image_url": "https://stacks.stanford.edu/image/iiif/zp866tm4852%2Fzp866tm4852_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/zp866tm4852/zp866tm4852_0001/info.json",
     "number": "3310",
+    "performer": "Backhaus, Wilhelm",
     "publisher": "Welte-Mignon",
     "title": "Chopin-Backhaus/Backhaus - Pianoforte concerto op. ii, e minor: 2nd movement",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Pianoforte concerto op. ii, e minor: 2nd movement"
   },
   {
+    "arranger": "Backhaus, Wilhelm",
+    "composer": "Chopin, Frédéric",
     "druid": "qd784zj3903",
-    "image_url": "https://stacks.stanford.edu/image/iiif/qd784zj3903%2Fqd784zj3903_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/qd784zj3903/qd784zj3903_0001/info.json",
     "number": "3310",
+    "performer": "Backhaus, Wilhelm",
     "publisher": "Welte-Mignon",
     "title": "Chopin-Backhaus/Backhaus - Romanze a. e-moll konzert: II. Satz",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Romanze a. e-moll konzert: II. Satz"
   },
   {
+    "arranger": "",
+    "composer": "Chopin, Frédéric",
     "druid": "nq628rc4181",
-    "image_url": "https://stacks.stanford.edu/image/iiif/nq628rc4181%2Fnq628rc4181_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/nq628rc4181/nq628rc4181_0001/info.json",
     "number": "83",
+    "performer": "Adam-Benard, Eugenie",
     "publisher": "Welte-Mignon",
     "title": "Chopin/Adam-Benard - Nocturne op. 9, no. 2, e flat major",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Nocturne op. 9, no. 2, e flat major"
   },
   {
+    "arranger": "",
+    "composer": "Chopin, Frédéric",
     "druid": "gf160gq3516",
-    "image_url": "https://stacks.stanford.edu/image/iiif/gf160gq3516%2Fgf160gq3516_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/gf160gq3516/gf160gq3516_0001/info.json",
     "number": "2979",
+    "performer": "Albert, Eugen d'",
     "publisher": "Welte-Mignon",
     "title": "Chopin/Albert - Nocturne op. 9, no. 1, b-flat minor",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Nocturne op. 9, no. 1, b-flat minor"
   },
   {
+    "arranger": "",
+    "composer": "Chopin, Frédéric",
     "druid": "fr853pn6519",
-    "image_url": "https://stacks.stanford.edu/image/iiif/fr853pn6519%2Ffr853pn6519_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/fr853pn6519/fr853pn6519_0001/info.json",
     "number": "419",
+    "performer": "Albert, Eugen d'",
     "publisher": "Welte-Mignon",
     "title": "Chopin/Albert - Polonaise op. 53, a flat",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Polonaise op. 53, a flat"
   },
   {
+    "arranger": "",
+    "composer": "Chopin, Frédéric",
     "druid": "pj688nx2384",
-    "image_url": "https://stacks.stanford.edu/image/iiif/pj688nx2384%2Fpj688nx2384_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/pj688nx2384/pj688nx2384_0001/info.json",
     "number": "1464",
+    "performer": "Bloomfield-Zeisler, Fannie",
     "publisher": "Welte-Mignon",
     "title": "Chopin/Bloomfield-Zeisler - Scherzo b-moll",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Scherzo b-moll"
   },
   {
+    "arranger": "",
+    "composer": "Chopin, Frédéric",
     "druid": "fh358rd2268",
-    "image_url": "https://stacks.stanford.edu/image/iiif/fh358rd2268%2Ffh358rd2268_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/fh358rd2268/fh358rd2268_0001/info.json",
     "number": "2586",
+    "performer": "Bloomfield-Zeisler, Fannie",
     "publisher": "Welte-Mignon",
     "title": "Chopin/Bloomfield-Zeisler - Sonata op. 35, b minor: Part 1",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Sonata op. 35, b minor: Part 1"
   },
   {
+    "arranger": "",
+    "composer": "Chopin, Frédéric",
     "druid": "kw738fg7467",
-    "image_url": "https://stacks.stanford.edu/image/iiif/kw738fg7467%2Fkw738fg7467_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/kw738fg7467/kw738fg7467_0001/info.json",
     "number": "2588",
+    "performer": "Bloomfield-Zeisler, Fannie",
     "publisher": "Welte-Mignon",
     "title": "Chopin/Bloomfield-Zeisler - Sonata op. 35: Funeralmarch and Presto",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Sonata op. 35: Funeralmarch and Presto"
   },
   {
+    "arranger": "",
+    "composer": "Chopin, Frédéric",
     "druid": "zw904vm6502",
-    "image_url": "https://stacks.stanford.edu/image/iiif/zw904vm6502%2Fzw904vm6502_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/zw904vm6502/zw904vm6502_0001/info.json",
     "number": "1465",
+    "performer": "Bloomfield-Zeisler, Fannie",
     "publisher": "Welte-Mignon",
     "title": "Chopin/Bloomfield-Zeisler - Waltz, op. 70, no. 1",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Waltz, op. 70, no. 1"
   },
   {
+    "arranger": "",
+    "composer": "Chopin, Frédéric",
     "druid": "wz719qg6993",
-    "image_url": "https://stacks.stanford.edu/image/iiif/wz719qg6993%2Fwz719qg6993_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/wz719qg6993/wz719qg6993_0001/info.json",
     "number": "441",
+    "performer": "Busoni, Ferruccio",
     "publisher": "Welte-Mignon",
     "title": "Chopin/Busoni - Nocturne op. 15, no. 2, fis-dur",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Nocturne op. 15, no. 2, fis-dur"
   },
   {
+    "arranger": "",
+    "composer": "Chopin, Frédéric",
     "druid": "gc795vb4435",
-    "image_url": "https://stacks.stanford.edu/image/iiif/gc795vb4435%2Fgc795vb4435_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/gc795vb4435/gc795vb4435_0001/info.json",
     "number": "1319",
+    "performer": "Busoni, Ferruccio",
     "publisher": "Welte-Mignon",
     "title": "Chopin/Busoni - Prelude op. 28, nr. 15, d flat",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Prelude op. 28, nr. 15, d flat"
   },
   {
+    "arranger": "",
+    "composer": "Chopin, Frédéric",
     "druid": "sn610pr8684",
-    "image_url": "https://stacks.stanford.edu/image/iiif/sn610pr8684%2Fsn610pr8684_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/sn610pr8684/sn610pr8684_0001/info.json",
     "number": "3184",
+    "performer": "Carreras, Maria",
     "publisher": "Welte-Mignon",
     "title": "Chopin/Carreras - Preludes: No. 3, G major; No. 6, B minor",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Preludes: No. 3, G major ; No. 6, B minor"
   },
   {
+    "arranger": "",
+    "composer": "Chopin, Frédéric",
     "druid": "bj606rp8160",
-    "image_url": "https://stacks.stanford.edu/image/iiif/bj606rp8160%2Fbj606rp8160_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/bj606rp8160/bj606rp8160_0001/info.json",
     "number": "367",
+    "performer": "Carreño, Teresa",
     "publisher": "Welte-Mignon",
     "title": "Chopin/Carreño - Ballade op. 23, g minor",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Ballade op. 23, g minor"
   },
   {
+    "arranger": "",
+    "composer": "Chopin, Frédéric",
     "druid": "rj799hj0968",
-    "image_url": "https://stacks.stanford.edu/image/iiif/rj799hj0968%2Frj799hj0968_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/rj799hj0968/rj799hj0968_0001/info.json",
     "number": "364",
+    "performer": "Carreño, Teresa",
     "publisher": "Welte-Mignon",
     "title": "Chopin/Carreño - Nocturne g major, op. 37, no. 2",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Nocturne g major, op. 37, no. 2"
   },
   {
+    "arranger": "",
+    "composer": "Chopin, Frédéric",
     "druid": "st828pc9818",
-    "image_url": "https://stacks.stanford.edu/image/iiif/st828pc9818%2Fst828pc9818_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/st828pc9818/st828pc9818_0001/info.json",
     "number": "364",
+    "performer": "Carreño, Teresa",
     "publisher": "Welte-Mignon",
     "title": "Chopin/Carreño - Nocturne op. 37, no. 2, g major",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Nocturne op. 37, no. 2, g major"
   },
   {
+    "arranger": "",
+    "composer": "Chopin, Frédéric",
     "druid": "gs556hk6631",
-    "image_url": "https://stacks.stanford.edu/image/iiif/gs556hk6631%2Fgs556hk6631_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/gs556hk6631/gs556hk6631_0001/info.json",
     "number": "366",
+    "performer": "Carreño, Teresa",
     "publisher": "Welte-Mignon",
     "title": "Chopin/Carreño - Nocturne op. 48, no. 1, c minor",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Nocturne op. 48, no. 1, c minor"
   },
   {
+    "arranger": "",
+    "composer": "Chopin, Frédéric",
     "druid": "wg598sj1504",
-    "image_url": "https://stacks.stanford.edu/image/iiif/wg598sj1504%2Fwg598sj1504_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/wg598sj1504/wg598sj1504_0001/info.json",
     "number": "2621",
+    "performer": "Di Benici, Tosta",
     "publisher": "Welte-Mignon",
     "title": "Chopin/Di Benici - Etude ges dur, op. 10, no. 5: (Schwarze Tasten)",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Etude ges dur, op. 10, no. 5: (Schwarze Tasten)"
   },
   {
+    "arranger": "",
+    "composer": "Chopin, Frédéric",
     "druid": "jm300wy4714",
-    "image_url": "https://stacks.stanford.edu/image/iiif/jm300wy4714%2Fjm300wy4714_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/jm300wy4714/jm300wy4714_0001/info.json",
     "number": "2622",
+    "performer": "Di Benici, Tosta",
     "publisher": "Welte-Mignon",
     "title": "Chopin/Di Benici - Prelude op. 28, no. 18, f minor",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Prelude op. 28, no. 18, f minor"
   },
   {
+    "arranger": "",
+    "composer": "Chopin, Frédéric",
     "druid": "nf733yv1324",
-    "image_url": "https://stacks.stanford.edu/image/iiif/nf733yv1324%2Fnf733yv1324_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/nf733yv1324/nf733yv1324_0001/info.json",
     "number": "498",
+    "performer": "Dohnányi, Ernő",
     "publisher": "Welte-Mignon",
     "title": "Chopin/Dohnányi - Valse op. 64, no. 2, cis-moll",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Valse op. 64, no. 2, cis-moll"
   },
   {
+    "arranger": "",
+    "composer": "Chopin, Frédéric",
     "druid": "kv601my2750",
-    "image_url": "https://stacks.stanford.edu/image/iiif/kv601my2750%2Fkv601my2750_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/kv601my2750/kv601my2750_0001/info.json",
     "number": "1077",
+    "performer": "Esipova, Anna Nikolaevna",
     "publisher": "Welte-Mignon",
     "title": "Chopin/Esipova - Prelude, a flat major",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Prelude, a flat major"
   },
   {
+    "arranger": "",
+    "composer": "Chopin, Frédéric",
     "druid": "gs573tj9547",
-    "image_url": "https://stacks.stanford.edu/image/iiif/gs573tj9547%2Fgs573tj9547_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/gs573tj9547/gs573tj9547_0001/info.json",
     "number": "1328",
+    "performer": "Fryer, Herbert",
     "publisher": "Welte-Mignon",
     "title": "Chopin/Fryer - Preludes op. 28, nos. 6 & 11",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Preludes op. 28, nos. 6 & 11"
   },
   {
+    "arranger": "",
+    "composer": "Chopin, Frédéric",
     "druid": "mj416dn1432",
-    "image_url": "https://stacks.stanford.edu/image/iiif/mj416dn1432%2Fmj416dn1432_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/mj416dn1432/mj416dn1432_0001/info.json",
     "number": "594",
+    "performer": "Galston, Gottfried",
     "publisher": "Welte-Mignon",
     "title": "Chopin/Galston - Etude op. 10, no. 12: (Revolutions-Etude)",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Etude op. 10, no. 12: (Revolutions-Etude)"
   },
   {
+    "arranger": "",
+    "composer": "Chopin, Frédéric",
     "druid": "qf640sj3141",
-    "image_url": "https://stacks.stanford.edu/image/iiif/qf640sj3141%2Fqf640sj3141_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/qf640sj3141/qf640sj3141_0001/info.json",
     "number": "2159",
+    "performer": "Goraïnoff, Irina",
     "publisher": "Welte-Mignon",
     "title": "Chopin/Goraïnoff - Concert e-moll, op. 11: 1. Teil",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Concert e-moll, op. 11: 1. Teil"
   },
   {
+    "arranger": "",
+    "composer": "Chopin, Frédéric",
     "druid": "bs279zc9206",
-    "image_url": "https://stacks.stanford.edu/image/iiif/bs279zc9206%2Fbs279zc9206_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/bs279zc9206/bs279zc9206_0001/info.json",
     "number": "2160",
+    "performer": "Goraïnoff, Irina",
     "publisher": "Welte-Mignon",
     "title": "Chopin/Goraïnoff - Concerto e minor: Part II",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Concerto e minor: Part II"
   },
   {
+    "arranger": "",
+    "composer": "Chopin, Frédéric",
     "druid": "yk477xx5343",
-    "image_url": "https://stacks.stanford.edu/image/iiif/yk477xx5343%2Fyk477xx5343_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/yk477xx5343/yk477xx5343_0001/info.json",
     "number": "2161",
+    "performer": "Goraïnoff, Irina",
     "publisher": "Welte-Mignon",
     "title": "Chopin/Goraïnoff - Concerto op. 11, e minor: 3rd movement",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Concerto op. 11, e minor: 3rd movement"
   },
   {
+    "arranger": "",
+    "composer": "Chopin, Frédéric",
     "druid": "gg384dv5303",
-    "image_url": "https://stacks.stanford.edu/image/iiif/gg384dv5303%2Fgg384dv5303_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/gg384dv5303/gg384dv5303_0001/info.json",
     "number": "194",
+    "performer": "Grünfeld, Alfred",
     "publisher": "Welte-Mignon",
     "title": "Chopin/Grünfeld - Nocturne h-dur op. 32",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Nocturne h-dur op. 32"
   },
   {
+    "arranger": "",
+    "composer": "Chopin, Frédéric",
     "druid": "wj177bx9196",
-    "image_url": "https://stacks.stanford.edu/image/iiif/wj177bx9196%2Fwj177bx9196_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/wj177bx9196/wj177bx9196_0001/info.json",
     "number": "931",
+    "performer": "Hambourg, Mark",
     "publisher": "Welte-Mignon",
     "title": "Chopin/Hambourg - Mazurka a-moll: (posthume)",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Mazurka a-moll: (posthume)"
   },
   {
+    "arranger": "",
+    "composer": "Chopin, Frédéric",
     "druid": "vs167qc5364",
-    "image_url": "https://stacks.stanford.edu/image/iiif/vs167qc5364%2Fvs167qc5364_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/vs167qc5364/vs167qc5364_0001/info.json",
     "number": "668",
+    "performer": "Hofmann, Josef",
     "publisher": "Welte-Mignon",
     "title": "Chopin/Hofmann - Nocturne, d flat major, op. 27, no. 2",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Nocturne, d flat major, op. 27, no. 2"
   },
   {
+    "arranger": "",
+    "composer": "Chopin, Frédéric",
     "druid": "qq244fh1388",
-    "image_url": "https://stacks.stanford.edu/image/iiif/qq244fh1388%2Fqq244fh1388_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/qq244fh1388/qq244fh1388_0001/info.json",
     "number": "669",
+    "performer": "Hofmann, Josef",
     "publisher": "Welte-Mignon",
     "title": "Chopin/Hofmann - Polonaise op. 44, fis-moll",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Polonaise op. 44, fis-moll"
   },
   {
+    "arranger": "",
+    "composer": "Chopin, Frédéric",
     "druid": "xm418xm6937",
-    "image_url": "https://stacks.stanford.edu/image/iiif/xm418xm6937%2Fxm418xm6937_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/xm418xm6937/xm418xm6937_0001/info.json",
     "number": "3976",
+    "performer": "Koczalski, Raoul",
     "publisher": "Welte-Mignon",
     "title": "Chopin/Koczalski - Concerto op. 11, e minor, 1st movement: Allegro maestoso",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Concerto op. 11, e minor, 1st movement: Allegro maestoso"
   },
   {
+    "arranger": "",
+    "composer": "Chopin, Frédéric",
     "druid": "nf274ng7905",
-    "image_url": "https://stacks.stanford.edu/image/iiif/nf274ng7905%2Fnf274ng7905_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/nf274ng7905/nf274ng7905_0001/info.json",
     "number": "209",
+    "performer": "Krah, Alexander",
     "publisher": "Welte-Mignon",
     "title": "Chopin/Krah - Nocturne op. 55, no. 2, e flat major",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Nocturne op. 55, no. 2, e flat major"
   },
   {
+    "arranger": "",
+    "composer": "Chopin, Frédéric",
     "druid": "kt780tm7975",
-    "image_url": "https://stacks.stanford.edu/image/iiif/kt780tm7975%2Fkt780tm7975_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/kt780tm7975/kt780tm7975_0001/info.json",
     "number": "568",
+    "performer": "Lamond, Frederic",
     "publisher": "Welte-Mignon",
     "title": "Chopin/Lamond - Valse op. 70",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Valse op. 70"
   },
   {
+    "arranger": "",
+    "composer": "Chopin, Frédéric",
     "druid": "bm016sg7202",
-    "image_url": "https://stacks.stanford.edu/image/iiif/bm016sg7202%2Fbm016sg7202_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/bm016sg7202/bm016sg7202_0001/info.json",
     "number": "1671",
+    "performer": "Margolies, Vera",
     "publisher": "Welte-Mignon",
     "title": "Chopin/Margolies - Polonaise: (polonaise militaire): op. 40, no. 1",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Polonaise: (polonaise militaire) : op. 40, no. 1"
   },
   {
+    "arranger": "",
+    "composer": "Chopin, Frédéric",
     "druid": "ym117yd8356",
-    "image_url": "https://stacks.stanford.edu/image/iiif/ym117yd8356%2Fym117yd8356_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/ym117yd8356/ym117yd8356_0001/info.json",
     "number": "1670",
+    "performer": "Margolies, Vera",
     "publisher": "Welte-Mignon",
     "title": "Chopin/Margolies - Sonata b-moll, op. 35: Parts 2, 3, & 4",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Sonata b-moll, op. 35: Parts 2, 3, & 4"
   },
   {
+    "arranger": "",
+    "composer": "Chopin, Frédéric",
     "druid": "xc665jf8254",
-    "image_url": "https://stacks.stanford.edu/image/iiif/xc665jf8254%2Fxc665jf8254_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/xc665jf8254/xc665jf8254_0001/info.json",
     "number": "719",
+    "performer": "Motta, José Vianna da",
     "publisher": "Welte-Mignon",
     "title": "Chopin/Motta - Scherzo e-dur, op. 54",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Scherzo e-dur, op. 54"
   },
   {
+    "arranger": "",
+    "composer": "Chopin, Frédéric",
     "druid": "ky458kj7325",
-    "image_url": "https://stacks.stanford.edu/image/iiif/ky458kj7325%2Fky458kj7325_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/ky458kj7325/ky458kj7325_0001/info.json",
     "number": "2882",
+    "performer": "Novaes, Guiomar",
     "publisher": "Welte-Mignon",
     "title": "Chopin/Novaes - Ballade, op. 47, a major",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Ballade, op. 47, a major"
   },
   {
+    "arranger": "",
+    "composer": "Chopin, Frédéric",
     "druid": "wq296df7434",
-    "image_url": "https://stacks.stanford.edu/image/iiif/wq296df7434%2Fwq296df7434_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/wq296df7434/wq296df7434_0001/info.json",
     "number": "1212",
+    "performer": "Pachmann, Vladimir de",
     "publisher": "Welte-Mignon",
     "title": "Chopin/Pachmann - Prelude op. 28, no. 16, b-flat minor",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Prelude op. 28, no. 16, b-flat minor"
   },
   {
+    "arranger": "",
+    "composer": "Chopin, Frédéric",
     "druid": "fn111kx0654",
-    "image_url": "https://stacks.stanford.edu/image/iiif/fn111kx0654%2Ffn111kx0654_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/fn111kx0654/fn111kx0654_0001/info.json",
     "number": "1213",
+    "performer": "Pachmann, Vladimir de",
     "publisher": "Welte-Mignon",
     "title": "Chopin/Pachmann - Prélude op. 28, no. 20, c-moll",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Prélude op. 28, no. 20, c-moll"
   },
   {
+    "arranger": "",
+    "composer": "Chopin, Frédéric",
     "druid": "cw078rn1143",
-    "image_url": "https://stacks.stanford.edu/image/iiif/cw078rn1143%2Fcw078rn1143_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/cw078rn1143/cw078rn1143_0001/info.json",
     "number": "1220",
+    "performer": "Pachmann, Vladimir de",
     "publisher": "Welte-Mignon",
     "title": "Chopin/Pachmann - Waltz, d flat major, op. 64, no. 1",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Waltz, d flat major, op. 64, no. 1"
   },
   {
+    "arranger": "",
+    "composer": "Chopin, Frédéric",
     "druid": "hc229ht1024",
-    "image_url": "https://stacks.stanford.edu/image/iiif/hc229ht1024%2Fhc229ht1024_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/hc229ht1024/hc229ht1024_0001/info.json",
     "number": "1249",
+    "performer": "Paderewski, Ignace Jan",
     "publisher": "Welte-Mignon",
     "title": "Chopin/Paderewski - Ballade op. 47, a flat major",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Ballade op. 47, a flat major"
   },
   {
+    "arranger": "",
+    "composer": "Chopin, Frédéric",
     "druid": "qv334zb6243",
-    "image_url": "https://stacks.stanford.edu/image/iiif/qv334zb6243%2Fqv334zb6243_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/qv334zb6243/qv334zb6243_0001/info.json",
     "number": "1254",
+    "performer": "Paderewski, Ignace Jan",
     "publisher": "Welte-Mignon",
     "title": "Chopin/Paderewski - Etude e-dur, op. 10, no. 3",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Etude e-dur, op. 10, no. 3"
   },
   {
+    "arranger": "",
+    "composer": "Chopin, Frédéric",
     "druid": "ft746ns5736",
-    "image_url": "https://stacks.stanford.edu/image/iiif/ft746ns5736%2Fft746ns5736_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/ft746ns5736/ft746ns5736_0001/info.json",
     "number": "1253",
+    "performer": "Paderewski, Ignace Jan",
     "publisher": "Welte-Mignon",
     "title": "Chopin/Paderewski - Etude op. 25, no. 9, g flat",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Etude op. 25, no. 9, g flat"
   },
   {
+    "arranger": "",
+    "composer": "Chopin, Frédéric",
     "druid": "sm246yb9650",
-    "image_url": "https://stacks.stanford.edu/image/iiif/sm246yb9650%2Fsm246yb9650_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/sm246yb9650/sm246yb9650_0001/info.json",
     "number": "1256",
+    "performer": "Paderewski, Ignace Jan",
     "publisher": "Welte-Mignon",
     "title": "Chopin/Paderewski - Polonaise a flat major, op. 53",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Polonaise a flat major, op. 53"
   },
   {
+    "arranger": "",
+    "composer": "Chopin, Frédéric",
     "druid": "zc614qh7060",
-    "image_url": "https://stacks.stanford.edu/image/iiif/zc614qh7060%2Fzc614qh7060_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/zc614qh7060/zc614qh7060_0001/info.json",
     "number": "545",
+    "performer": "Pugno, Raoul",
     "publisher": "Welte-Mignon",
     "title": "Chopin/Pugno - Grande polonaise: op. 22, Es-Dur",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Grande polonaise: op. 22, Es-Dur"
   },
   {
+    "arranger": "",
+    "composer": "Chopin, Frédéric",
     "druid": "vm423wb2944",
-    "image_url": "https://stacks.stanford.edu/image/iiif/vm423wb2944%2Fvm423wb2944_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/vm423wb2944/vm423wb2944_0001/info.json",
     "number": "548",
+    "performer": "Pugno, Raoul",
     "publisher": "Welte-Mignon",
     "title": "Chopin/Pugno - Nocturn op. 15, no. 2, fis-dur",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Nocturn op. 15, no. 2, fis-dur"
   },
   {
+    "arranger": "",
+    "composer": "Chopin, Frédéric",
     "druid": "bj021jc9795",
-    "image_url": "https://stacks.stanford.edu/image/iiif/bj021jc9795%2Fbj021jc9795_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/bj021jc9795/bj021jc9795_0001/info.json",
     "number": "328",
+    "performer": "Reisenauer, Alfred",
     "publisher": "Welte-Mignon",
     "title": "Chopin/Reisenauer - Berceuse",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Berceuse"
   },
   {
+    "arranger": "",
+    "composer": "Chopin, Frédéric",
     "druid": "mv259zt7103",
-    "image_url": "https://stacks.stanford.edu/image/iiif/mv259zt7103%2Fmv259zt7103_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/mv259zt7103/mv259zt7103_0001/info.json",
     "number": "325",
+    "performer": "Reisenauer, Alfred",
     "publisher": "Welte-Mignon",
     "title": "Chopin/Reisenauer - Chant polonais: (Des Mädchens Wunsch)",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Chant polonais: (Des Mädchens Wunsch)"
   },
   {
+    "arranger": "",
+    "composer": "Chopin, Frédéric",
     "druid": "tx963yw9164",
-    "image_url": "https://stacks.stanford.edu/image/iiif/tx963yw9164%2Ftx963yw9164_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/tx963yw9164/tx963yw9164_0001/info.json",
     "number": "807",
+    "performer": "Saint-Saëns, Camille",
     "publisher": "Welte-Mignon",
     "title": "Chopin/Saint-Saëns - Nocturne f sharp, op. 15, no. 2",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Nocturne f sharp, op. 15, no. 2"
   },
   {
+    "arranger": "",
+    "composer": "Chopin, Frédéric",
     "druid": "dw559kr7002",
-    "image_url": "https://stacks.stanford.edu/image/iiif/dw559kr7002%2Fdw559kr7002_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/dw559kr7002/dw559kr7002_0001/info.json",
     "number": "1472",
+    "performer": "Samaroff Stokowski, Olga",
     "publisher": "Welte-Mignon",
     "title": "Chopin/Samaroff Stokowski - Sonata b minor: 1st and 2nd movement",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Sonata b minor: 1st and 2nd movement"
   },
   {
+    "arranger": "",
+    "composer": "Chopin, Frédéric",
     "druid": "wz252pk3255",
-    "image_url": "https://stacks.stanford.edu/image/iiif/wz252pk3255%2Fwz252pk3255_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/wz252pk3255/wz252pk3255_0001/info.json",
     "number": "1473",
+    "performer": "Samaroff Stokowski, Olga",
     "publisher": "Welte-Mignon",
     "title": "Chopin/Samaroff Stokowski - Sonata b minor: 3rd and 4th movement",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Sonata b minor: 3rd and 4th movement"
   },
   {
+    "arranger": "",
+    "composer": "Chopin, Frédéric",
     "druid": "ch197br4742",
-    "image_url": "https://stacks.stanford.edu/image/iiif/ch197br4742%2Fch197br4742_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/ch197br4742/ch197br4742_0001/info.json",
     "number": "881",
+    "performer": "Sauer, Emil von",
     "publisher": "Welte-Mignon",
     "title": "Chopin/Sauer - Etude op. 25, no. 9: (staccato)",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Etude op. 25, no. 9: (staccato)"
   },
   {
+    "arranger": "",
+    "composer": "Chopin, Frédéric",
     "druid": "rp390kt0160",
-    "image_url": "https://stacks.stanford.edu/image/iiif/rp390kt0160%2Frp390kt0160_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/rp390kt0160/rp390kt0160_0001/info.json",
     "number": "879",
+    "performer": "Sauer, Emil von",
     "publisher": "Welte-Mignon",
     "title": "Chopin/Sauer - Nocturne des-dur, op. 27, no. 2",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Nocturne des-dur, op. 27, no. 2"
   },
   {
+    "arranger": "",
+    "composer": "Chopin, Frédéric",
     "druid": "vy018tw5237",
-    "image_url": "https://stacks.stanford.edu/image/iiif/vy018tw5237%2Fvy018tw5237_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/vy018tw5237/vy018tw5237_0001/info.json",
     "number": "245",
+    "performer": "Scharwenka, Xaver",
     "publisher": "Welte-Mignon",
     "title": "Chopin/Scharwenka - Valse op. 42 as-dur",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Valse op. 42 as-dur"
   },
   {
+    "arranger": "",
+    "composer": "Chopin, Frédéric",
     "druid": "kg488qt3887",
-    "image_url": "https://stacks.stanford.edu/image/iiif/kg488qt3887%2Fkg488qt3887_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/kg488qt3887/kg488qt3887_0001/info.json",
     "number": "1447",
+    "performer": "Schelling, Ernest",
     "publisher": "Welte-Mignon",
     "title": "Chopin/Schelling - 2 préludes: op. 28, Nr. 1, C-Dur u. Nr. 21, B-Dur",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "2 préludes: op. 28, Nr. 1, C-Dur u. Nr. 21, B-Dur"
   },
   {
+    "arranger": "",
+    "composer": "Chopin, Frédéric",
     "druid": "jg886ps8946",
-    "image_url": "https://stacks.stanford.edu/image/iiif/jg886ps8946%2Fjg886ps8946_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/jg886ps8946/jg886ps8946_0001/info.json",
     "number": "1445",
+    "performer": "Schelling, Ernest",
     "publisher": "Welte-Mignon",
     "title": "Chopin/Schelling - Etude op. 10, no. 10, a flat",
-    "type": "welte-green"
+    "type": "welte-green",
+    "work": "Etude op. 10, no. 10, a flat"
   },
   {
+    "arranger": "",
+    "composer": "Chopin, Frédéric",
     "druid": "pz175wg5571",
-    "image_url": "https://stacks.stanford.edu/image/iiif/pz175wg5571%2Fpz175wg5571_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/pz175wg5571/pz175wg5571_0001/info.json",
     "number": "1447",
+    "performer": "Schelling, Ernest",
     "publisher": "Welte-Mignon",
     "title": "Chopin/Schelling - Préludes, op. 28, no. 1, c major, op. 28, no. 21, b flat",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Préludes, op. 28, no. 1, c major, op. 28, no. 21, b flat"
   },
   {
+    "arranger": "",
+    "composer": "Chopin, Frédéric",
     "druid": "st755cm2486",
-    "image_url": "https://stacks.stanford.edu/image/iiif/st755cm2486%2Fst755cm2486_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/st755cm2486/st755cm2486_0001/info.json",
     "number": "390",
+    "performer": "Schnabel, Artur",
     "publisher": "Welte-Mignon",
     "title": "Chopin/Schnabel - Etude op. 10, no. 5, ges-dur",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Etude op. 10, no. 5, ges-dur"
   },
   {
+    "arranger": "",
+    "composer": "Chopin, Frédéric",
     "druid": "ww627mg3287",
-    "image_url": "https://stacks.stanford.edu/image/iiif/ww627mg3287%2Fww627mg3287_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/ww627mg3287/ww627mg3287_0001/info.json",
     "number": "1035",
+    "performer": "Stavenhagen, Bernhard",
     "publisher": "Welte-Mignon",
     "title": "Chopin/Stavenhagen - Chant polonaise: Ges-Dur: (nach persönlichen Erinnerungen)",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Chant polonaise: Ges-Dur : (nach persönlichen Erinnerungen)"
   },
   {
+    "arranger": "",
+    "composer": "Chopin, Frédéric",
     "druid": "kv921kh0629",
-    "image_url": "https://stacks.stanford.edu/image/iiif/kv921kh0629%2Fkv921kh0629_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/kv921kh0629/kv921kh0629_0001/info.json",
     "number": "1039",
+    "performer": "Stavenhagen, Bernhard",
     "publisher": "Welte-Mignon",
     "title": "Chopin/Stavenhagen - Valse op. 69, no. 1, as-dur",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Valse op. 69, no. 1, as-dur"
   },
   {
+    "arranger": "",
+    "composer": "Chopin, Frédéric",
     "druid": "jh069yf5255",
-    "image_url": "https://stacks.stanford.edu/image/iiif/jh069yf5255%2Fjh069yf5255_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/jh069yf5255/jh069yf5255_0001/info.json",
     "number": "704",
+    "performer": "Wurmser, Lucien",
     "publisher": "Welte-Mignon",
     "title": "Chopin/Wurmser - Waltz op. 64, no. 2, c-sharp minor",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Waltz op. 64, no. 2, c-sharp minor"
   },
   {
+    "arranger": "",
+    "composer": "Chopin, Frédéric",
     "druid": "vy941zv8672",
-    "image_url": "https://stacks.stanford.edu/image/iiif/vy941zv8672%2Fvy941zv8672_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/vy941zv8672/vy941zv8672_0001/info.json",
     "number": "470",
+    "performer": "Zadora, Michael",
     "publisher": "Welte-Mignon",
     "title": "Chopin/Zadora - Preludes: Nos. 2, 4, 9, 13 and 22",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Preludes: Nos. 2, 4, 9, 13 and 22"
   },
   {
+    "arranger": "",
+    "composer": "Chueca, Federico, 1846-1908",
     "druid": "vc943nk4921",
-    "image_url": "https://stacks.stanford.edu/image/iiif/vc943nk4921%2Fvc943nk4921_0002/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/vc943nk4921/vc943nk4921_0002/info.json",
     "number": "4319",
+    "performer": "",
     "publisher": "Princesa",
     "title": "Chueca - La Alegría de la huerta: selecciones",
-    "type": "88-note"
+    "type": "88-note",
+    "work": "La Alegría de la huerta: selecciones"
   },
   {
+    "arranger": "",
+    "composer": "Clará, E. (Enrique), 1883-1941",
     "druid": "rh357hg0211",
-    "image_url": "https://stacks.stanford.edu/image/iiif/rh357hg0211%2Frh357hg0211_0002/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/rh357hg0211/rh357hg0211_0002/info.json",
     "number": "4301",
+    "performer": "",
     "publisher": "Princesa",
     "title": "Clará - Modern pericón",
-    "type": "88-note"
+    "type": "88-note",
+    "work": "Modern pericón"
   },
   {
+    "arranger": "",
+    "composer": "Clará, E. (Enrique), 1883-1941",
     "druid": "kz454tt7354",
-    "image_url": "https://stacks.stanford.edu/image/iiif/kz454tt7354%2Fkz454tt7354_0002/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/kz454tt7354/kz454tt7354_0002/info.json",
     "number": "4629",
+    "performer": "",
     "publisher": "Princesa",
     "title": "Clará - Qué mujer, qué mujer!: vals de la Revista Bis Bis",
-    "type": "88-note"
+    "type": "88-note",
+    "work": "Qué mujer, qué mujer!: vals de la Revista Bis Bis"
   },
   {
+    "arranger": "",
+    "composer": "Cuvillier, Charles",
     "druid": "cg834ff4729",
-    "image_url": "https://stacks.stanford.edu/image/iiif/cg834ff4729%2Fcg834ff4729_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/cg834ff4729/cg834ff4729_0001/info.json",
     "number": "3647",
+    "performer": "Heineck, Franz",
     "publisher": "Welte-Mignon",
     "title": "Cuvillier/Heineck - Lilac domino: hesitation waltz",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Lilac domino: hesitation waltz"
   },
   {
+    "arranger": "",
+    "composer": "Czerny, Carl",
     "druid": "wn516xn5163",
-    "image_url": "https://stacks.stanford.edu/image/iiif/wn516xn5163%2Fwn516xn5163_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/wn516xn5163/wn516xn5163_0001/info.json",
     "number": "2430",
+    "performer": "Lhévinne, Josef",
     "publisher": "Welte-Mignon",
     "title": "Czerny/Lhévinne - Oktavenetude: op. 740, no. 5",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Oktavenetude: op. 740, no. 5"
   },
   {
+    "arranger": "",
+    "composer": "D'Egville, Louis H. (Louis Hervey)",
     "druid": "rq642tt1626",
-    "image_url": "https://stacks.stanford.edu/image/iiif/rq642tt1626%2Frq642tt1626_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/rq642tt1626/rq642tt1626_0001/info.json",
     "number": "2580",
+    "performer": "D'Egville, Louis H. (Louis Hervey)",
     "publisher": "Welte-Mignon",
     "title": "D'Egville/D'Egville - A Canadian rondo: a passing-fancy",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "A Canadian rondo: a passing-fancy"
   },
   {
+    "arranger": "",
+    "composer": "Daly, William",
     "druid": "wp666fn2104",
-    "image_url": "https://stacks.stanford.edu/image/iiif/wp666fn2104%2Fwp666fn2104_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/wp666fn2104/wp666fn2104_0001/info.json",
     "number": "5537",
+    "performer": "Coach, W",
     "publisher": "Welte-Mignon",
     "title": "Daly/Coach - Oh gee! oh gosh!: from Stop flirting: fox-trot",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Oh gee! oh gosh!: from Stop flirting : fox-trot"
   },
   {
+    "arranger": "",
+    "composer": "Debussy, Claude",
     "druid": "jh696my0069",
-    "image_url": "https://stacks.stanford.edu/image/iiif/jh696my0069%2Fjh696my0069_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/jh696my0069/jh696my0069_0001/info.json",
     "number": "1765",
+    "performer": "Buhlig, Richard",
     "publisher": "Welte-Mignon",
     "title": "Debussy/Buhlig - Poissons d'or",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Poissons d'or"
   },
   {
+    "arranger": "",
+    "composer": "Debussy, Claude",
     "druid": "dc920rk8870",
-    "image_url": "https://stacks.stanford.edu/image/iiif/dc920rk8870%2Fdc920rk8870_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/dc920rk8870/dc920rk8870_0001/info.json",
     "number": "2733",
+    "performer": "Debussy, Claude",
     "publisher": "Welte-Mignon",
     "title": "Debussy/Debussy - Children's corner",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Children's corner"
   },
   {
+    "arranger": "",
+    "composer": "Debussy, Claude",
     "druid": "ws250sr1272",
-    "image_url": "https://stacks.stanford.edu/image/iiif/ws250sr1272%2Fws250sr1272_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/ws250sr1272/ws250sr1272_0001/info.json",
     "number": "2739",
+    "performer": "Debussy, Claude",
     "publisher": "Welte-Mignon",
     "title": "Debussy/Debussy - Preludes: Le vent dans la plaine; Minstrels",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Preludes: Le vent dans la plaine ; Minstrels"
   },
   {
+    "arranger": "",
+    "composer": "Debussy, Claude",
     "druid": "tq268fs9721",
-    "image_url": "https://stacks.stanford.edu/image/iiif/tq268fs9721%2Ftq268fs9721_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/tq268fs9721/tq268fs9721_0001/info.json",
     "number": "3045",
+    "performer": "Ganz, Rudolph",
     "publisher": "Welte-Mignon",
     "title": "Debussy/Ganz - Preludes: La fille aux cheveux de lin; La puerto del vino",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Preludes: La fille aux cheveux de lin ; La puerto del vino"
   },
   {
+    "arranger": "",
+    "composer": "Debussy, Claude",
     "druid": "dw005gw3358",
-    "image_url": "https://stacks.stanford.edu/image/iiif/dw005gw3358%2Fdw005gw3358_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/dw005gw3358/dw005gw3358_0001/info.json",
     "number": "1450",
+    "performer": "Schelling, Ernest",
     "publisher": "Welte-Mignon",
     "title": "Debussy/Schelling - La Soirée dane granade",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "La Soirée dane granade"
   },
   {
+    "arranger": "",
+    "composer": "Debussy, Claude",
     "druid": "rg591sj4242",
-    "image_url": "https://stacks.stanford.edu/image/iiif/rg591sj4242%2Frg591sj4242_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/rg591sj4242/rg591sj4242_0001/info.json",
     "number": "1451",
+    "performer": "Schelling, Ernest",
     "publisher": "Welte-Mignon",
     "title": "Debussy/Schelling - Toccata",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Toccata"
   },
   {
+    "arranger": "Dohnányi, Ernő, 1877-1960",
+    "composer": "Delibes, Léo, 1836-1891",
     "druid": "bs533ns1949",
-    "image_url": "https://stacks.stanford.edu/image/iiif/bs533ns1949%2Fbs533ns1949_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/bs533ns1949/bs533ns1949_0001/info.json",
     "number": "3398",
+    "performer": "Blumen, Alfred",
     "publisher": "Welte-Mignon",
     "title": "Delibes-Dohnányi/Blumen - \"naïla\": Walzer",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "\"naïla\": Walzer"
   },
   {
+    "arranger": "",
+    "composer": "Delibes, Léo",
     "druid": "xn585zh2707",
-    "image_url": "https://stacks.stanford.edu/image/iiif/xn585zh2707%2Fxn585zh2707_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/xn585zh2707/xn585zh2707_0001/info.json",
     "number": "2805",
+    "performer": "Gayraud, P",
     "publisher": "Welte-Mignon",
     "title": "Delibes/Gayraud - Lakmé: Fantasie I",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Lakmé: Fantasie I"
   },
   {
+    "arranger": "",
+    "composer": "Dohnányi, Ernő",
     "druid": "fz632cv0288",
-    "image_url": "https://stacks.stanford.edu/image/iiif/fz632cv0288%2Ffz632cv0288_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/fz632cv0288/fz632cv0288_0001/info.json",
     "number": "1828",
+    "performer": "Mero, Yolanda",
     "publisher": "Welte-Mignon",
     "title": "Dohnányi/Mero - Rhapsody, c major, op. 11, no. 3",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Rhapsody, c major, op. 11, no. 3"
   },
   {
+    "arranger": "",
+    "composer": "Dohnányi, Ernő",
     "druid": "bp952tr1116",
-    "image_url": "https://stacks.stanford.edu/image/iiif/bp952tr1116%2Fbp952tr1116_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/bp952tr1116/bp952tr1116_0001/info.json",
     "number": "399",
+    "performer": "Weiss, Josef",
     "publisher": "Welte-Mignon",
     "title": "Dohnányi/Weiss - Ii rhapsodie op. 11",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Ii rhapsodie op. 11"
   },
   {
+    "arranger": "",
+    "composer": "Dvořák, Antonín",
     "druid": "xy699sy1462",
-    "image_url": "https://stacks.stanford.edu/image/iiif/xy699sy1462%2Fxy699sy1462_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/xy699sy1462/xy699sy1462_0001/info.json",
     "number": "1324",
+    "performer": "Fryer, Herbert",
     "publisher": "Welte-Mignon",
     "title": "Dvořák/Fryer - Humoreske op. 10, no. 7",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Humoreske op. 10, no. 7"
   },
   {
+    "arranger": "",
+    "composer": "Epstein, Richard",
     "druid": "dy191sv5188",
-    "image_url": "https://stacks.stanford.edu/image/iiif/dy191sv5188%2Fdy191sv5188_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/dy191sv5188/dy191sv5188_0001/info.json",
     "number": "2261",
+    "performer": "Epstein, Richard",
     "publisher": "Welte-Mignon",
     "title": "Epstein/Epstein - Wiener walzer",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Wiener walzer"
   },
   {
+    "arranger": "",
+    "composer": "Europe, James Reese",
     "druid": "nt812xg8796",
-    "image_url": "https://stacks.stanford.edu/image/iiif/nt812xg8796%2Fnt812xg8796_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/nt812xg8796/nt812xg8796_0001/info.json",
     "number": "3567",
+    "performer": "Europe, James Reese",
     "publisher": "Welte-Mignon",
     "title": "Europe/Europe - Castle house rag: one-step",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Castle house rag: one-step"
   },
   {
+    "arranger": "",
+    "composer": "Fall, Richard",
     "druid": "mv647hz9361",
-    "image_url": "https://stacks.stanford.edu/image/iiif/mv647hz9361%2Fmv647hz9361_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/mv647hz9361/mv647hz9361_0001/info.json",
     "number": "5669",
+    "performer": "Black, Sidney",
     "publisher": "Welte-Mignon",
     "title": "Fall/Black - Sergeant percy: one-step",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Sergeant percy: one-step"
   },
   {
+    "arranger": "",
+    "composer": "Fall, Richard",
     "druid": "qk926qc7779",
-    "image_url": "https://stacks.stanford.edu/image/iiif/qk926qc7779%2Fqk926qc7779_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/qk926qc7779/qk926qc7779_0001/info.json",
     "number": "5728",
+    "performer": "Haass, Hans",
     "publisher": "Welte-Mignon",
     "title": "Fall/Haass - Was machst du mit dem knie, lieber hans?: paso doble",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Was machst du mit dem knie, lieber hans?: paso doble"
   },
   {
+    "arranger": "",
+    "composer": "Fall, Leo",
     "druid": "hj604wr7502",
-    "image_url": "https://stacks.stanford.edu/image/iiif/hj604wr7502%2Fhj604wr7502_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/hj604wr7502/hj604wr7502_0001/info.json",
     "number": "1526",
+    "performer": "Utz, Paula",
     "publisher": "Welte-Mignon",
     "title": "Fall/Utz - Potpourri aus \"der fidele bauer\"",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Potpourri aus \"der fidele bauer\""
   },
   {
+    "arranger": "",
+    "composer": "Font y de Anta, Manuel, 1895-1936",
     "druid": "mw139zj5450",
-    "image_url": "https://stacks.stanford.edu/image/iiif/mw139zj5450%2Fmw139zj5450_0002/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/mw139zj5450/mw139zj5450_0002/info.json",
     "number": "4420",
+    "performer": "",
     "publisher": "Aeolian",
     "title": "Font y de Anta - El Organillo y... yo: schotish",
-    "type": "88-note"
+    "type": "88-note",
+    "work": "El Organillo y... yo: schotish"
   },
   {
+    "arranger": "",
+    "composer": "Foster, Stephen Collins",
     "druid": "jt036qh8967",
-    "image_url": "https://stacks.stanford.edu/image/iiif/jt036qh8967%2Fjt036qh8967_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/jt036qh8967/jt036qh8967_0001/info.json",
     "number": "3549",
+    "performer": "Merrigan, Orlando",
     "publisher": "Welte-Mignon",
     "title": "Foster/Merrigan - Old black joe: Old folks at home: (way upon the Swanee River)",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Old black joe: Old folks at home : (way upon the Swanee River)"
   },
   {
+    "arranger": "",
+    "composer": "Franco Ribate, José, 1878-1951",
     "druid": "xz373zg4809",
-    "image_url": "https://stacks.stanford.edu/image/iiif/xz373zg4809%2Fxz373zg4809_0002/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/xz373zg4809/xz373zg4809_0002/info.json",
     "number": "40.007",
+    "performer": "",
     "publisher": "Princesa",
     "title": "Franco Ribate - Gitanillo de triana: pasodoble",
-    "type": "88-note"
+    "type": "88-note",
+    "work": "Gitanillo de triana: pasodoble"
   },
   {
+    "arranger": "",
+    "composer": "Friml, Rudolf",
     "druid": "vd312rr8990",
-    "image_url": "https://stacks.stanford.edu/image/iiif/vd312rr8990%2Fvd312rr8990_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/vd312rr8990/vd312rr8990_0001/info.json",
     "number": "3568",
+    "performer": "Europe, James Reese",
     "publisher": "Welte-Mignon",
     "title": "Friml/Europe - Ting-a-ling-a-ling: (from \"High Jinks\")",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Ting-a-ling-a-ling: (from \"High Jinks\")"
   },
   {
+    "arranger": "",
+    "composer": "Friml, Rudolf",
     "druid": "zk082zq3962",
-    "image_url": "https://stacks.stanford.edu/image/iiif/zk082zq3962%2Fzk082zq3962_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/zk082zq3962/zk082zq3962_0001/info.json",
     "number": "5707",
+    "performer": "Johnson, Edward",
     "publisher": "Welte-Mignon",
     "title": "Friml/Johnson - Rose marie: fox-trot: from the musical play \"Rose Marie\"",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Rose marie: fox-trot : from the musical play \"Rose Marie\""
   },
   {
+    "arranger": "",
+    "composer": "Friml, Rudolf",
     "druid": "kz819wb8990",
-    "image_url": "https://stacks.stanford.edu/image/iiif/kz819wb8990%2Fkz819wb8990_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/kz819wb8990/kz819wb8990_0001/info.json",
     "number": "3505",
+    "performer": "Savino, Domenico",
     "publisher": "Welte-Mignon",
     "title": "Friml/Savino - Sympathy: (waltz song): from the comedy-opera \"The Firefly\"",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Sympathy: (waltz song) : from the comedy-opera \"The Firefly\""
   },
   {
+    "arranger": "",
+    "composer": "Fugazot, Roberto, 1902-1971",
     "druid": "wq696jd1149",
-    "image_url": "https://stacks.stanford.edu/image/iiif/wq696jd1149%2Fwq696jd1149_0002/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/wq696jd1149/wq696jd1149_0002/info.json",
     "number": "4663",
+    "performer": "",
     "publisher": "Princesa",
     "title": "Fugazot - Barrio reo: tango",
-    "type": "88-note"
+    "type": "88-note",
+    "work": "Barrio reo: tango"
   },
   {
+    "arranger": "",
+    "composer": "Gabrilowitsch, Ossip",
     "druid": "zn339mg3395",
-    "image_url": "https://stacks.stanford.edu/image/iiif/zn339mg3395%2Fzn339mg3395_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/zn339mg3395/zn339mg3395_0001/info.json",
     "number": "297",
+    "performer": "Gabrilowitsch, Ossip",
     "publisher": "Welte-Mignon",
     "title": "Gabrilowitsch/Gabrilowitsch - Caprice-burlesque op. 3",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Caprice-burlesque op. 3"
   },
   {
+    "arranger": "",
+    "composer": "García Ibáñez, Nicolás, -1955",
     "druid": "dk418xy4378",
-    "image_url": "https://stacks.stanford.edu/image/iiif/dk418xy4378%2Fdk418xy4378_0002/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/dk418xy4378/dk418xy4378_0002/info.json",
     "number": "4668",
+    "performer": "",
     "publisher": "Princesa",
     "title": "García Ibáñez - Félix rodríguez: Pasodoble flamenco",
-    "type": "88-note"
+    "type": "88-note",
+    "work": "Félix rodríguez: Pasodoble flamenco"
   },
   {
+    "arranger": "",
+    "composer": "German, Edward",
     "druid": "qd424rx3516",
-    "image_url": "https://stacks.stanford.edu/image/iiif/qd424rx3516%2Fqd424rx3516_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/qd424rx3516/qd424rx3516_0001/info.json",
     "number": "3671",
+    "performer": "La Forge, Frank",
     "publisher": "Welte-Mignon",
     "title": "German/La Forge - Three dances from henry viii",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Three dances from henry viii"
   },
   {
+    "arranger": "",
+    "composer": "Gilbert, Jean",
     "druid": "ry050yb9492",
-    "image_url": "https://stacks.stanford.edu/image/iiif/ry050yb9492%2Fry050yb9492_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/ry050yb9492/ry050yb9492_0001/info.json",
     "number": "2525",
+    "performer": "Ebenstein, K",
     "publisher": "Welte-Mignon",
     "title": "Gilbert/Ebenstein - Die Keusche susanna: Potpourri",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Die Keusche susanna: Potpourri"
   },
   {
+    "arranger": "",
+    "composer": "Giménez, Gerónimo, 1854-1923",
     "druid": "zm791gz4425",
-    "image_url": "https://stacks.stanford.edu/image/iiif/zm791gz4425%2Fzm791gz4425_0002/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/zm791gz4425/zm791gz4425_0002/info.json",
     "number": "4490",
+    "performer": "",
     "publisher": "Princesa",
     "title": "Giménez - El Barbero de sevilla: (zarzuela española): selecciones",
-    "type": "88-note"
+    "type": "88-note",
+    "work": "El Barbero de sevilla: (zarzuela española) : selecciones"
   },
   {
+    "arranger": "",
+    "composer": "Giménez, Gerónimo, 1854-1923",
     "druid": "qd454gb9111",
-    "image_url": "https://stacks.stanford.edu/image/iiif/qd454gb9111%2Fqd454gb9111_0002/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/qd454gb9111/qd454gb9111_0002/info.json",
     "number": "4514",
+    "performer": "",
     "publisher": "Princesa",
     "title": "Giménez - La Tempranica: selecciones",
-    "type": "88-note"
+    "type": "88-note",
+    "work": "La Tempranica: selecciones"
   },
   {
+    "arranger": "Blumenfeld, Félix",
+    "composer": "Glazunov, Aleksandr Konstantinovich",
     "druid": "fn744pq2157",
-    "image_url": "https://stacks.stanford.edu/image/iiif/fn744pq2157%2Ffn744pq2157_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/fn744pq2157/fn744pq2157_0001/info.json",
     "number": "1990",
+    "performer": "Lemba, Artur",
     "publisher": "Welte-Mignon",
     "title": "Glazunov-Blumenfeld/Lemba - Grande valse de concert: op. 47, D major",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Grande valse de concert: op. 47, D major"
   },
   {
+    "arranger": "",
+    "composer": "Glazunov, Aleksandr Konstantinovich",
     "druid": "nz678zw1579",
-    "image_url": "https://stacks.stanford.edu/image/iiif/nz678zw1579%2Fnz678zw1579_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/nz678zw1579/nz678zw1579_0001/info.json",
     "number": "1939",
+    "performer": "Glazunov, Aleksandr Konstantinovich",
     "publisher": "Welte-Mignon",
     "title": "Glazunov/Glazunov - 1. sonata op. 74, b flat: 2nd movement, Andante",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "1. sonata op. 74, b flat: 2nd movement, Andante"
   },
   {
+    "arranger": "",
+    "composer": "Glazunov, Aleksandr Konstantinovich",
     "druid": "dq276yn8963",
-    "image_url": "https://stacks.stanford.edu/image/iiif/dq276yn8963%2Fdq276yn8963_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/dq276yn8963/dq276yn8963_0001/info.json",
     "number": "1945",
+    "performer": "Glazunov, Aleksandr Konstantinovich",
     "publisher": "Welte-Mignon",
     "title": "Glazunov/Glazunov - Les Saisons, ballet",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Les Saisons, ballet"
   },
   {
+    "arranger": "",
+    "composer": "Glazunov, Aleksandr Konstantinovich",
     "druid": "vs880hb3425",
-    "image_url": "https://stacks.stanford.edu/image/iiif/vs880hb3425%2Fvs880hb3425_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/vs880hb3425/vs880hb3425_0001/info.json",
     "number": "1942",
+    "performer": "Glazunov, Aleksandr Konstantinovich",
     "publisher": "Welte-Mignon",
     "title": "Glazunov/Glazunov - Raymonda",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Raymonda"
   },
   {
+    "arranger": "",
+    "composer": "Glazunov, Aleksandr Konstantinovich",
     "druid": "kx293yk2859",
-    "image_url": "https://stacks.stanford.edu/image/iiif/kx293yk2859%2Fkx293yk2859_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/kx293yk2859/kx293yk2859_0001/info.json",
     "number": "1996",
+    "performer": "Hoffmann, Nelli",
     "publisher": "Welte-Mignon",
     "title": "Glazunov/Hoffmann - Theme and variations, f sharp minor",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Theme and variations, f sharp minor"
   },
   {
+    "arranger": "",
+    "composer": "Glazunov, Aleksandr Konstantinovich",
     "druid": "kq892pn7618",
-    "image_url": "https://stacks.stanford.edu/image/iiif/kq892pn7618%2Fkq892pn7618_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/kq892pn7618/kq892pn7618_0001/info.json",
     "number": "1968",
+    "performer": "Kimontt-Jacynowa, Marceline",
     "publisher": "Welte-Mignon",
     "title": "Glazunov/Kimontt-Jacynowa - Grand valse de concert: op. 41",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Grand valse de concert: op. 41"
   },
   {
+    "arranger": "",
+    "composer": "Gomes, Carlos",
     "druid": "xb072rc7617",
-    "image_url": "https://stacks.stanford.edu/image/iiif/xb072rc7617%2Fxb072rc7617_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/xb072rc7617/xb072rc7617_0001/info.json",
     "number": "4028",
+    "performer": "Haass, Hans",
     "publisher": "Welte-Mignon",
-    "title": "Gomes/Haass - Il Guarany: fantasie",
-    "type": "welte-red"
+    "title": "Gomes/Haass - Il   Guarany: fantasie",
+    "type": "welte-red",
+    "work": "Il   Guarany: fantasie"
   },
   {
+    "arranger": "",
+    "composer": "Gottschalk, Louis Moreau",
     "druid": "hj502vv5162",
-    "image_url": "https://stacks.stanford.edu/image/iiif/hj502vv5162%2Fhj502vv5162_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/hj502vv5162/hj502vv5162_0001/info.json",
     "number": "B-6294",
+    "performer": "Hart, Edna",
     "publisher": "De Luxe",
     "title": "Gottschalk/Hart - Ricordati",
-    "type": "welte-licensee"
+    "type": "welte-licensee",
+    "work": "Ricordati"
   },
   {
+    "arranger": "",
+    "composer": "Gottschalk, Louis Moreau",
     "druid": "jy277ht0636",
-    "image_url": "https://stacks.stanford.edu/image/iiif/jy277ht0636%2Fjy277ht0636_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/jy277ht0636/jy277ht0636_0001/info.json",
     "number": "1819",
+    "performer": "Utz, Paula",
     "publisher": "Welte-Mignon",
     "title": "Gottschalk/Utz - The Last hope: (meditation réligieuse)",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "The Last hope: (meditation réligieuse)"
   },
   {
+    "arranger": "Liszt, Franz",
+    "composer": "Gounod, Charles",
     "druid": "xq762nt7491",
-    "image_url": "https://stacks.stanford.edu/image/iiif/xq762nt7491%2Fxq762nt7491_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/xq762nt7491/xq762nt7491_0001/info.json",
     "number": "26",
+    "performer": "Adam-Benard, Eugenie",
     "publisher": "Welte-Mignon",
     "title": "Gounod-Liszt/Adam-Benard - Faust-walzer",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Faust-walzer"
   },
   {
+    "arranger": "",
+    "composer": "Gounod, Charles",
     "druid": "hm373bm3807",
-    "image_url": "https://stacks.stanford.edu/image/iiif/hm373bm3807%2Fhm373bm3807_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/hm373bm3807/hm373bm3807_0001/info.json",
     "number": "57",
+    "performer": "Adam-Benard, Eugenie",
     "publisher": "Welte-Mignon",
     "title": "Gounod/Adam-Benard - Faust prelude",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Faust prelude"
   },
   {
+    "arranger": "",
+    "composer": "Gounod, Charles",
     "druid": "py987gg6088",
-    "image_url": "https://stacks.stanford.edu/image/iiif/py987gg6088%2Fpy987gg6088_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/py987gg6088/py987gg6088_0001/info.json",
     "number": "57",
+    "performer": "Adam-Benard, Eugenie",
     "publisher": "Welte-Mignon",
     "title": "Gounod/Adam-Benard - Faust prelude",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Faust prelude"
   },
   {
+    "arranger": "",
+    "composer": "Gounod, Charles",
     "druid": "hr679fk5315",
-    "image_url": "https://stacks.stanford.edu/image/iiif/hr679fk5315%2Fhr679fk5315_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/hr679fk5315/hr679fk5315_0001/info.json",
     "number": "2172",
+    "performer": "Adam-Benard, Eugenie",
     "publisher": "Welte-Mignon",
     "title": "Gounod/Adam-Benard - Nazareth: sacred song",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Nazareth: sacred song"
   },
   {
+    "arranger": "",
+    "composer": "Gounod, Charles",
     "druid": "rg931dy5023",
-    "image_url": "https://stacks.stanford.edu/image/iiif/rg931dy5023%2Frg931dy5023_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/rg931dy5023/rg931dy5023_0001/info.json",
     "number": "2944",
+    "performer": "Cor de Las, A",
     "publisher": "Welte-Mignon",
     "title": "Gounod/Cor de Las - Faust reminiscenzen a. d. iii. und iv. akt",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Faust reminiscenzen a. d. iii. und iv. akt"
   },
   {
+    "arranger": "",
+    "composer": "Gounod, Charles",
     "druid": "sj582bt2976",
-    "image_url": "https://stacks.stanford.edu/image/iiif/sj582bt2976%2Fsj582bt2976_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/sj582bt2976/sj582bt2976_0001/info.json",
     "number": "2799",
+    "performer": "Gayraud, P",
     "publisher": "Welte-Mignon",
     "title": "Gounod/Gayraud - Faust: Selection I",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Faust: Selection I"
   },
   {
+    "arranger": "",
+    "composer": "Gounod, Charles",
     "druid": "gs012fx5529",
-    "image_url": "https://stacks.stanford.edu/image/iiif/gs012fx5529%2Fgs012fx5529_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/gs012fx5529/gs012fx5529_0001/info.json",
     "number": "1343",
+    "performer": "Starke, Gustav",
     "publisher": "Welte-Mignon",
     "title": "Gounod/Starke - Romeo and juliette: potpourri",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Romeo and juliette: potpourri"
   },
   {
+    "arranger": "",
+    "composer": "Grainger, Percy",
     "druid": "nw765mr4994",
-    "image_url": "https://stacks.stanford.edu/image/iiif/nw765mr4994%2Fnw765mr4994_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/nw765mr4994/nw765mr4994_0001/info.json",
     "number": "3790",
+    "performer": "Haass, Hans",
     "publisher": "Welte-Mignon",
     "title": "Grainger/Haass - British folkmusic: Settings Nr. 4: \"Shepherd's hey\"",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "British folkmusic: Settings Nr. 4: \"Shepherd's hey\""
   },
   {
+    "arranger": "",
+    "composer": "Grainger, Percy",
     "druid": "qv976bq3639",
-    "image_url": "https://stacks.stanford.edu/image/iiif/qv976bq3639%2Fqv976bq3639_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/qv976bq3639/qv976bq3639_0001/info.json",
     "number": "3791",
+    "performer": "Haass, Hans",
     "publisher": "Welte-Mignon",
     "title": "Grainger/Haass - British folkmusic: Settings Nr. 6: Irish tune from County Derry",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "British folkmusic: Settings Nr. 6: Irish tune from County Derry"
   },
   {
+    "arranger": "",
+    "composer": "Grieg, Edvard",
     "druid": "df354sy6634",
-    "image_url": "https://stacks.stanford.edu/image/iiif/df354sy6634%2Fdf354sy6634_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/df354sy6634/df354sy6634_0001/info.json",
     "number": "3379",
+    "performer": "Berend, Fritz",
     "publisher": "Welte-Mignon",
     "title": "Grieg/Berend - Peer gynt ii, op. 55, no. 4: Solvejgs Lied",
-    "type": "welte-green"
+    "type": "welte-green",
+    "work": "Peer gynt ii, op. 55, no. 4: Solvejgs Lied"
   },
   {
+    "arranger": "",
+    "composer": "Grieg, Edvard",
     "druid": "jw822wm2644",
-    "image_url": "https://stacks.stanford.edu/image/iiif/jw822wm2644%2Fjw822wm2644_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/jw822wm2644/jw822wm2644_0001/info.json",
     "number": "1275",
+    "performer": "Grieg, Edvard",
     "publisher": "Welte-Mignon",
     "title": "Grieg/Grieg - Butterfly: op. 43, no. 1",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Butterfly: op. 43, no. 1"
   },
   {
+    "arranger": "",
+    "composer": "Grieg, Edvard",
     "druid": "mh255vw4599",
-    "image_url": "https://stacks.stanford.edu/image/iiif/mh255vw4599%2Fmh255vw4599_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/mh255vw4599/mh255vw4599_0001/info.json",
     "number": "1276",
+    "performer": "Grieg, Edvard",
     "publisher": "Welte-Mignon",
     "title": "Grieg/Grieg - Norwegischer brautzug im vorüberziehen",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Norwegischer brautzug im vorüberziehen"
   },
   {
+    "arranger": "",
+    "composer": "Grieg, Edvard",
     "druid": "zf882fv0052",
-    "image_url": "https://stacks.stanford.edu/image/iiif/zf882fv0052%2Fzf882fv0052_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/zf882fv0052/zf882fv0052_0001/info.json",
     "number": "1277",
+    "performer": "Grieg, Edvard",
     "publisher": "Welte-Mignon",
     "title": "Grieg/Grieg - Vögelein a. lyrische stücke, op. 43",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Vögelein a. lyrische stücke, op. 43"
   },
   {
+    "arranger": "",
+    "composer": "Grieg, Edvard",
     "druid": "kj344bw3083",
-    "image_url": "https://stacks.stanford.edu/image/iiif/kj344bw3083%2Fkj344bw3083_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/kj344bw3083/kj344bw3083_0001/info.json",
     "number": "1307",
+    "performer": "Pugno, Raoul",
     "publisher": "Welte-Mignon",
     "title": "Grieg/Pugno - An Den frühling: op. 43, no. 1: (Lyrische Stücke)",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "An Den frühling: op. 43, no. 1 : (Lyrische Stücke)"
   },
   {
+    "arranger": "",
+    "composer": "Grieg, Edvard",
     "druid": "yr522jf5585",
-    "image_url": "https://stacks.stanford.edu/image/iiif/yr522jf5585%2Fyr522jf5585_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/yr522jf5585/yr522jf5585_0001/info.json",
     "number": "1478",
+    "performer": "Samaroff Stokowski, Olga",
     "publisher": "Welte-Mignon",
     "title": "Grieg/Samaroff Stokowski - Concerto a minor, op. 16",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Concerto a minor, op. 16"
   },
   {
+    "arranger": "",
+    "composer": "Grieg, Edvard",
     "druid": "ym773gh2267",
-    "image_url": "https://stacks.stanford.edu/image/iiif/ym773gh2267%2Fym773gh2267_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/ym773gh2267/ym773gh2267_0001/info.json",
     "number": "1478",
+    "performer": "Samaroff Stokowski, Olga",
     "publisher": "Welte-Mignon",
     "title": "Grieg/Samaroff Stokowski - Concerto a minor: 1st movement",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Concerto a minor: 1st movement"
   },
   {
+    "arranger": "",
+    "composer": "Grieg, Edvard",
     "druid": "bf644yy6536",
-    "image_url": "https://stacks.stanford.edu/image/iiif/bf644yy6536%2Fbf644yy6536_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/bf644yy6536/bf644yy6536_0001/info.json",
     "number": "1480",
+    "performer": "Samaroff Stokowski, Olga",
     "publisher": "Welte-Mignon",
     "title": "Grieg/Samaroff Stokowski - Peer gynt suite ii",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Peer gynt suite ii"
   },
   {
+    "arranger": "",
+    "composer": "Grieg, Edvard",
     "druid": "vz717bq6543",
-    "image_url": "https://stacks.stanford.edu/image/iiif/vz717bq6543%2Fvz717bq6543_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/vz717bq6543/vz717bq6543_0001/info.json",
     "number": "1480",
+    "performer": "Samaroff Stokowski, Olga",
     "publisher": "Welte-Mignon",
     "title": "Grieg/Samaroff Stokowski - Peer gynt suite: No. 1",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Peer gynt suite: No. 1"
   },
   {
+    "arranger": "",
+    "composer": "Grieg, Edvard",
     "druid": "hk155fw7898",
-    "image_url": "https://stacks.stanford.edu/image/iiif/hk155fw7898%2Fhk155fw7898_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/hk155fw7898/hk155fw7898_0001/info.json",
     "number": "1005",
+    "performer": "Stebel, Paula",
     "publisher": "Welte-Mignon",
     "title": "Grieg/Stebel - Schmetterling",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Schmetterling"
   },
   {
+    "arranger": "",
+    "composer": "Grieg, Edvard",
     "druid": "hs635sh6729",
-    "image_url": "https://stacks.stanford.edu/image/iiif/hs635sh6729%2Fhs635sh6729_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/hs635sh6729/hs635sh6729_0001/info.json",
     "number": "378",
+    "performer": "Wendling, Carl",
     "publisher": "Welte-Mignon",
     "title": "Grieg/Wendling - Hochzeitstag auf troldhangen op. 65 no. 1",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Hochzeitstag auf troldhangen op. 65 no. 1"
   },
   {
+    "arranger": "",
+    "composer": "Guerrero, Jacinto, 1895-1951",
     "druid": "km927sd2616",
-    "image_url": "https://stacks.stanford.edu/image/iiif/km927sd2616%2Fkm927sd2616_0002/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/km927sd2616/km927sd2616_0002/info.json",
     "number": "4323",
+    "performer": "",
     "publisher": "Caecilia",
     "title": "Guerrero - Don quintín el amargao: Java",
-    "type": "88-note"
+    "type": "88-note",
+    "work": "Don quintín el amargao: Java"
   },
   {
+    "arranger": "",
+    "composer": "Guerrero, Jacinto, 1895-1951",
     "druid": "gn803sk7089",
-    "image_url": "https://stacks.stanford.edu/image/iiif/gn803sk7089%2Fgn803sk7089_0002/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/gn803sk7089/gn803sk7089_0002/info.json",
     "number": "5404",
+    "performer": "",
     "publisher": "Princesa",
     "title": "Guerrero - El Huésped del sevillano: Lagarteranas",
-    "type": "88-note"
+    "type": "88-note",
+    "work": "El Huésped del sevillano: Lagarteranas"
   },
   {
+    "arranger": "",
+    "composer": "Guerrero, Jacinto, 1895-1951",
     "druid": "vk572hg6636",
-    "image_url": "https://stacks.stanford.edu/image/iiif/vk572hg6636%2Fvk572hg6636_0002/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/vk572hg6636/vk572hg6636_0002/info.json",
     "number": "4540",
+    "performer": "",
     "publisher": "Princesa",
     "title": "Guerrero - El Sobre verde: Bombones de chocolate",
-    "type": "88-note"
+    "type": "88-note",
+    "work": "El Sobre verde: Bombones de chocolate"
   },
   {
+    "arranger": "",
+    "composer": "Halévy, F",
     "druid": "hx789sg2918",
-    "image_url": "https://stacks.stanford.edu/image/iiif/hx789sg2918%2Fhx789sg2918_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/hx789sg2918/hx789sg2918_0001/info.json",
     "number": "3376",
+    "performer": "Berend, Fritz",
     "publisher": "Welte-Mignon",
     "title": "Halévy/Berend - Die Jüdin",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Die Jüdin"
   },
   {
+    "arranger": "",
+    "composer": "Handel, George Frideric",
     "druid": "sw740gd4329",
-    "image_url": "https://stacks.stanford.edu/image/iiif/sw740gd4329%2Fsw740gd4329_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/sw740gd4329/sw740gd4329_0001/info.json",
     "number": "76",
+    "performer": "Adam-Benard, Eugenie",
     "publisher": "Welte-Mignon",
     "title": "Handel/Adam-Benard - Largo",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Largo"
   },
   {
+    "arranger": "",
+    "composer": "Handel, George Frideric",
     "druid": "hx184ww0780",
-    "image_url": "https://stacks.stanford.edu/image/iiif/hx184ww0780%2Fhx184ww0780_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/hx184ww0780/hx184ww0780_0001/info.json",
     "number": "10",
+    "performer": "Adam-Benard, Eugenie",
     "publisher": "Welte-Mignon",
     "title": "Handel/Adam-Benard - The Harmonius blacksmith: E major, 5th suite = Le forgeron harmonieux",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "The Harmonius blacksmith: E major, 5th suite = Le forgeron harmonieux"
   },
   {
+    "arranger": "",
+    "composer": "Henderson, Ray",
     "druid": "cw965qx3168",
-    "image_url": "https://stacks.stanford.edu/image/iiif/cw965qx3168%2Fcw965qx3168_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/cw965qx3168/cw965qx3168_0001/info.json",
     "number": "5661",
+    "performer": "Johnson, Edward",
     "publisher": "Welte-Mignon",
     "title": "Henderson/Johnson - Follow the swallow: fox-trot",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Follow the swallow: fox-trot"
   },
   {
+    "arranger": "",
+    "composer": "Henselt, Adolf von",
     "druid": "fb623cd1247",
-    "image_url": "https://stacks.stanford.edu/image/iiif/fb623cd1247%2Ffb623cd1247_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/fb623cd1247/fb623cd1247_0001/info.json",
     "number": "1654",
+    "performer": "Cory, Annie",
     "publisher": "Welte-Mignon",
     "title": "Henselt/Cory - Si oiseau j'étais",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Si oiseau j'étais"
   },
   {
+    "arranger": "",
+    "composer": "Henselt, Adolf von",
     "druid": "sc787kg5664",
-    "image_url": "https://stacks.stanford.edu/image/iiif/sc787kg5664%2Fsc787kg5664_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/sc787kg5664/sc787kg5664_0001/info.json",
     "number": "1654",
+    "performer": "Cory, Annie",
     "publisher": "Welte-Mignon",
     "title": "Henselt/Cory - Si oiseau j'étais",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Si oiseau j'étais"
   },
   {
+    "arranger": "",
+    "composer": "Holzmann, Abe",
     "druid": "kr645mg0298",
-    "image_url": "https://stacks.stanford.edu/image/iiif/kr645mg0298%2Fkr645mg0298_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/kr645mg0298/kr645mg0298_0001/info.json",
     "number": "1405",
+    "performer": "Orlando, N",
     "publisher": "Welte-Mignon",
     "title": "Holzmann/Orlando - Love land",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Love land"
   },
   {
+    "arranger": "",
+    "composer": "Hoyos, Raul de los",
     "druid": "sb388kg1678",
-    "image_url": "https://stacks.stanford.edu/image/iiif/sb388kg1678%2Fsb388kg1678_0002/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/sb388kg1678/sb388kg1678_0002/info.json",
     "number": "40019",
+    "performer": "",
     "publisher": "Princesa",
     "title": "Hoyos - El Carrerito: tango argentino",
-    "type": "88-note"
+    "type": "88-note",
+    "work": "El Carrerito: tango argentino"
   },
   {
+    "arranger": "",
+    "composer": "Humperdinck, Engelbert",
     "druid": "rt308hy9235",
-    "image_url": "https://stacks.stanford.edu/image/iiif/rt308hy9235%2Frt308hy9235_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/rt308hy9235/rt308hy9235_0001/info.json",
     "number": "646",
+    "performer": "Humperdinck, Engelbert",
     "publisher": "Welte-Mignon",
     "title": "Humperdinck/Humperdinck - Traumscene a. hänsel und gretel",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Traumscene a. hänsel und gretel"
   },
   {
+    "arranger": "",
+    "composer": "Humperdinck, Engelbert",
     "druid": "fb100cb2366",
-    "image_url": "https://stacks.stanford.edu/image/iiif/fb100cb2366%2Ffb100cb2366_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/fb100cb2366/fb100cb2366_0001/info.json",
     "number": "2948",
+    "performer": "Sommer, Ernst",
     "publisher": "Welte-Mignon",
     "title": "Humperdinck/Sommer - Selections from \"hansel & gretel\"",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Selections from \"hansel & gretel\""
   },
   {
+    "arranger": "",
+    "composer": "Joyce, Archibald, 1873-1963",
     "druid": "zy618kz1670",
-    "image_url": "https://stacks.stanford.edu/image/iiif/zy618kz1670%2Fzy618kz1670_0002/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/zy618kz1670/zy618kz1670_0002/info.json",
     "number": "4677",
+    "performer": "",
     "publisher": "Victoria",
     "title": "Joyce - Remembrance: valse",
-    "type": "88-note"
+    "type": "88-note",
+    "work": "Remembrance: valse"
   },
   {
+    "arranger": "",
+    "composer": "Joyce, Archibald",
     "druid": "fr859hh7893",
-    "image_url": "https://stacks.stanford.edu/image/iiif/fr859hh7893%2Ffr859hh7893_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/fr859hh7893/fr859hh7893_0001/info.json",
     "number": "3524",
+    "performer": "Dyck, Ernest van",
     "publisher": "Welte-Mignon",
     "title": "Joyce/Dyck - Dreaming: waltz",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Dreaming: waltz"
   },
   {
+    "arranger": "",
+    "composer": "Keefer, George",
     "druid": "mr400mf6531",
-    "image_url": "https://stacks.stanford.edu/image/iiif/mr400mf6531%2Fmr400mf6531_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/mr400mf6531/mr400mf6531_0001/info.json",
     "number": "5662",
+    "performer": "Johnson, Edward",
     "publisher": "Welte-Mignon",
     "title": "Keefer/Johnson - Dream daddy: fox-trot",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Dream daddy: fox-trot"
   },
   {
+    "arranger": "",
+    "composer": "Korngold, Erich Wolfgang",
     "druid": "gm296rz0673",
-    "image_url": "https://stacks.stanford.edu/image/iiif/gm296rz0673%2Fgm296rz0673_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/gm296rz0673/gm296rz0673_0001/info.json",
     "number": "3055",
+    "performer": "Ganz, Rudolph",
     "publisher": "Welte-Mignon",
     "title": "Korngold/Ganz - Sonate e-dur, op. 2, no. 2: I. und II. Satz",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Sonate e-dur, op. 2, no. 2: I. und II. Satz"
   },
   {
+    "arranger": "",
+    "composer": "Korngold, Erich Wolfgang",
     "druid": "rb861vm6094",
-    "image_url": "https://stacks.stanford.edu/image/iiif/rb861vm6094%2Frb861vm6094_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/rb861vm6094/rb861vm6094_0001/info.json",
     "number": "3056",
+    "performer": "Ganz, Rudolph",
     "publisher": "Welte-Mignon",
     "title": "Korngold/Ganz - Sonate e-dur, op. 2, no. 2: III. und IV. Satz",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Sonate e-dur, op. 2, no. 2: III. und IV. Satz"
   },
   {
+    "arranger": "",
+    "composer": "Korngold, Erich Wolfgang",
     "druid": "ct503bz7189",
-    "image_url": "https://stacks.stanford.edu/image/iiif/ct503bz7189%2Fct503bz7189_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/ct503bz7189/ct503bz7189_0001/info.json",
     "number": "3842",
+    "performer": "Heinemann, Käthe",
     "publisher": "Welte-Mignon",
     "title": "Korngold/Heinemann - Märchenbilder: 5-7",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Märchenbilder: 5-7"
   },
   {
+    "arranger": "",
+    "composer": "Kreisler, Fritz",
     "druid": "xh403hj3866",
-    "image_url": "https://stacks.stanford.edu/image/iiif/xh403hj3866%2Fxh403hj3866_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/xh403hj3866/xh403hj3866_0001/info.json",
     "number": "384",
+    "performer": "Schnabel, Artur",
     "publisher": "Welte-Mignon",
     "title": "Kreisler/Schnabel - Old vienna waltzes",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Old vienna waltzes"
   },
   {
+    "arranger": "",
+    "composer": "Lecocq, Charles",
     "druid": "ft113cg5195",
-    "image_url": "https://stacks.stanford.edu/image/iiif/ft113cg5195%2Fft113cg5195_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/ft113cg5195/ft113cg5195_0001/info.json",
     "number": "2810",
+    "performer": "Gayraud, P",
     "publisher": "Welte-Mignon",
     "title": "Lecocq/Gayraud - La Fille de madame angot: (fantasie mosaïque)",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "La Fille de madame angot: (fantasie mosaïque)"
   },
   {
+    "arranger": "",
+    "composer": "Lehár, Franz",
     "druid": "pc364sy7115",
-    "image_url": "https://stacks.stanford.edu/image/iiif/pc364sy7115%2Fpc364sy7115_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/pc364sy7115/pc364sy7115_0001/info.json",
     "number": "2609",
+    "performer": "Goodall, B",
     "publisher": "Welte-Mignon",
     "title": "Lehár/Goodall - Graf von luxemburg: Selektion I",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Graf von luxemburg: Selektion I"
   },
   {
+    "arranger": "",
+    "composer": "Lehár, Franz",
     "druid": "wj488tq5861",
-    "image_url": "https://stacks.stanford.edu/image/iiif/wj488tq5861%2Fwj488tq5861_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/wj488tq5861/wj488tq5861_0001/info.json",
     "number": "1338",
+    "performer": "Starke, Gustav",
     "publisher": "Welte-Mignon",
-    "title": "Lehár/Starke - Die Lustige witwe: II. Potpourri",
-    "type": "welte-red"
+    "title": "Lehár/Starke - Die   Lustige witwe: II. Potpourri",
+    "type": "welte-red",
+    "work": "Die   Lustige witwe: II. Potpourri"
   },
   {
+    "arranger": "",
+    "composer": "Leoncavallo, Ruggiero",
     "druid": "jg699wz4435",
-    "image_url": "https://stacks.stanford.edu/image/iiif/jg699wz4435%2Fjg699wz4435_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/jg699wz4435/jg699wz4435_0001/info.json",
     "number": "106",
+    "performer": "Adam-Benard, Eugenie",
     "publisher": "Welte-Mignon",
     "title": "Leoncavallo/Adam-Benard - Prolog a. bajazzo",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Prolog a. bajazzo"
   },
   {
+    "arranger": "",
+    "composer": "Leoncavallo, Ruggiero",
     "druid": "zw751nw0097",
-    "image_url": "https://stacks.stanford.edu/image/iiif/zw751nw0097%2Fzw751nw0097_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/zw751nw0097/zw751nw0097_0001/info.json",
     "number": "1023",
+    "performer": "Leoncavallo, Ruggiero",
     "publisher": "Welte-Mignon",
     "title": "Leoncavallo/Leoncavallo - Valse de musette: a. II. Act \"die Bohème\"",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Valse de musette: a. II. Act \"die Bohème\""
   },
   {
+    "arranger": "",
+    "composer": "Leschetizky, Theodor",
     "druid": "ts972sy8288",
-    "image_url": "https://stacks.stanford.edu/image/iiif/ts972sy8288%2Fts972sy8288_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/ts972sy8288/ts972sy8288_0001/info.json",
     "number": "1196",
+    "performer": "Leschetizky, Theodor",
     "publisher": "Welte-Mignon",
     "title": "Leschetizky/Leschetizky - Barcarolle op. 39, no. 1",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Barcarolle op. 39, no. 1"
   },
   {
+    "arranger": "",
+    "composer": "Leschetizky, Theodor",
     "druid": "ws749sk4778",
-    "image_url": "https://stacks.stanford.edu/image/iiif/ws749sk4778%2Fws749sk4778_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/ws749sk4778/ws749sk4778_0001/info.json",
     "number": "1203",
+    "performer": "Leschetizky, Theodor",
     "publisher": "Welte-Mignon",
-    "title": "Leschetizky/Leschetizky - The Two larks",
-    "type": "welte-red"
+    "title": "Leschetizky/Leschetizky - The   Two larks",
+    "type": "welte-red",
+    "work": "The   Two larks"
   },
   {
+    "arranger": "",
+    "composer": "Lincke, Paul",
     "druid": "xk500gs5691",
-    "image_url": "https://stacks.stanford.edu/image/iiif/xk500gs5691%2Fxk500gs5691_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/xk500gs5691/xk500gs5691_0001/info.json",
     "number": "337",
+    "performer": "Kupfernagel, Albrecht",
     "publisher": "Welte-Mignon",
     "title": "Lincke/Kupfernagel - Berliner luft: Marsch",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Berliner luft: Marsch"
   },
   {
+    "arranger": "",
+    "composer": "Lincke, Paul",
     "druid": "fw547rc7021",
-    "image_url": "https://stacks.stanford.edu/image/iiif/fw547rc7021%2Ffw547rc7021_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/fw547rc7021/fw547rc7021_0001/info.json",
     "number": "1396",
+    "performer": "Orlando, N",
     "publisher": "Welte-Mignon",
     "title": "Lincke/Orlando - Luna-walzer: a. d. Operette \"Frau Luna\"",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Luna-walzer: a. d. Operette \"Frau Luna\""
   },
   {
+    "arranger": "Vetter, Hermann, 1859-1928",
+    "composer": "Liszt, Franz, 1811-1886",
     "druid": "jg717nb8731",
-    "image_url": "https://stacks.stanford.edu/image/iiif/jg717nb8731%2Fjg717nb8731_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/jg717nb8731/jg717nb8731_0001/info.json",
     "number": "2703",
+    "performer": "Lohr, Johanna",
     "publisher": "Welte-Mignon",
     "title": "Liszt-Vetter/Lohr - Ii. ungarische rhapsodie: mit Cadenz von Prof. H. Vetter",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Ii. ungarische rhapsodie: mit Cadenz von Prof. H. Vetter"
   },
   {
+    "arranger": "",
+    "composer": "Liszt, Franz",
     "druid": "vs059bb4318",
-    "image_url": "https://stacks.stanford.edu/image/iiif/vs059bb4318%2Fvs059bb4318_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/vs059bb4318/vs059bb4318_0001/info.json",
     "number": "104",
+    "performer": "Adam-Benard, Eugenie",
     "publisher": "Welte-Mignon",
     "title": "Liszt/Adam-Benard - Nocturne no. 2",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Nocturne no. 2"
   },
   {
+    "arranger": "",
+    "composer": "Liszt, Franz",
     "druid": "gg920pz0818",
-    "image_url": "https://stacks.stanford.edu/image/iiif/gg920pz0818%2Fgg920pz0818_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/gg920pz0818/gg920pz0818_0001/info.json",
     "number": "415",
+    "performer": "Albert, Eugen d'",
     "publisher": "Welte-Mignon",
     "title": "Liszt/Albert - Loves dream",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Loves dream"
   },
   {
+    "arranger": "",
+    "composer": "Liszt, Franz",
     "druid": "ky445sz4630",
-    "image_url": "https://stacks.stanford.edu/image/iiif/ky445sz4630%2Fky445sz4630_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/ky445sz4630/ky445sz4630_0001/info.json",
     "number": "412",
+    "performer": "Albert, Eugen d'",
     "publisher": "Welte-Mignon",
     "title": "Liszt/Albert - Soirée de vienne: I [i.e., 2]",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Soirée de vienne: I [i.e., 2]"
   },
   {
+    "arranger": "",
+    "composer": "Liszt, Franz",
     "druid": "vy193qr6005",
-    "image_url": "https://stacks.stanford.edu/image/iiif/vy193qr6005%2Fvy193qr6005_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/vy193qr6005/vy193qr6005_0001/info.json",
     "number": "2988",
+    "performer": "Albert, Eugen d'",
     "publisher": "Welte-Mignon",
     "title": "Liszt/Albert - Sonata b minor, 2nd part",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Sonata b minor, 2nd part"
   },
   {
+    "arranger": "",
+    "composer": "Liszt, Franz",
     "druid": "gy310qs3678",
-    "image_url": "https://stacks.stanford.edu/image/iiif/gy310qs3678%2Fgy310qs3678_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/gy310qs3678/gy310qs3678_0001/info.json",
     "number": "2987",
+    "performer": "Albert, Eugen d'",
     "publisher": "Welte-Mignon",
     "title": "Liszt/Albert - Sonata b minor, part 1",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Sonata b minor, part 1"
   },
   {
+    "arranger": "",
+    "composer": "Liszt, Franz",
     "druid": "kv550vj8954",
-    "image_url": "https://stacks.stanford.edu/image/iiif/kv550vj8954%2Fkv550vj8954_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/kv550vj8954/kv550vj8954_0001/info.json",
     "number": "444",
+    "performer": "Busoni, Ferruccio",
     "publisher": "Welte-Mignon",
     "title": "Liszt/Busoni - La Campanella: Paganini etude no. 3",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "La Campanella: Paganini etude no. 3"
   },
   {
+    "arranger": "",
+    "composer": "Liszt, Franz",
     "druid": "tp302mb4101",
-    "image_url": "https://stacks.stanford.edu/image/iiif/tp302mb4101%2Ftp302mb4101_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/tp302mb4101/tp302mb4101_0001/info.json",
     "number": "1321",
+    "performer": "Busoni, Ferruccio",
     "publisher": "Welte-Mignon",
     "title": "Liszt/Busoni - Norma: Fantasie",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Norma: Fantasie"
   },
   {
+    "arranger": "",
+    "composer": "Liszt, Franz",
     "druid": "yx536mq2915",
-    "image_url": "https://stacks.stanford.edu/image/iiif/yx536mq2915%2Fyx536mq2915_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/yx536mq2915/yx536mq2915_0001/info.json",
     "number": "365",
+    "performer": "Carreño, Teresa",
     "publisher": "Welte-Mignon",
     "title": "Liszt/Carreño - 6th hungarian rhapsody",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "6th hungarian rhapsody"
   },
   {
+    "arranger": "",
+    "composer": "Liszt, Franz",
     "druid": "yj598pj2879",
-    "image_url": "https://stacks.stanford.edu/image/iiif/yj598pj2879%2Fyj598pj2879_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/yj598pj2879/yj598pj2879_0001/info.json",
     "number": "360",
+    "performer": "Carreño, Teresa",
     "publisher": "Welte-Mignon",
     "title": "Liszt/Carreño - Soirée de vienne, no. 6",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Soirée de vienne, no. 6"
   },
   {
+    "arranger": "",
+    "composer": "Liszt, Franz",
     "druid": "yc867qr9425",
-    "image_url": "https://stacks.stanford.edu/image/iiif/yc867qr9425%2Fyc867qr9425_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/yc867qr9425/yc867qr9425_0001/info.json",
     "number": "2456",
+    "performer": "Danziger, Laura",
     "publisher": "Welte-Mignon",
     "title": "Liszt/Danziger - Gondoliera from venezia e napoli",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Gondoliera from venezia e napoli"
   },
   {
+    "arranger": "",
+    "composer": "Liszt, Franz",
     "druid": "bg098gg3899",
-    "image_url": "https://stacks.stanford.edu/image/iiif/bg098gg3899%2Fbg098gg3899_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/bg098gg3899/bg098gg3899_0001/info.json",
     "number": "494",
+    "performer": "Dohnányi, Ernő",
     "publisher": "Welte-Mignon",
     "title": "Liszt/Dohnányi - 13th rhapsody",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "13th rhapsody"
   },
   {
+    "arranger": "",
+    "composer": "Liszt, Franz",
     "druid": "dp563zh2166",
-    "image_url": "https://stacks.stanford.edu/image/iiif/dp563zh2166%2Fdp563zh2166_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/dp563zh2166/dp563zh2166_0001/info.json",
     "number": "492",
+    "performer": "Dohnányi, Ernő",
     "publisher": "Welte-Mignon",
     "title": "Liszt/Dohnányi - Rakoczy-marsch",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Rakoczy-marsch"
   },
   {
+    "arranger": "",
+    "composer": "Liszt, Franz",
     "druid": "hn488rk0690",
-    "image_url": "https://stacks.stanford.edu/image/iiif/hn488rk0690%2Fhn488rk0690_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/hn488rk0690/hn488rk0690_0001/info.json",
     "number": "496",
+    "performer": "Dohnányi, Ernő",
     "publisher": "Welte-Mignon",
     "title": "Liszt/Dohnányi - Soiree de vienne, no. 4",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Soiree de vienne, no. 4"
   },
   {
+    "arranger": "",
+    "composer": "Liszt, Franz",
     "druid": "hh429fw8081",
-    "image_url": "https://stacks.stanford.edu/image/iiif/hh429fw8081%2Fhh429fw8081_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/hh429fw8081/hh429fw8081_0001/info.json",
     "number": "274",
+    "performer": "Droucker, Sandra",
     "publisher": "Welte-Mignon",
     "title": "Liszt/Droucker - Gnomenreigen",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Gnomenreigen"
   },
   {
+    "arranger": "",
+    "composer": "Liszt, Franz",
     "druid": "tb707nd8515",
-    "image_url": "https://stacks.stanford.edu/image/iiif/tb707nd8515%2Ftb707nd8515_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/tb707nd8515/tb707nd8515_0001/info.json",
     "number": "993",
+    "performer": "Elvyn, Myrtle",
     "publisher": "Welte-Mignon",
     "title": "Liszt/Elvyn - Widmung",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Widmung"
   },
   {
+    "arranger": "",
+    "composer": "Liszt, Franz",
     "druid": "mx460bt7026",
-    "image_url": "https://stacks.stanford.edu/image/iiif/mx460bt7026%2Fmx460bt7026_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/mx460bt7026/mx460bt7026_0001/info.json",
     "number": "198",
+    "performer": "Friedheim, Arthur",
     "publisher": "Welte-Mignon",
     "title": "Liszt/Friedheim - Xii rhapsodie",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Xii rhapsodie"
   },
   {
+    "arranger": "",
+    "composer": "Liszt, Franz",
     "druid": "ch401rm7382",
-    "image_url": "https://stacks.stanford.edu/image/iiif/ch401rm7382%2Fch401rm7382_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/ch401rm7382/ch401rm7382_0001/info.json",
     "number": "3058",
+    "performer": "Ganz, Rudolph",
     "publisher": "Welte-Mignon",
     "title": "Liszt/Ganz - Mignon's lied",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Mignon's lied"
   },
   {
+    "arranger": "",
+    "composer": "Liszt, Franz",
     "druid": "jf649gs2184",
-    "image_url": "https://stacks.stanford.edu/image/iiif/jf649gs2184%2Fjf649gs2184_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/jf649gs2184/jf649gs2184_0001/info.json",
     "number": "936",
+    "performer": "Hambourg, Mark",
     "publisher": "Welte-Mignon",
     "title": "Liszt/Hambourg - Polonaise e major",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Polonaise e major"
   },
   {
+    "arranger": "",
+    "composer": "Liszt, Franz",
     "druid": "cv806rf2664",
-    "image_url": "https://stacks.stanford.edu/image/iiif/cv806rf2664%2Fcv806rf2664_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/cv806rf2664/cv806rf2664_0001/info.json",
     "number": "3410",
+    "performer": "Kwast-Hodapp, Frieda",
     "publisher": "Welte-Mignon",
     "title": "Liszt/Kwast-Hodapp - Wilde jagd: Etude",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Wilde jagd: Etude"
   },
   {
+    "arranger": "",
+    "composer": "Liszt, Franz",
     "druid": "rb625rv7300",
-    "image_url": "https://stacks.stanford.edu/image/iiif/rb625rv7300%2Frb625rv7300_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/rb625rv7300/rb625rv7300_0001/info.json",
     "number": "569",
+    "performer": "Lamond, Frederic",
     "publisher": "Welte-Mignon",
     "title": "Liszt/Lamond - Etude no. 3, des-dur",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Etude no. 3, des-dur"
   },
   {
+    "arranger": "",
+    "composer": "Liszt, Franz",
     "druid": "kz379jn2491",
-    "image_url": "https://stacks.stanford.edu/image/iiif/kz379jn2491%2Fkz379jn2491_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/kz379jn2491/kz379jn2491_0001/info.json",
     "number": "570",
+    "performer": "Lamond, Frederic",
     "publisher": "Welte-Mignon",
     "title": "Liszt/Lamond - Liebestraum",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Liebestraum"
   },
   {
+    "arranger": "",
+    "composer": "Liszt, Franz",
     "druid": "ng103jj1150",
-    "image_url": "https://stacks.stanford.edu/image/iiif/ng103jj1150%2Fng103jj1150_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/ng103jj1150/ng103jj1150_0001/info.json",
     "number": "570",
+    "performer": "Lamond, Frederic",
     "publisher": "Welte-Mignon",
     "title": "Liszt/Lamond - Liebestraum: Nocturn No. 3",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Liebestraum: Nocturn No. 3"
   },
   {
+    "arranger": "",
+    "composer": "Liszt, Franz",
     "druid": "dw083wh0675",
-    "image_url": "https://stacks.stanford.edu/image/iiif/dw083wh0675%2Fdw083wh0675_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/dw083wh0675/dw083wh0675_0001/info.json",
     "number": "1302",
+    "performer": "Lhévinne, Josef",
     "publisher": "Welte-Mignon",
     "title": "Liszt/Lhévinne - Loreley",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Loreley"
   },
   {
+    "arranger": "",
+    "composer": "Liszt, Franz",
     "druid": "jy572md2211",
-    "image_url": "https://stacks.stanford.edu/image/iiif/jy572md2211%2Fjy572md2211_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/jy572md2211/jy572md2211_0001/info.json",
     "number": "3333",
+    "performer": "Lászlò, Sándor",
     "publisher": "Welte-Mignon",
     "title": "Liszt/Lászlò - Piano-concert e major: 1st movement",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Piano-concert e major: 1st movement"
   },
   {
+    "arranger": "",
+    "composer": "Liszt, Franz",
     "druid": "zk440mh1715",
-    "image_url": "https://stacks.stanford.edu/image/iiif/zk440mh1715%2Fzk440mh1715_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/zk440mh1715/zk440mh1715_0001/info.json",
     "number": "757",
+    "performer": "Mero, Yolanda",
     "publisher": "Welte-Mignon",
     "title": "Liszt/Mero - 2nd hungarian rhapsody",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "2nd hungarian rhapsody"
   },
   {
+    "arranger": "",
+    "composer": "Liszt, Franz",
     "druid": "hg174cq6672",
-    "image_url": "https://stacks.stanford.edu/image/iiif/hg174cq6672%2Fhg174cq6672_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/hg174cq6672/hg174cq6672_0001/info.json",
     "number": "757",
+    "performer": "Mero, Yolanda",
     "publisher": "Welte-Mignon",
     "title": "Liszt/Mero - Ii. ungarische rhapsodie",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Ii. ungarische rhapsodie"
   },
   {
+    "arranger": "",
+    "composer": "Liszt, Franz",
     "druid": "cz847th6835",
-    "image_url": "https://stacks.stanford.edu/image/iiif/cz847th6835%2Fcz847th6835_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/cz847th6835/cz847th6835_0001/info.json",
     "number": "1112",
+    "performer": "Ney, Elly",
     "publisher": "Welte-Mignon",
     "title": "Liszt/Ney - Viii. rhapsodie",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Viii. rhapsodie"
   },
   {
+    "arranger": "",
+    "composer": "Liszt, Franz",
     "druid": "wp442mf3514",
-    "image_url": "https://stacks.stanford.edu/image/iiif/wp442mf3514%2Fwp442mf3514_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/wp442mf3514/wp442mf3514_0001/info.json",
     "number": "1216",
+    "performer": "Pachmann, Vladimir de",
     "publisher": "Welte-Mignon",
     "title": "Liszt/Pachmann - Etude de concert: no. 2, f-Moll",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Etude de concert: no. 2, f-Moll"
   },
   {
+    "arranger": "",
+    "composer": "Liszt, Franz",
     "druid": "zv884mc0794",
-    "image_url": "https://stacks.stanford.edu/image/iiif/zv884mc0794%2Fzv884mc0794_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/zv884mc0794/zv884mc0794_0001/info.json",
     "number": "1259",
+    "performer": "Paderewski, Ignace Jan",
     "publisher": "Welte-Mignon",
     "title": "Liszt/Paderewski - 10th hungarian rhapsody",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "10th hungarian rhapsody"
   },
   {
+    "arranger": "",
+    "composer": "Liszt, Franz",
     "druid": "qg121rz6125",
-    "image_url": "https://stacks.stanford.edu/image/iiif/qg121rz6125%2Fqg121rz6125_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/qg121rz6125/qg121rz6125_0001/info.json",
     "number": "1259",
+    "performer": "Paderewski, Ignace Jan",
     "publisher": "Welte-Mignon",
     "title": "Liszt/Paderewski - X. rhapsodie",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "X. rhapsodie"
   },
   {
+    "arranger": "",
+    "composer": "Liszt, Franz",
     "druid": "gz430tm0196",
-    "image_url": "https://stacks.stanford.edu/image/iiif/gz430tm0196%2Fgz430tm0196_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/gz430tm0196/gz430tm0196_0001/info.json",
     "number": "844",
+    "performer": "Pauer, Max",
     "publisher": "Welte-Mignon",
     "title": "Liszt/Pauer - Harmonie du soir",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Harmonie du soir"
   },
   {
+    "arranger": "",
+    "composer": "Liszt, Franz",
     "druid": "fd761bx2206",
-    "image_url": "https://stacks.stanford.edu/image/iiif/fd761bx2206%2Ffd761bx2206_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/fd761bx2206/fd761bx2206_0001/info.json",
     "number": "518",
+    "performer": "Petri, Egon",
     "publisher": "Welte-Mignon",
     "title": "Liszt/Petri - Années de pélerinage, iii, no. 4: les jeux d'eaux de la Villa d'Este",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Années de pélerinage, iii, no. 4: les jeux d'eaux de la Villa d'Este"
   },
   {
+    "arranger": "",
+    "composer": "Liszt, Franz",
     "druid": "qq914np5449",
-    "image_url": "https://stacks.stanford.edu/image/iiif/qq914np5449%2Fqq914np5449_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/qq914np5449/qq914np5449_0001/info.json",
     "number": "324",
+    "performer": "Reisenauer, Alfred",
     "publisher": "Welte-Mignon",
     "title": "Liszt/Reisenauer - X ung. rhapsodie",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "X ung. rhapsodie"
   },
   {
+    "arranger": "",
+    "composer": "Liszt, Franz",
     "druid": "zw755dp8285",
-    "image_url": "https://stacks.stanford.edu/image/iiif/zw755dp8285%2Fzw755dp8285_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/zw755dp8285/zw755dp8285_0001/info.json",
     "number": "483",
+    "performer": "Ripper, Alice",
     "publisher": "Welte-Mignon",
     "title": "Liszt/Ripper - Faust-walzer",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Faust-walzer"
   },
   {
+    "arranger": "",
+    "composer": "Liszt, Franz",
     "druid": "fv104hn7521",
-    "image_url": "https://stacks.stanford.edu/image/iiif/fv104hn7521%2Ffv104hn7521_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/fv104hn7521/fv104hn7521_0001/info.json",
     "number": "304",
+    "performer": "Rössel, Anatol von",
     "publisher": "Welte-Mignon",
     "title": "Liszt/Rössel - V. hungarian rhapsody: (Heroide elegique)",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "V. hungarian rhapsody: (Heroide elegique)"
   },
   {
+    "arranger": "",
+    "composer": "Liszt, Franz",
     "druid": "ns598kr8616",
-    "image_url": "https://stacks.stanford.edu/image/iiif/ns598kr8616%2Fns598kr8616_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/ns598kr8616/ns598kr8616_0001/info.json",
     "number": "1474",
+    "performer": "Samaroff Stokowski, Olga",
     "publisher": "Welte-Mignon",
     "title": "Liszt/Samaroff Stokowski - Tannhauser march",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Tannhauser march"
   },
   {
+    "arranger": "",
+    "composer": "Liszt, Franz",
     "druid": "fj448by1666",
-    "image_url": "https://stacks.stanford.edu/image/iiif/fj448by1666%2Ffj448by1666_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/fj448by1666/fj448by1666_0001/info.json",
     "number": "1474",
+    "performer": "Samaroff Stokowski, Olga",
     "publisher": "Welte-Mignon",
     "title": "Liszt/Samaroff Stokowski - Tannhäuser-marsch",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Tannhäuser-marsch"
   },
   {
+    "arranger": "",
+    "composer": "Liszt, Franz",
     "druid": "rq927dq9061",
-    "image_url": "https://stacks.stanford.edu/image/iiif/rq927dq9061%2Frq927dq9061_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/rq927dq9061/rq927dq9061_0001/info.json",
     "number": "951",
+    "performer": "Sapellnikoff, W. (Wassily)",
     "publisher": "Welte-Mignon",
     "title": "Liszt/Sapellnikoff - Nocturne: No. 1: \"Hohe Liebe\"",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Nocturne: No. 1: \"Hohe Liebe\""
   },
   {
+    "arranger": "",
+    "composer": "Liszt, Franz",
     "druid": "hm523dq5554",
-    "image_url": "https://stacks.stanford.edu/image/iiif/hm523dq5554%2Fhm523dq5554_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/hm523dq5554/hm523dq5554_0001/info.json",
     "number": "876",
+    "performer": "Sauer, Emil von",
     "publisher": "Welte-Mignon",
     "title": "Liszt/Sauer - Don juan: Fantasie",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Don juan: Fantasie"
   },
   {
+    "arranger": "",
+    "composer": "Liszt, Franz",
     "druid": "yt837kd6607",
-    "image_url": "https://stacks.stanford.edu/image/iiif/yt837kd6607%2Fyt837kd6607_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/yt837kd6607/yt837kd6607_0001/info.json",
     "number": "244",
+    "performer": "Scharwenka, Xaver",
     "publisher": "Welte-Mignon",
     "title": "Liszt/Scharwenka - Ricordanza",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Ricordanza"
   },
   {
+    "arranger": "",
+    "composer": "Liszt, Franz",
     "druid": "ny706rg1119",
-    "image_url": "https://stacks.stanford.edu/image/iiif/ny706rg1119%2Fny706rg1119_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/ny706rg1119/ny706rg1119_0001/info.json",
     "number": "895",
+    "performer": "Schnitzer, Germaine",
     "publisher": "Welte-Mignon",
     "title": "Liszt/Schnitzer - Ix. rhapsodie",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Ix. rhapsodie"
   },
   {
+    "arranger": "",
+    "composer": "Liszt, Franz",
     "druid": "st011pr3757",
-    "image_url": "https://stacks.stanford.edu/image/iiif/st011pr3757%2Fst011pr3757_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/st011pr3757/st011pr3757_0001/info.json",
     "number": "738",
+    "performer": "Schumann, Georg",
     "publisher": "Welte-Mignon",
     "title": "Liszt/Schumann - Waldesrauschen: 1st concert étude",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Waldesrauschen: 1st concert étude"
   },
   {
+    "arranger": "",
+    "composer": "Liszt, Franz",
     "druid": "bx815rz0622",
-    "image_url": "https://stacks.stanford.edu/image/iiif/bx815rz0622%2Fbx815rz0622_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/bx815rz0622/bx815rz0622_0001/info.json",
     "number": "1033",
+    "performer": "Stavenhagen, Bernhard",
     "publisher": "Welte-Mignon",
     "title": "Liszt/Stavenhagen - 12th hungarian rhapsody: (as played by Liszt)",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "12th hungarian rhapsody: (as played by Liszt)"
   },
   {
+    "arranger": "",
+    "composer": "Liszt, Franz",
     "druid": "ry948sf9078",
-    "image_url": "https://stacks.stanford.edu/image/iiif/ry948sf9078%2Fry948sf9078_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/ry948sf9078/ry948sf9078_0001/info.json",
     "number": "1032",
+    "performer": "Stavenhagen, Bernhard",
     "publisher": "Welte-Mignon",
     "title": "Liszt/Stavenhagen - Ii. legende: Der hl. Franziskus über die Wogen schreitend",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Ii. legende: Der hl. Franziskus über die Wogen schreitend"
   },
   {
+    "arranger": "",
+    "composer": "Liszt, Franz",
     "druid": "hg282mg9396",
-    "image_url": "https://stacks.stanford.edu/image/iiif/hg282mg9396%2Fhg282mg9396_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/hg282mg9396/hg282mg9396_0001/info.json",
     "number": "1033",
+    "performer": "Stavenhagen, Bernhard",
     "publisher": "Welte-Mignon",
     "title": "Liszt/Stavenhagen - Xii. ungar. rapsodie: (nach persönlicher Erinnerung an Liszt = (played by as Liszt)",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Xii. ungar. rapsodie: (nach persönlicher Erinnerung an Liszt = (played by as Liszt)"
   },
   {
+    "arranger": "",
+    "composer": "Liszt, Franz",
     "druid": "np829dt9039",
-    "image_url": "https://stacks.stanford.edu/image/iiif/np829dt9039%2Fnp829dt9039_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/np829dt9039/np829dt9039_0001/info.json",
     "number": "1386",
+    "performer": "Timanoff, Vera",
     "publisher": "Welte-Mignon",
     "title": "Liszt/Timanoff - I. ungarische rhapsodie",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "I. ungarische rhapsodie"
   },
   {
+    "arranger": "",
+    "composer": "Liszt, Franz",
     "druid": "sr504pc8797",
-    "image_url": "https://stacks.stanford.edu/image/iiif/sr504pc8797%2Fsr504pc8797_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/sr504pc8797/sr504pc8797_0001/info.json",
     "number": "376",
+    "performer": "Wendling, Carl",
     "publisher": "Welte-Mignon",
     "title": "Liszt/Wendling - Lohengrin: Elsa's bridal procession",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Lohengrin: Elsa's bridal procession"
   },
   {
+    "arranger": "",
+    "composer": "Li͡apunov, S. M. (Sergeĭ Mikhaĭlovich)",
     "druid": "gx118hr0306",
-    "image_url": "https://stacks.stanford.edu/image/iiif/gx118hr0306%2Fgx118hr0306_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/gx118hr0306/gx118hr0306_0001/info.json",
     "number": "1957",
+    "performer": "Drozdov, Vladimir",
     "publisher": "Welte-Mignon",
     "title": "Li͡apunov/Drozdov - Carillon",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Carillon"
   },
   {
+    "arranger": "",
+    "composer": "Lope, Santiago",
     "druid": "gv741wj6162",
-    "image_url": "https://stacks.stanford.edu/image/iiif/gv741wj6162%2Fgv741wj6162_0002/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/gv741wj6162/gv741wj6162_0002/info.json",
     "number": "4478",
+    "performer": "",
     "publisher": "Princesa",
     "title": "Lope - Gallito: paso doble flamenco",
-    "type": "88-note"
+    "type": "88-note",
+    "work": "Gallito: paso doble flamenco"
   },
   {
+    "arranger": "",
+    "composer": "MacDowell, Edward",
     "druid": "xy812vy7103",
-    "image_url": "https://stacks.stanford.edu/image/iiif/xy812vy7103%2Fxy812vy7103_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/xy812vy7103/xy812vy7103_0001/info.json",
     "number": "3681",
+    "performer": "Cone, Carolyne",
     "publisher": "Welte-Mignon",
-    "title": "MacDowell/Cone - An Old love story: op. 61, no. 1",
-    "type": "welte-red"
+    "title": "MacDowell/Cone - An   Old love story: op. 61, no. 1",
+    "type": "welte-red",
+    "work": "An   Old love story: op. 61, no. 1"
   },
   {
+    "arranger": "",
+    "composer": "MacDowell, Edward",
     "druid": "fk269mx8427",
-    "image_url": "https://stacks.stanford.edu/image/iiif/fk269mx8427%2Ffk269mx8427_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/fk269mx8427/fk269mx8427_0001/info.json",
     "number": "2998",
+    "performer": "Winogradoff-Gorges, Nora",
     "publisher": "Welte-Mignon",
     "title": "MacDowell/Winogradoff-Gorges - Polonaise e minor, op. 46, no. 12",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Polonaise e minor, op. 46, no. 12"
   },
   {
+    "arranger": "",
+    "composer": "MacDowell, Edward",
     "druid": "dp497dz1055",
-    "image_url": "https://stacks.stanford.edu/image/iiif/dp497dz1055%2Fdp497dz1055_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/dp497dz1055/dp497dz1055_0001/info.json",
     "number": "469",
+    "performer": "Zadora, Michael",
     "publisher": "Welte-Mignon",
     "title": "MacDowell/Zadora - Hexentanz: op. 17, no. 2",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Hexentanz: op. 17, no. 2"
   },
   {
+    "arranger": "",
+    "composer": "Malderen, Édouard van",
     "druid": "md908xy8241",
-    "image_url": "https://stacks.stanford.edu/image/iiif/md908xy8241%2Fmd908xy8241_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/md908xy8241/md908xy8241_0001/info.json",
     "number": "5551",
+    "performer": "Schrempp, O",
     "publisher": "Welte-Mignon",
     "title": "Malderen/Schrempp - Tango du rêve: (Traum Tango)",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Tango du rêve: (Traum Tango)"
   },
   {
+    "arranger": "",
+    "composer": "Marquina, Pascual, 1873-1948",
     "druid": "qh464nj1973",
-    "image_url": "https://stacks.stanford.edu/image/iiif/qh464nj1973%2Fqh464nj1973_0002/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/qh464nj1973/qh464nj1973_0002/info.json",
     "number": "4671",
+    "performer": "",
     "publisher": "Princesa",
     "title": "Marquina - Ecos españoles: pasodoble",
-    "type": "88-note"
+    "type": "88-note",
+    "work": "Ecos españoles: pasodoble"
   },
   {
+    "arranger": "",
+    "composer": "Martínez Valls, Rafael, 1887-1946",
     "druid": "jp202jq5812",
-    "image_url": "https://stacks.stanford.edu/image/iiif/jp202jq5812%2Fjp202jq5812_0002/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/jp202jq5812/jp202jq5812_0002/info.json",
     "number": "1606",
+    "performer": "",
     "publisher": "Caecilia",
     "title": "Martínez Valls - Serenata poética: en forma de fox trot",
-    "type": "88-note"
+    "type": "88-note",
+    "work": "Serenata poética: en forma de fox trot"
   },
   {
+    "arranger": "",
+    "composer": "Marx-Goldschmidt, Berthe",
     "druid": "ps751km7125",
-    "image_url": "https://stacks.stanford.edu/image/iiif/ps751km7125%2Fps751km7125_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/ps751km7125/ps751km7125_0001/info.json",
     "number": "814",
+    "performer": "Marx-Goldschmidt, Berthe",
     "publisher": "Welte-Mignon",
     "title": "Marx-Goldschmidt/Marx-Goldschmidt - Rhapsodie hongroise: nach Sarasates Zigeunerweisen",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Rhapsodie hongroise: nach Sarasates Zigeunerweisen"
   },
   {
+    "arranger": "",
+    "composer": "Mascagni, Pietro",
     "druid": "ny606dc0992",
-    "image_url": "https://stacks.stanford.edu/image/iiif/ny606dc0992%2Fny606dc0992_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/ny606dc0992/ny606dc0992_0001/info.json",
     "number": "B-6239",
+    "performer": "Davis, Mettler",
     "publisher": "De Luxe",
     "title": "Mascagni/Davis - Cavelleria rusticana",
-    "type": "welte-licensee"
+    "type": "welte-licensee",
+    "work": "Cavelleria rusticana"
   },
   {
+    "arranger": "",
+    "composer": "Mascagni, Pietro",
     "druid": "vm351pv9656",
-    "image_url": "https://stacks.stanford.edu/image/iiif/vm351pv9656%2Fvm351pv9656_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/vm351pv9656/vm351pv9656_0001/info.json",
     "number": "253",
+    "performer": "Zscherneck, Georg",
     "publisher": "Welte-Mignon",
     "title": "Mascagni/Zscherneck - Intermezzo aus cavalleria rusticana",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Intermezzo aus cavalleria rusticana"
   },
   {
+    "arranger": "",
+    "composer": "Mason, Lowell",
     "druid": "jd052zg1047",
-    "image_url": "https://stacks.stanford.edu/image/iiif/jd052zg1047%2Fjd052zg1047_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/jd052zg1047/jd052zg1047_0001/info.json",
     "number": "2685",
+    "performer": "Adam, Eugenie",
     "publisher": "Welte-Mignon",
     "title": "Mason/Adam - Nearer my god to thee",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Nearer my god to thee"
   },
   {
+    "arranger": "",
+    "composer": "Massenet, Jules",
     "druid": "fm197wc9522",
-    "image_url": "https://stacks.stanford.edu/image/iiif/fm197wc9522%2Ffm197wc9522_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/fm197wc9522/fm197wc9522_0001/info.json",
     "number": "2908",
+    "performer": "Epstein, Richard",
     "publisher": "Welte-Mignon",
     "title": "Massenet/Epstein - Manon: selection",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Manon: selection"
   },
   {
+    "arranger": "",
+    "composer": "Massenet, Jules",
     "druid": "rs765sm2000",
-    "image_url": "https://stacks.stanford.edu/image/iiif/rs765sm2000%2Frs765sm2000_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/rs765sm2000/rs765sm2000_0001/info.json",
     "number": "2822",
+    "performer": "Gayraud, P",
     "publisher": "Welte-Mignon",
     "title": "Massenet/Gayraud - Thaïs: fantasia mosaïc",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Thaïs: fantasia mosaïc"
   },
   {
+    "arranger": "",
+    "composer": "Massenet, Jules",
     "druid": "zr938kz3902",
-    "image_url": "https://stacks.stanford.edu/image/iiif/zr938kz3902%2Fzr938kz3902_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/zr938kz3902/zr938kz3902_0001/info.json",
     "number": "2823",
+    "performer": "Gayraud, P",
     "publisher": "Welte-Mignon",
     "title": "Massenet/Gayraud - Werther: fantasia, part I",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Werther: fantasia, part I"
   },
   {
+    "arranger": "",
+    "composer": "Massenet, Jules",
     "druid": "nz852nk6103",
-    "image_url": "https://stacks.stanford.edu/image/iiif/nz852nk6103%2Fnz852nk6103_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/nz852nk6103/nz852nk6103_0001/info.json",
     "number": "2556",
+    "performer": "Paur, Emil",
     "publisher": "Welte-Mignon",
     "title": "Massenet/Paur - Thais, meditation",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Thais, meditation"
   },
   {
+    "arranger": "Hutcheson, Ernest",
+    "composer": "Mendelssohn-Bartholdy, Felix",
     "druid": "hh361xy4933",
-    "image_url": "https://stacks.stanford.edu/image/iiif/hh361xy4933%2Fhh361xy4933_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/hh361xy4933/hh361xy4933_0001/info.json",
     "number": "C-6893",
+    "performer": "Bacon, Katherine",
     "publisher": "De Luxe",
     "title": "Mendelssohn-Bartholdy-Hutcheson/Bacon - Scherzo (midsummer night's dream)",
-    "type": "welte-licensee"
+    "type": "welte-licensee",
+    "work": "Scherzo (midsummer night's dream)"
   },
   {
+    "arranger": "Liszt, Franz",
+    "composer": "Mendelssohn-Bartholdy, Felix",
     "druid": "xp003dy0437",
-    "image_url": "https://stacks.stanford.edu/image/iiif/xp003dy0437%2Fxp003dy0437_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/xp003dy0437/xp003dy0437_0001/info.json",
     "number": "882",
+    "performer": "Sauer, Emil von",
     "publisher": "Welte-Mignon",
     "title": "Mendelssohn-Bartholdy-Liszt/Sauer - Auf flügeln des gesangs",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Auf flügeln des gesangs"
   },
   {
+    "arranger": "",
+    "composer": "Mendelssohn-Bartholdy, Felix",
     "druid": "xn796bh4368",
-    "image_url": "https://stacks.stanford.edu/image/iiif/xn796bh4368%2Fxn796bh4368_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/xn796bh4368/xn796bh4368_0001/info.json",
     "number": "216",
+    "performer": "Adam-Benard, Eugenie",
     "publisher": "Welte-Mignon",
     "title": "Mendelssohn-Bartholdy/Adam-Benard - Lied ohne worte: Moderato, No. 4",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Lied ohne worte: Moderato, No. 4"
   },
   {
+    "arranger": "",
+    "composer": "Mendelssohn-Bartholdy, Felix",
     "druid": "mx599qs6329",
-    "image_url": "https://stacks.stanford.edu/image/iiif/mx599qs6329%2Fmx599qs6329_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/mx599qs6329/mx599qs6329_0001/info.json",
     "number": "40",
+    "performer": "Adam-Benard, Eugenie",
     "publisher": "Welte-Mignon",
     "title": "Mendelssohn-Bartholdy/Adam-Benard - Lied ohne worte: Volkslied, No. 23",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Lied ohne worte: Volkslied, No. 23"
   },
   {
+    "arranger": "",
+    "composer": "Mendelssohn-Bartholdy, Felix",
     "druid": "jk702cg2022",
-    "image_url": "https://stacks.stanford.edu/image/iiif/jk702cg2022%2Fjk702cg2022_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/jk702cg2022/jk702cg2022_0001/info.json",
     "number": "1466",
+    "performer": "Bloomfield-Zeisler, Fannie",
     "publisher": "Welte-Mignon",
     "title": "Mendelssohn-Bartholdy/Bloomfield-Zeisler - Frühlingslied",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Frühlingslied"
   },
   {
+    "arranger": "",
+    "composer": "Mendelssohn-Bartholdy, Felix",
     "druid": "cw427tw4145",
-    "image_url": "https://stacks.stanford.edu/image/iiif/cw427tw4145%2Fcw427tw4145_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/cw427tw4145/cw427tw4145_0001/info.json",
     "number": "2000",
+    "performer": "Goraïnoff, Irina",
     "publisher": "Welte-Mignon",
     "title": "Mendelssohn-Bartholdy/Goraïnoff - Rondo capriccioso",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Rondo capriccioso"
   },
   {
+    "arranger": "",
+    "composer": "Mendelssohn-Bartholdy, Felix",
     "druid": "cd381jt9273",
-    "image_url": "https://stacks.stanford.edu/image/iiif/cd381jt9273%2Fcd381jt9273_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/cd381jt9273/cd381jt9273_0001/info.json",
     "number": "3172",
+    "performer": "Kiek, Georges",
     "publisher": "Welte-Mignon",
     "title": "Mendelssohn-Bartholdy/Kiek - 3th symphony: Allegro vivacissimo",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "3th symphony: Allegro vivacissimo"
   },
   {
+    "arranger": "",
+    "composer": "Mendelssohn-Bartholdy, Felix",
     "druid": "bd915bs0646",
-    "image_url": "https://stacks.stanford.edu/image/iiif/bd915bs0646%2Fbd915bs0646_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/bd915bs0646/bd915bs0646_0001/info.json",
     "number": "3162",
+    "performer": "Kiek, Georges",
     "publisher": "Welte-Mignon",
     "title": "Mendelssohn-Bartholdy/Kiek - Capriccio brilliante b major",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Capriccio brilliante b major"
   },
   {
+    "arranger": "",
+    "composer": "Mendelssohn-Bartholdy, Felix",
     "druid": "zv706jf8277",
-    "image_url": "https://stacks.stanford.edu/image/iiif/zv706jf8277%2Fzv706jf8277_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/zv706jf8277/zv706jf8277_0001/info.json",
     "number": "458",
+    "performer": "Kleeberg, Clotilde",
     "publisher": "Welte-Mignon",
     "title": "Mendelssohn-Bartholdy/Kleeberg - Duetto: (Song without words): A flat major",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Duetto: (Song without words) : A flat major"
   },
   {
+    "arranger": "",
+    "composer": "Mendelssohn-Bartholdy, Felix",
     "druid": "ym420hv4366",
-    "image_url": "https://stacks.stanford.edu/image/iiif/ym420hv4366%2Fym420hv4366_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/ym420hv4366/ym420hv4366_0001/info.json",
     "number": "231",
+    "performer": "Möhle, Hermann",
     "publisher": "Welte-Mignon",
     "title": "Mendelssohn-Bartholdy/Möhle - Lied ohne worte, op. 62, [no. 4], no. 28",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Lied ohne worte, op. 62, [no. 4], no. 28"
   },
   {
+    "arranger": "",
+    "composer": "Mendelssohn-Bartholdy, Felix",
     "druid": "mz508vq7890",
-    "image_url": "https://stacks.stanford.edu/image/iiif/mz508vq7890%2Fmz508vq7890_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/mz508vq7890/mz508vq7890_0001/info.json",
     "number": "232",
+    "performer": "Scharwenka, Xaver",
     "publisher": "Welte-Mignon",
     "title": "Mendelssohn-Bartholdy/Scharwenka - Scherzo e-moll",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Scherzo e-moll"
   },
   {
+    "arranger": "",
+    "composer": "",
     "druid": "sg713kb1834",
-    "image_url": "https://stacks.stanford.edu/image/iiif/sg713kb1834%2Fsg713kb1834_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/sg713kb1834/sg713kb1834_0001/info.json",
     "number": "3548",
+    "performer": "Merrigan, Orlando",
     "publisher": "Welte-Mignon",
     "title": "Merrigan - Carry me back to ole virginny",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Carry me back to ole virginny"
   },
   {
+    "arranger": "",
+    "composer": "Meyer-Helmund, Erik",
     "druid": "rf416pb7833",
-    "image_url": "https://stacks.stanford.edu/image/iiif/rf416pb7833%2Frf416pb7833_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/rf416pb7833/rf416pb7833_0001/info.json",
     "number": "3452",
+    "performer": "Haass, Hans",
     "publisher": "Welte-Mignon",
     "title": "Meyer-Helmund/Haass - Zauberlied",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Zauberlied"
   },
   {
+    "arranger": "",
+    "composer": "Meyer-Helmund, Erik",
     "druid": "sq235zh0909",
-    "image_url": "https://stacks.stanford.edu/image/iiif/sq235zh0909%2Fsq235zh0909_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/sq235zh0909/sq235zh0909_0001/info.json",
     "number": "612",
+    "performer": "Meyer-Helmund, Erik",
     "publisher": "Welte-Mignon",
     "title": "Meyer-Helmund/Meyer-Helmund - Dein gedenk ich, margarethe",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Dein gedenk ich, margarethe"
   },
   {
+    "arranger": "",
+    "composer": "Moreno Torroba, Federico, 1891-1982",
     "druid": "qf152xr6941",
-    "image_url": "https://stacks.stanford.edu/image/iiif/qf152xr6941%2Fqf152xr6941_0002/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/qf152xr6941/qf152xr6941_0002/info.json",
     "number": "4660",
+    "performer": "",
     "publisher": "Princesa",
     "title": "Moreno Torroba - La Marchenera: Petenera",
-    "type": "88-note"
+    "type": "88-note",
+    "work": "La Marchenera: Petenera"
   },
   {
+    "arranger": "",
+    "composer": "Moszkowski, Moritz",
     "druid": "mn110mt1775",
-    "image_url": "https://stacks.stanford.edu/image/iiif/mn110mt1775%2Fmn110mt1775_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/mn110mt1775/mn110mt1775_0001/info.json",
     "number": "3556",
+    "performer": "Danziger, Laura",
     "publisher": "Welte-Mignon",
     "title": "Moszkowski/Danziger - Barcarole: (from Tales of Hoffman)",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Barcarole: (from Tales of Hoffman)"
   },
   {
+    "arranger": "",
+    "composer": "Moszkowski, Moritz",
     "druid": "hq933dq4264",
-    "image_url": "https://stacks.stanford.edu/image/iiif/hq933dq4264%2Fhq933dq4264_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/hq933dq4264/hq933dq4264_0001/info.json",
     "number": "449",
+    "performer": "Kleeberg, Clotilde",
     "publisher": "Welte-Mignon",
     "title": "Moszkowski/Kleeberg - Liebes walzer: op. 57 no. 5 = (Love's waltz)",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Liebes walzer: op. 57 no. 5 = (Love's waltz)"
   },
   {
+    "arranger": "",
+    "composer": "Mozart, Wolfgang Amadeus",
     "druid": "jx095ty1753",
-    "image_url": "https://stacks.stanford.edu/image/iiif/jx095ty1753%2Fjx095ty1753_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/jx095ty1753/jx095ty1753_0001/info.json",
     "number": "1204",
+    "performer": "Pachmann, Vladimir de",
     "publisher": "Welte-Mignon",
     "title": "Mozart/Pachmann - Sonate, a-dur, nr. 9",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Sonate, a-dur, nr. 9"
   },
   {
+    "arranger": "",
+    "composer": "Mozart, Wolfgang Amadeus",
     "druid": "zb497jz4405",
-    "image_url": "https://stacks.stanford.edu/image/iiif/zb497jz4405%2Fzb497jz4405_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/zb497jz4405/zb497jz4405_0001/info.json",
     "number": "182",
+    "performer": "Reinecke, Carl",
     "publisher": "Welte-Mignon",
     "title": "Mozart/Reinecke - Türkischer marsch",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Türkischer marsch"
   },
   {
+    "arranger": "",
+    "composer": "Mozart, Wolfgang Amadeus",
     "druid": "dq126tp4234",
-    "image_url": "https://stacks.stanford.edu/image/iiif/dq126tp4234%2Fdq126tp4234_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/dq126tp4234/dq126tp4234_0001/info.json",
     "number": "3143",
+    "performer": "Ritter, Franz",
     "publisher": "Welte-Mignon",
     "title": "Mozart/Ritter - Don juan: Overture",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Don juan: Overture"
   },
   {
+    "arranger": "",
+    "composer": "Muñoz Aceña, Patricio, 1894-1940",
     "druid": "zx785pg9042",
-    "image_url": "https://stacks.stanford.edu/image/iiif/zx785pg9042%2Fzx785pg9042_0002/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/zx785pg9042/zx785pg9042_0002/info.json",
     "number": "4636",
+    "performer": "",
     "publisher": "Princesa",
     "title": "Muñoz Aceña - La Cieguita: tango-canción",
-    "type": "88-note"
+    "type": "88-note",
+    "work": "La Cieguita: tango-canción"
   },
   {
+    "arranger": "",
+    "composer": "Offenbach, Jacques",
     "druid": "tr981xw2871",
-    "image_url": "https://stacks.stanford.edu/image/iiif/tr981xw2871%2Ftr981xw2871_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/tr981xw2871/tr981xw2871_0001/info.json",
     "number": "1613",
+    "performer": "Francklyn, Bernard",
     "publisher": "Welte-Mignon",
     "title": "Offenbach/Francklyn - Tales of hoffmann: selection",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Tales of hoffmann: selection"
   },
   {
+    "arranger": "",
+    "composer": "Offenbach, Jacques",
     "druid": "jf942gh3232",
-    "image_url": "https://stacks.stanford.edu/image/iiif/jf942gh3232%2Fjf942gh3232_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/jf942gh3232/jf942gh3232_0001/info.json",
     "number": "258",
+    "performer": "Zscherneck, Georg",
     "publisher": "Welte-Mignon",
     "title": "Offenbach/Zscherneck - Barcarole aus \"hoffmann's erzählungen\"",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Barcarole aus \"hoffmann's erzählungen\""
   },
   {
+    "arranger": "",
+    "composer": "",
     "druid": "pd354nj6106",
-    "image_url": "https://stacks.stanford.edu/image/iiif/pd354nj6106%2Fpd354nj6106_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/pd354nj6106/pd354nj6106_0001/info.json",
     "number": "1454",
+    "performer": "Orlando, N",
     "publisher": "Welte-Mignon",
     "title": "Orlando - God save the king: (national anthem)",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "God save the king: (national anthem)"
   },
   {
+    "arranger": "",
+    "composer": "Pachmann, Vladimir de",
     "druid": "qb477sd2923",
-    "image_url": "https://stacks.stanford.edu/image/iiif/qb477sd2923%2Fqb477sd2923_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/qb477sd2923/qb477sd2923_0001/info.json",
     "number": "1226",
+    "performer": "Pachmann, Vladimir de",
     "publisher": "Welte-Mignon",
     "title": "Pachmann/Pachmann - Improvisation on \"the maiden's prayer\"",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Improvisation on \"the maiden's prayer\""
   },
   {
+    "arranger": "",
+    "composer": "Paderewski, Ignace Jan",
     "druid": "dw479gk0103",
-    "image_url": "https://stacks.stanford.edu/image/iiif/dw479gk0103%2Fdw479gk0103_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/dw479gk0103/dw479gk0103_0001/info.json",
     "number": "1263",
+    "performer": "Paderewski, Ignace Jan",
     "publisher": "Welte-Mignon",
     "title": "Paderewski/Paderewski - Minuett g major",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Minuett g major"
   },
   {
+    "arranger": "",
+    "composer": "Paderewski, Ignace Jan",
     "druid": "qt363fp0799",
-    "image_url": "https://stacks.stanford.edu/image/iiif/qt363fp0799%2Fqt363fp0799_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/qt363fp0799/qt363fp0799_0001/info.json",
     "number": "1262",
+    "performer": "Paderewski, Ignace Jan",
     "publisher": "Welte-Mignon",
     "title": "Paderewski/Paderewski - Nocturne op. 16, no. 4",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Nocturne op. 16, no. 4"
   },
   {
+    "arranger": "",
+    "composer": "Paderewski, Ignace Jan",
     "druid": "sb487jm2092",
-    "image_url": "https://stacks.stanford.edu/image/iiif/sb487jm2092%2Fsb487jm2092_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/sb487jm2092/sb487jm2092_0001/info.json",
     "number": "1262",
+    "performer": "Paderewski, Ignace Jan",
     "publisher": "Welte-Mignon",
     "title": "Paderewski/Paderewski - Nocturno op. 16, no. 4",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Nocturno op. 16, no. 4"
   },
   {
+    "arranger": "",
+    "composer": "Pancho Pérez, José",
     "druid": "bp752qs6053",
-    "image_url": "https://stacks.stanford.edu/image/iiif/bp752qs6053%2Fbp752qs6053_0002/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/bp752qs6053/bp752qs6053_0002/info.json",
     "number": "4291",
+    "performer": "",
     "publisher": "Princesa",
     "title": "Pancho Pérez - Grana y oro: pasodoble",
-    "type": "88-note"
+    "type": "88-note",
+    "work": "Grana y oro: pasodoble"
   },
   {
+    "arranger": "",
+    "composer": "Patiño, Luis, -1961",
     "druid": "qj765hb3428",
-    "image_url": "https://stacks.stanford.edu/image/iiif/qj765hb3428%2Fqj765hb3428_0002/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/qj765hb3428/qj765hb3428_0002/info.json",
     "number": "40059",
+    "performer": "",
     "publisher": "Princesa",
     "title": "Patiño - Suspiro flamenco: pasodoble",
-    "type": "88-note"
+    "type": "88-note",
+    "work": "Suspiro flamenco: pasodoble"
   },
   {
+    "arranger": "",
+    "composer": "Pettorossi, Horacio, 1896-1960",
     "druid": "rx870zt5437",
-    "image_url": "https://stacks.stanford.edu/image/iiif/rx870zt5437%2Frx870zt5437_0002/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/rx870zt5437/rx870zt5437_0002/info.json",
     "number": "4394",
+    "performer": "",
     "publisher": "Princesa",
     "title": "Pettorossi - Galleguita: tango argentino",
-    "type": "88-note"
+    "type": "88-note",
+    "work": "Galleguita: tango argentino"
   },
   {
+    "arranger": "",
+    "composer": "Poldini, Ede",
     "druid": "mf940cg4339",
-    "image_url": "https://stacks.stanford.edu/image/iiif/mf940cg4339%2Fmf940cg4339_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/mf940cg4339/mf940cg4339_0001/info.json",
     "number": "1468",
+    "performer": "Bloomfield-Zeisler, Fannie",
     "publisher": "Welte-Mignon",
     "title": "Poldini/Bloomfield-Zeisler - Poupée valsante",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Poupée valsante"
   },
   {
+    "arranger": "",
+    "composer": "Puccini, Giacomo",
     "druid": "ms935qj0194",
-    "image_url": "https://stacks.stanford.edu/image/iiif/ms935qj0194%2Fms935qj0194_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/ms935qj0194/ms935qj0194_0001/info.json",
     "number": "2255",
+    "performer": "Epstein, Richard",
     "publisher": "Welte-Mignon",
     "title": "Puccini/Epstein - La Boheme: selection",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "La Boheme: selection"
   },
   {
+    "arranger": "",
+    "composer": "Puccini, Giacomo",
     "druid": "fk036vh7282",
-    "image_url": "https://stacks.stanford.edu/image/iiif/fk036vh7282%2Ffk036vh7282_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/fk036vh7282/fk036vh7282_0001/info.json",
     "number": "2254",
+    "performer": "Epstein, Richard",
     "publisher": "Welte-Mignon",
     "title": "Puccini/Epstein - Madam butterfly: selection",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Madam butterfly: selection"
   },
   {
+    "arranger": "",
+    "composer": "Puccini, Giacomo",
     "druid": "pf050rx0162",
-    "image_url": "https://stacks.stanford.edu/image/iiif/pf050rx0162%2Fpf050rx0162_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/pf050rx0162/pf050rx0162_0001/info.json",
     "number": "2254",
+    "performer": "Epstein, Richard",
     "publisher": "Welte-Mignon",
     "title": "Puccini/Epstein - Madam butterfly: selektion",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Madam butterfly: selektion"
   },
   {
+    "arranger": "",
+    "composer": "Puccini, Giacomo",
     "druid": "rr990ym0199",
-    "image_url": "https://stacks.stanford.edu/image/iiif/rr990ym0199%2Frr990ym0199_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/rr990ym0199/rr990ym0199_0001/info.json",
     "number": "2560",
+    "performer": "Paur, Emil",
     "publisher": "Welte-Mignon",
     "title": "Puccini/Paur - Tosca, fantasia",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Tosca, fantasia"
   },
   {
+    "arranger": "",
+    "composer": "Pérez Soriano, Agustín, 1846-1907",
     "druid": "jg489yw0942",
-    "image_url": "https://stacks.stanford.edu/image/iiif/jg489yw0942%2Fjg489yw0942_0002/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/jg489yw0942/jg489yw0942_0002/info.json",
     "number": "4309",
+    "performer": "",
     "publisher": "Princesa",
     "title": "Pérez Soriano - El Guitarrico: Jota",
-    "type": "88-note"
+    "type": "88-note",
+    "work": "El Guitarrico: Jota"
   },
   {
+    "arranger": "",
+    "composer": "Rachmaninoff, Sergei",
     "druid": "kj388dj3308",
-    "image_url": "https://stacks.stanford.edu/image/iiif/kj388dj3308%2Fkj388dj3308_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/kj388dj3308/kj388dj3308_0001/info.json",
     "number": "2079",
+    "performer": "Hill, R",
     "publisher": "Welte-Mignon",
     "title": "Rachmaninoff/Hill - Prelude op. 3, no. 2, c sharp minor",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Prelude op. 3, no. 2, c sharp minor"
   },
   {
+    "arranger": "",
+    "composer": "Rachmaninoff, Sergei",
     "druid": "bh573cc4821",
-    "image_url": "https://stacks.stanford.edu/image/iiif/bh573cc4821%2Fbh573cc4821_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/bh573cc4821/bh573cc4821_0001/info.json",
     "number": "X-6622",
+    "performer": "Leonardi, Leonidas",
     "publisher": "De Luxe",
     "title": "Rachmaninoff/Leonardi - Prelude (op. 32, no. 12)",
-    "type": "welte-licensee"
+    "type": "welte-licensee",
+    "work": "Prelude (op. 32, no. 12)"
   },
   {
+    "arranger": "",
+    "composer": "Rachmaninoff, Sergei",
     "druid": "pr464zk8674",
-    "image_url": "https://stacks.stanford.edu/image/iiif/pr464zk8674%2Fpr464zk8674_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/pr464zk8674/pr464zk8674_0001/info.json",
     "number": "1567",
+    "performer": "Pintel, Jacques",
     "publisher": "Welte-Mignon",
     "title": "Rachmaninoff/Pintel - Prélude d-dur",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Prélude d-dur"
   },
   {
+    "arranger": "",
+    "composer": "Rachmaninoff, Sergei",
     "druid": "yg250xz9762",
-    "image_url": "https://stacks.stanford.edu/image/iiif/yg250xz9762%2Fyg250xz9762_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/yg250xz9762/yg250xz9762_0001/info.json",
     "number": "1571",
+    "performer": "Pintel, Jacques",
     "publisher": "Welte-Mignon",
     "title": "Rachmaninoff/Pintel - Prélude g minor",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Prélude g minor"
   },
   {
+    "arranger": "",
+    "composer": "Rachmaninoff, Sergei",
     "druid": "qj203cn5343",
-    "image_url": "https://stacks.stanford.edu/image/iiif/qj203cn5343%2Fqj203cn5343_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/qj203cn5343/qj203cn5343_0001/info.json",
     "number": "1959",
+    "performer": "Pouishnoff, Leff",
     "publisher": "Welte-Mignon",
     "title": "Rachmaninoff/Pouishnoff - Polichenelle: op. 3, no. 4",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Polichenelle: op. 3, no. 4"
   },
   {
+    "arranger": "",
+    "composer": "Raff, Joachim, 1822-1882",
     "druid": "jy320zw1102",
-    "image_url": "https://stacks.stanford.edu/image/iiif/jy320zw1102%2Fjy320zw1102_0002/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/jy320zw1102/jy320zw1102_0002/info.json",
     "number": "4486",
+    "performer": "",
     "publisher": "Victoria",
     "title": "Raff - Valse impromptu",
-    "type": "88-note"
+    "type": "88-note",
+    "work": "Valse impromptu"
   },
   {
+    "arranger": "",
+    "composer": "Raff, Joachim",
     "druid": "kw215gn3365",
-    "image_url": "https://stacks.stanford.edu/image/iiif/kw215gn3365%2Fkw215gn3365_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/kw215gn3365/kw215gn3365_0001/info.json",
     "number": "3357",
+    "performer": "Flohr, Hubert",
     "publisher": "Welte-Mignon",
     "title": "Raff/Flohr - Cachoucha",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Cachoucha"
   },
   {
+    "arranger": "",
+    "composer": "Raff, Joachim",
     "druid": "hh466mq4616",
-    "image_url": "https://stacks.stanford.edu/image/iiif/hh466mq4616%2Fhh466mq4616_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/hh466mq4616/hh466mq4616_0001/info.json",
     "number": "296",
+    "performer": "Gabrilowitsch, Ossip",
     "publisher": "Welte-Mignon",
     "title": "Raff/Gabrilowitsch - Rigaudon d-dur",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Rigaudon d-dur"
   },
   {
+    "arranger": "",
+    "composer": "Raff, Joachim",
     "druid": "vq227vv6345",
-    "image_url": "https://stacks.stanford.edu/image/iiif/vq227vv6345%2Fvq227vv6345_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/vq227vv6345/vq227vv6345_0001/info.json",
     "number": "424",
+    "performer": "Wendling, Carl",
     "publisher": "Welte-Mignon",
     "title": "Raff/Wendling - La Fileuse: op. 157, no. 2",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "La Fileuse: op. 157, no. 2"
   },
   {
+    "arranger": "Whiteman, Paul",
+    "composer": "Rimsky-Korsakov, Nikolay",
     "druid": "rd899zb5188",
-    "image_url": "https://stacks.stanford.edu/image/iiif/rd899zb5188%2Frd899zb5188_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/rd899zb5188/rd899zb5188_0001/info.json",
     "number": "5608",
+    "performer": "Black, Sidney",
     "publisher": "Welte-Mignon",
     "title": "Rimsky-Korsakov-Whiteman/Black - Play that song of india again: fox-trot-song after \"Korsakow's Sadko\"",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Play that song of india again: fox-trot-song after \"Korsakow's Sadko\""
   },
   {
+    "arranger": "",
+    "composer": "Rosenzweig, Wilhelm",
     "druid": "rv790qz2532",
-    "image_url": "https://stacks.stanford.edu/image/iiif/rv790qz2532%2Frv790qz2532_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/rv790qz2532/rv790qz2532_0001/info.json",
     "number": "226",
+    "performer": "Popper, Hugo",
     "publisher": "Welte-Mignon",
     "title": "Rosenzweig/Popper - Sei mir gut: Walzerlied",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Sei mir gut: Walzerlied"
   },
   {
+    "arranger": "",
+    "composer": "Rosoff, Charles",
     "druid": "xr433hz5827",
-    "image_url": "https://stacks.stanford.edu/image/iiif/xr433hz5827%2Fxr433hz5827_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/xr433hz5827/xr433hz5827_0001/info.json",
     "number": "5718",
+    "performer": "Johnson, Edward",
     "publisher": "Welte-Mignon",
     "title": "Rosoff/Johnson - When you and i were seventeen",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "When you and i were seventeen"
   },
   {
+    "arranger": "Liszt, Franz",
+    "composer": "Rossini, Gioacchino",
     "druid": "sb158jt0685",
-    "image_url": "https://stacks.stanford.edu/image/iiif/sb158jt0685%2Fsb158jt0685_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/sb158jt0685/sb158jt0685_0001/info.json",
     "number": "953",
+    "performer": "Sapellnikoff, W. (Wassily)",
     "publisher": "Welte-Mignon",
     "title": "Rossini-Liszt/Sapellnikoff - William tell: Overture",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "William tell: Overture"
   },
   {
+    "arranger": "",
+    "composer": "Rouget de Lisle, Claude Joseph, 1760-1836",
     "druid": "dv468zh8208",
-    "image_url": "https://stacks.stanford.edu/image/iiif/dv468zh8208%2Fdv468zh8208_0002/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/dv468zh8208/dv468zh8208_0002/info.json",
     "number": "4246",
+    "performer": "",
     "publisher": "Pricesa",
     "title": "Rouget de Lisle - La Marsellesa: himno francés",
-    "type": "88-note"
+    "type": "88-note",
+    "work": "La Marsellesa: himno francés"
   },
   {
+    "arranger": "",
+    "composer": "Rubinstein, Anton",
     "druid": "dt352gh2011",
-    "image_url": "https://stacks.stanford.edu/image/iiif/dt352gh2011%2Fdt352gh2011_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/dt352gh2011/dt352gh2011_0001/info.json",
     "number": "2457",
+    "performer": "Danziger, Laura",
     "publisher": "Welte-Mignon",
     "title": "Rubinstein/Danziger - Kamennoi ostrow: op. 10, Nr. 22",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Kamennoi ostrow: op. 10, Nr. 22"
   },
   {
+    "arranger": "",
+    "composer": "Rubinstein, Anton",
     "druid": "xr682fm1233",
-    "image_url": "https://stacks.stanford.edu/image/iiif/xr682fm1233%2Fxr682fm1233_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/xr682fm1233/xr682fm1233_0001/info.json",
     "number": "660",
+    "performer": "Hofmann, Josef",
     "publisher": "Welte-Mignon",
     "title": "Rubinstein/Hofmann - Melodie op. 3, f major",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Melodie op. 3, f major"
   },
   {
+    "arranger": "",
+    "composer": "Rubinstein, Anton",
     "druid": "td134mh2760",
-    "image_url": "https://stacks.stanford.edu/image/iiif/td134mh2760%2Ftd134mh2760_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/td134mh2760/td134mh2760_0001/info.json",
     "number": "660",
+    "performer": "Hofmann, Josef",
     "publisher": "Welte-Mignon",
     "title": "Rubinstein/Hofmann - Melodie op. 3, f-dur",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Melodie op. 3, f-dur"
   },
   {
+    "arranger": "",
+    "composer": "Rubinstein, Anton",
     "druid": "zc568zf0361",
-    "image_url": "https://stacks.stanford.edu/image/iiif/zc568zf0361%2Fzc568zf0361_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/zc568zf0361/zc568zf0361_0001/info.json",
     "number": "661",
+    "performer": "Hofmann, Josef",
     "publisher": "Welte-Mignon",
     "title": "Rubinstein/Hofmann - Valse allemande",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Valse allemande"
   },
   {
+    "arranger": "",
+    "composer": "Rubinstein, Anton",
     "druid": "wv641dn9264",
-    "image_url": "https://stacks.stanford.edu/image/iiif/wv641dn9264%2Fwv641dn9264_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/wv641dn9264/wv641dn9264_0001/info.json",
     "number": "1304",
+    "performer": "Lhévinne, Josef",
     "publisher": "Welte-Mignon",
     "title": "Rubinstein/Lhévinne - Polka a. \"le bal\"",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Polka a. \"le bal\""
   },
   {
+    "arranger": "",
+    "composer": "Rubinstein, Anton",
     "druid": "cp145vd3423",
-    "image_url": "https://stacks.stanford.edu/image/iiif/cp145vd3423%2Fcp145vd3423_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/cp145vd3423/cp145vd3423_0001/info.json",
     "number": "1382",
+    "performer": "Timanoff, Vera",
     "publisher": "Welte-Mignon",
     "title": "Rubinstein/Timanoff - Sérénade espagnole: op. 16, no 3",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Sérénade espagnole: op. 16, no 3"
   },
   {
+    "arranger": "",
+    "composer": "Saint-Saëns, Camille",
     "druid": "cp259ms0085",
-    "image_url": "https://stacks.stanford.edu/image/iiif/cp259ms0085%2Fcp259ms0085_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/cp259ms0085/cp259ms0085_0001/info.json",
     "number": "2260",
+    "performer": "Epstein, Richard",
     "publisher": "Welte-Mignon",
     "title": "Saint-Saëns/Epstein - Samson and delilah: Cantabile du grand duo",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Samson and delilah: Cantabile du grand duo"
   },
   {
+    "arranger": "",
+    "composer": "Saint-Saëns, Camille",
     "druid": "pc276zv7038",
-    "image_url": "https://stacks.stanford.edu/image/iiif/pc276zv7038%2Fpc276zv7038_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/pc276zv7038/pc276zv7038_0001/info.json",
     "number": "2260",
+    "performer": "Epstein, Richard",
     "publisher": "Welte-Mignon",
     "title": "Saint-Saëns/Epstein - Samson and delilah: Cantabile du grand duo",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Samson and delilah: Cantabile du grand duo"
   },
   {
+    "arranger": "",
+    "composer": "Saint-Saëns, Camille",
     "druid": "fy803vj4057",
-    "image_url": "https://stacks.stanford.edu/image/iiif/fy803vj4057%2Ffy803vj4057_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/fy803vj4057/fy803vj4057_0001/info.json",
     "number": "799",
+    "performer": "Saint-Saëns, Camille",
     "publisher": "Welte-Mignon",
     "title": "Saint-Saëns/Saint-Saëns - Mazurka, no. 3",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Mazurka, no. 3"
   },
   {
+    "arranger": "",
+    "composer": "Saint-Saëns, Camille",
     "druid": "pk349zj4179",
-    "image_url": "https://stacks.stanford.edu/image/iiif/pk349zj4179%2Fpk349zj4179_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/pk349zj4179/pk349zj4179_0001/info.json",
     "number": "797",
+    "performer": "Saint-Saëns, Camille",
     "publisher": "Welte-Mignon",
     "title": "Saint-Saëns/Saint-Saëns - Samson and delilah: Finale, Act 1",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Samson and delilah: Finale, Act 1"
   },
   {
+    "arranger": "",
+    "composer": "Sanders, Julio, 1897-1942",
     "druid": "zk199jz1564",
-    "image_url": "https://stacks.stanford.edu/image/iiif/zk199jz1564%2Fzk199jz1564_0002/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/zk199jz1564/zk199jz1564_0002/info.json",
     "number": "4670",
+    "performer": "",
     "publisher": "Princesa",
     "title": "Sanders - Adiós muchachos: tango",
-    "type": "88-note"
+    "type": "88-note",
+    "work": "Adiós muchachos: tango"
   },
   {
+    "arranger": "",
+    "composer": "Schelling, Ernest",
     "druid": "cz952kx0008",
-    "image_url": "https://stacks.stanford.edu/image/iiif/cz952kx0008%2Fcz952kx0008_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/cz952kx0008/cz952kx0008_0001/info.json",
     "number": "1453",
+    "performer": "Schelling, Ernest",
     "publisher": "Welte-Mignon",
     "title": "Schelling/Schelling - Romanze cis-moll",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Romanze cis-moll"
   },
   {
+    "arranger": "",
+    "composer": "Schlözer, Paul de",
     "druid": "sz207mm8382",
-    "image_url": "https://stacks.stanford.edu/image/iiif/sz207mm8382%2Fsz207mm8382_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/sz207mm8382/sz207mm8382_0001/info.json",
     "number": "1296",
+    "performer": "Lhévinne, Josef",
     "publisher": "Welte-Mignon",
     "title": "Schlözer/Lhévinne - Etude de concert e flat",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Etude de concert e flat"
   },
   {
+    "arranger": "",
+    "composer": "Schlözer, Paul de",
     "druid": "sq640bh1919",
-    "image_url": "https://stacks.stanford.edu/image/iiif/sq640bh1919%2Fsq640bh1919_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/sq640bh1919/sq640bh1919_0001/info.json",
     "number": "1296",
+    "performer": "Lhévinne, Josef",
     "publisher": "Welte-Mignon",
     "title": "Schlözer/Lhévinne - Etude e flat major",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Etude e flat major"
   },
   {
+    "arranger": "Backhaus, Wilhelm",
+    "composer": "Schubert, Franz",
     "druid": "gq401ng9171",
-    "image_url": "https://stacks.stanford.edu/image/iiif/gq401ng9171%2Fgq401ng9171_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/gq401ng9171/gq401ng9171_0001/info.json",
     "number": "3309",
+    "performer": "Backhaus, Wilhelm",
     "publisher": "Welte-Mignon",
     "title": "Schubert-Backhaus/Backhaus - Military march e-flat",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Military march e-flat"
   },
   {
+    "arranger": "Backhaus, Wilhelm",
+    "composer": "Schubert, Franz",
     "druid": "jq774vx6544",
-    "image_url": "https://stacks.stanford.edu/image/iiif/jq774vx6544%2Fjq774vx6544_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/jq774vx6544/jq774vx6544_0001/info.json",
     "number": "3309",
+    "performer": "Backhaus, Wilhelm",
     "publisher": "Welte-Mignon",
     "title": "Schubert-Backhaus/Backhaus - Militärmarsch in es-dur",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Militärmarsch in es-dur"
   },
   {
+    "arranger": "Backhaus, Wilhelm",
+    "composer": "Schubert, Franz",
     "druid": "kf903tz5142",
-    "image_url": "https://stacks.stanford.edu/image/iiif/kf903tz5142%2Fkf903tz5142_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/kf903tz5142/kf903tz5142_0001/info.json",
     "number": "3312",
+    "performer": "Backhaus, Wilhelm",
     "publisher": "Welte-Mignon",
     "title": "Schubert-Backhaus/Backhaus - Wanderer-fantasie: 1st and 2nd movements",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Wanderer-fantasie: 1st and 2nd movements"
   },
   {
+    "arranger": "Liszt, Franz",
+    "composer": "Schubert, Franz",
     "druid": "md331fy4209",
-    "image_url": "https://stacks.stanford.edu/image/iiif/md331fy4209%2Fmd331fy4209_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/md331fy4209/md331fy4209_0001/info.json",
     "number": "723",
+    "performer": "Burmeister, Richard",
     "publisher": "Welte-Mignon",
     "title": "Schubert-Liszt/Burmeister - Ave maria",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Ave maria"
   },
   {
+    "arranger": "Liszt, Franz",
+    "composer": "Schubert, Franz",
     "druid": "sx417qf9868",
-    "image_url": "https://stacks.stanford.edu/image/iiif/sx417qf9868%2Fsx417qf9868_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/sx417qf9868/sx417qf9868_0001/info.json",
     "number": "723",
+    "performer": "Burmeister, Richard",
     "publisher": "Welte-Mignon",
     "title": "Schubert-Liszt/Burmeister - Ave maria",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Ave maria"
   },
   {
+    "arranger": "Liszt, Franz",
+    "composer": "Schubert, Franz",
     "druid": "yg667ds7662",
-    "image_url": "https://stacks.stanford.edu/image/iiif/yg667ds7662%2Fyg667ds7662_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/yg667ds7662/yg667ds7662_0001/info.json",
     "number": "446",
+    "performer": "Busoni, Ferruccio",
     "publisher": "Welte-Mignon",
     "title": "Schubert-Liszt/Busoni - Hungarian march: (Hungarian melodies)",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Hungarian march: (Hungarian melodies)"
   },
   {
+    "arranger": "Liszt, Franz",
+    "composer": "Schubert, Franz",
     "druid": "gq898yv9510",
-    "image_url": "https://stacks.stanford.edu/image/iiif/gq898yv9510%2Fgq898yv9510_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/gq898yv9510/gq898yv9510_0001/info.json",
     "number": "665",
+    "performer": "Hofmann, Josef",
     "publisher": "Welte-Mignon",
     "title": "Schubert-Liszt/Hofmann - Erlkönig",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Erlkönig"
   },
   {
+    "arranger": "Liszt, Franz",
+    "composer": "Schubert, Franz",
     "druid": "sc188ff2842",
-    "image_url": "https://stacks.stanford.edu/image/iiif/sc188ff2842%2Fsc188ff2842_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/sc188ff2842/sc188ff2842_0001/info.json",
     "number": "1260",
+    "performer": "Paderewski, Ignace Jan",
     "publisher": "Welte-Mignon",
     "title": "Schubert-Liszt/Paderewski - The Erl king",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "The Erl king"
   },
   {
+    "arranger": "Tausig, Carl",
+    "composer": "Schubert, Franz",
     "druid": "rc749wx0227",
-    "image_url": "https://stacks.stanford.edu/image/iiif/rc749wx0227%2Frc749wx0227_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/rc749wx0227/rc749wx0227_0001/info.json",
     "number": "1471",
+    "performer": "Bloomfield-Zeisler, Fannie",
     "publisher": "Welte-Mignon",
     "title": "Schubert-Tausig/Bloomfield-Zeisler - Militär-marsch =: (Military march)",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Militär-marsch =: (Military march)"
   },
   {
+    "arranger": "",
+    "composer": "Schubert, Franz",
     "druid": "gb034mq5877",
-    "image_url": "https://stacks.stanford.edu/image/iiif/gb034mq5877%2Fgb034mq5877_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/gb034mq5877/gb034mq5877_0001/info.json",
     "number": "422",
+    "performer": "Albert, Eugen d'",
     "publisher": "Welte-Mignon",
     "title": "Schubert/Albert - Impromptu g major, op. 90, no. 3",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Impromptu g major, op. 90, no. 3"
   },
   {
+    "arranger": "",
+    "composer": "Schubert, Franz",
     "druid": "cm852bp8620",
-    "image_url": "https://stacks.stanford.edu/image/iiif/cm852bp8620%2Fcm852bp8620_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/cm852bp8620/cm852bp8620_0001/info.json",
     "number": "3313",
+    "performer": "Backhaus, Wilhelm",
     "publisher": "Welte-Mignon",
     "title": "Schubert/Backhaus - Wanderer-fantasie: III. und IV. Satz",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Wanderer-fantasie: III. und IV. Satz"
   },
   {
+    "arranger": "",
+    "composer": "Schubert, Franz",
     "druid": "gx107hd3026",
-    "image_url": "https://stacks.stanford.edu/image/iiif/gx107hd3026%2Fgx107hd3026_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/gx107hd3026/gx107hd3026_0001/info.json",
     "number": "3316",
+    "performer": "Lászlò, Sándor",
     "publisher": "Welte-Mignon",
     "title": "Schubert/Lászlò - 8th symphony b minor: 2nd movement: Andante con motto (unfinished)",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "8th symphony b minor: 2nd movement : Andante con motto (unfinished)"
   },
   {
+    "arranger": "",
+    "composer": "Schubert, Franz",
     "druid": "fg074rf2950",
-    "image_url": "https://stacks.stanford.edu/image/iiif/fg074rf2950%2Ffg074rf2950_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/fg074rf2950/fg074rf2950_0001/info.json",
     "number": "2386",
+    "performer": "Mackle, Frieda",
     "publisher": "Welte-Mignon",
     "title": "Schubert/Mackle - Am meer",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Am meer"
   },
   {
+    "arranger": "",
+    "composer": "Schubert, Franz",
     "druid": "sk832rf0203",
-    "image_url": "https://stacks.stanford.edu/image/iiif/sk832rf0203%2Fsk832rf0203_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/sk832rf0203/sk832rf0203_0001/info.json",
     "number": "2388",
+    "performer": "Mackle, Frieda",
     "publisher": "Welte-Mignon",
     "title": "Schubert/Mackle - Der Wanderer",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Der Wanderer"
   },
   {
+    "arranger": "",
+    "composer": "Schubert, Franz",
     "druid": "tj337qh7786",
-    "image_url": "https://stacks.stanford.edu/image/iiif/tj337qh7786%2Ftj337qh7786_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/tj337qh7786/tj337qh7786_0001/info.json",
     "number": "1211",
+    "performer": "Pachmann, Vladimir de",
     "publisher": "Welte-Mignon",
     "title": "Schubert/Pachmann - Moment musical: op. 94, no. 3, F minor",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Moment musical: op. 94, no. 3, F minor"
   },
   {
+    "arranger": "",
+    "composer": "Schubert, Franz",
     "druid": "jv484vp9065",
-    "image_url": "https://stacks.stanford.edu/image/iiif/jv484vp9065%2Fjv484vp9065_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/jv484vp9065/jv484vp9065_0001/info.json",
     "number": "1248",
+    "performer": "Paderewski, Ignace Jan",
     "publisher": "Welte-Mignon",
     "title": "Schubert/Paderewski - Impromptu op. 142, b-dur",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Impromptu op. 142, b-dur"
   },
   {
+    "arranger": "",
+    "composer": "Schulhoff, Julius, 1825-1898",
     "druid": "vc908xz3554",
-    "image_url": "https://stacks.stanford.edu/image/iiif/vc908xz3554%2Fvc908xz3554_0002/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/vc908xz3554/vc908xz3554_0002/info.json",
     "number": "7822",
+    "performer": "",
     "publisher": "Ideal",
     "title": "Schulhoff - Carnaval de venezia",
-    "type": "88-note"
+    "type": "88-note",
+    "work": "Carnaval de venezia"
   },
   {
+    "arranger": "",
+    "composer": "Schulz-Evler, Andrei",
     "druid": "yn137rt9938",
-    "image_url": "https://stacks.stanford.edu/image/iiif/yn137rt9938%2Fyn137rt9938_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/yn137rt9938/yn137rt9938_0001/info.json",
     "number": "1305",
+    "performer": "Lhévinne, Josef",
     "publisher": "Welte-Mignon",
     "title": "Schulz-Evler/Lhévinne - Arabesque über \"an der schönen blauen donau\"",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Arabesque über \"an der schönen blauen donau\""
   },
   {
+    "arranger": "",
+    "composer": "Schumann, Robert, 1810-1856",
     "druid": "tc493dq4498",
-    "image_url": "https://stacks.stanford.edu/image/iiif/tc493dq4498%2Ftc493dq4498_0002/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/tc493dq4498/tc493dq4498_0002/info.json",
     "number": "3020",
+    "performer": "",
     "publisher": "Victoria",
     "title": "Schumann - Fantaisiestück, op. 12: N. 8: Amici, comedia finita est",
-    "type": "88-note"
+    "type": "88-note",
+    "work": "Fantaisiestück, op. 12: N. 8: Amici, comedia finita est"
   },
   {
+    "arranger": "",
+    "composer": "Schumann, Robert",
     "druid": "rt595wj4442",
-    "image_url": "https://stacks.stanford.edu/image/iiif/rt595wj4442%2Frt595wj4442_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/rt595wj4442/rt595wj4442_0001/info.json",
     "number": "28",
+    "performer": "Adam-Benard, Eugenie",
     "publisher": "Welte-Mignon",
     "title": "Schumann/Adam-Benard - Klavierconcert a-moll, op. 54: Allegro affectuoso, allegro molto",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Klavierconcert a-moll, op. 54: Allegro affectuoso, allegro molto"
   },
   {
+    "arranger": "",
+    "composer": "Schumann, Robert",
     "druid": "bj093nh2591",
-    "image_url": "https://stacks.stanford.edu/image/iiif/bj093nh2591%2Fbj093nh2591_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/bj093nh2591/bj093nh2591_0001/info.json",
     "number": "28",
+    "performer": "Adam-Benard, Eugenie",
     "publisher": "Welte-Mignon",
     "title": "Schumann/Adam-Benard - Piano concerto op. 54, a minor: Allegro affectuoso, allegro molto",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Piano concerto op. 54, a minor: Allegro affectuoso, allegro molto"
   },
   {
+    "arranger": "",
+    "composer": "Schumann, Robert",
     "druid": "ps931qh5746",
-    "image_url": "https://stacks.stanford.edu/image/iiif/ps931qh5746%2Fps931qh5746_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/ps931qh5746/ps931qh5746_0001/info.json",
     "number": "2591",
+    "performer": "Bloomfield-Zeisler, Fannie",
     "publisher": "Welte-Mignon",
     "title": "Schumann/Bloomfield-Zeisler - Caprice e dur",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Caprice e dur"
   },
   {
+    "arranger": "",
+    "composer": "Schumann, Robert",
     "druid": "vw531zy4220",
-    "image_url": "https://stacks.stanford.edu/image/iiif/vw531zy4220%2Fvw531zy4220_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/vw531zy4220/vw531zy4220_0001/info.json",
     "number": "2591",
+    "performer": "Bloomfield-Zeisler, Fannie",
     "publisher": "Welte-Mignon",
     "title": "Schumann/Bloomfield-Zeisler - Caprice e dur",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Caprice e dur"
   },
   {
+    "arranger": "",
+    "composer": "Schumann, Robert",
     "druid": "gf569df0451",
-    "image_url": "https://stacks.stanford.edu/image/iiif/gf569df0451%2Fgf569df0451_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/gf569df0451/gf569df0451_0001/info.json",
     "number": "361",
+    "performer": "Carreño, Teresa",
     "publisher": "Welte-Mignon",
     "title": "Schumann/Carreño - Fantasia op. 17, c-major: Part 1",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Fantasia op. 17, c-major: Part 1"
   },
   {
+    "arranger": "",
+    "composer": "Schumann, Robert",
     "druid": "vm096df0179",
-    "image_url": "https://stacks.stanford.edu/image/iiif/vm096df0179%2Fvm096df0179_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/vm096df0179/vm096df0179_0001/info.json",
     "number": "363",
+    "performer": "Carreño, Teresa",
     "publisher": "Welte-Mignon",
     "title": "Schumann/Carreño - Fantasie c-dur, op. 17: III. Satz",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Fantasie c-dur, op. 17: III. Satz"
   },
   {
+    "arranger": "",
+    "composer": "Schumann, Robert",
     "druid": "kx034vy1374",
-    "image_url": "https://stacks.stanford.edu/image/iiif/kx034vy1374%2Fkx034vy1374_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/kx034vy1374/kx034vy1374_0001/info.json",
     "number": "362",
+    "performer": "Carreño, Teresa",
     "publisher": "Welte-Mignon",
     "title": "Schumann/Carreño - Fantasie op. 17, c-dur: II. Satz",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Fantasie op. 17, c-dur: II. Satz"
   },
   {
+    "arranger": "",
+    "composer": "Schumann, Robert",
     "druid": "kq525dc4373",
-    "image_url": "https://stacks.stanford.edu/image/iiif/kq525dc4373%2Fkq525dc4373_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/kq525dc4373/kq525dc4373_0001/info.json",
     "number": "1755",
+    "performer": "Collins, H. B. (Henry Bird)",
     "publisher": "Welte-Mignon",
     "title": "Schumann/Collins - Widmung =: (Devotion)",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Widmung =: (Devotion)"
   },
   {
+    "arranger": "",
+    "composer": "Schumann, Robert",
     "druid": "jb107tz1859",
-    "image_url": "https://stacks.stanford.edu/image/iiif/jb107tz1859%2Fjb107tz1859_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/jb107tz1859/jb107tz1859_0001/info.json",
     "number": "1772",
+    "performer": "Davies, Fanny",
     "publisher": "Welte-Mignon",
     "title": "Schumann/Davies - Kinderscenen: 1-6",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Kinderscenen: 1-6"
   },
   {
+    "arranger": "",
+    "composer": "Schumann, Robert",
     "druid": "ds710xd1794",
-    "image_url": "https://stacks.stanford.edu/image/iiif/ds710xd1794%2Fds710xd1794_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/ds710xd1794/ds710xd1794_0001/info.json",
     "number": "1773",
+    "performer": "Davies, Fanny",
     "publisher": "Welte-Mignon",
     "title": "Schumann/Davies - Scenes from childhood: No. 7-13",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Scenes from childhood: No. 7-13"
   },
   {
+    "arranger": "",
+    "composer": "Schumann, Robert",
     "druid": "nk632jz1564",
-    "image_url": "https://stacks.stanford.edu/image/iiif/nk632jz1564%2Fnk632jz1564_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/nk632jz1564/nk632jz1564_0001/info.json",
     "number": "501",
+    "performer": "Dohnányi, Ernő",
     "publisher": "Welte-Mignon",
     "title": "Schumann/Dohnányi - Romance op. 28, no. 2, fis-dur",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Romance op. 28, no. 2, fis-dur"
   },
   {
+    "arranger": "",
+    "composer": "Schumann, Robert",
     "druid": "ph502kz9777",
-    "image_url": "https://stacks.stanford.edu/image/iiif/ph502kz9777%2Fph502kz9777_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/ph502kz9777/ph502kz9777_0001/info.json",
     "number": "270",
+    "performer": "Droucker, Sandra",
     "publisher": "Welte-Mignon",
     "title": "Schumann/Droucker - Arabesque c major op. 18",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Arabesque c major op. 18"
   },
   {
+    "arranger": "",
+    "composer": "Schumann, Robert",
     "druid": "sk293jg8184",
-    "image_url": "https://stacks.stanford.edu/image/iiif/sk293jg8184%2Fsk293jg8184_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/sk293jg8184/sk293jg8184_0001/info.json",
     "number": "1063",
+    "performer": "Grosz, Gisella",
     "publisher": "Welte-Mignon",
     "title": "Schumann/Grosz - 2nd sonata, op. 22, no. 2, g minor: Adantino",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "2nd sonata, op. 22, no. 2, g minor: Adantino"
   },
   {
+    "arranger": "",
+    "composer": "Schumann, Robert",
     "druid": "hn285vs3930",
-    "image_url": "https://stacks.stanford.edu/image/iiif/hn285vs3930%2Fhn285vs3930_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/hn285vs3930/hn285vs3930_0001/info.json",
     "number": "1064",
+    "performer": "Grosz, Gisella",
     "publisher": "Welte-Mignon",
     "title": "Schumann/Grosz - 2nd sonata, op. 22, no. 2, g minor: scherzo, rondo, presto",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "2nd sonata, op. 22, no. 2, g minor: scherzo, rondo, presto"
   },
   {
+    "arranger": "",
+    "composer": "Schumann, Robert",
     "druid": "yg150mb0559",
-    "image_url": "https://stacks.stanford.edu/image/iiif/yg150mb0559%2Fyg150mb0559_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/yg150mb0559/yg150mb0559_0001/info.json",
     "number": "207",
+    "performer": "Grünfeld, Alfred",
     "publisher": "Welte-Mignon",
     "title": "Schumann/Grünfeld - Des abends op. 12",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Des abends op. 12"
   },
   {
+    "arranger": "",
+    "composer": "Schumann, Robert",
     "druid": "wv912mm2332",
-    "image_url": "https://stacks.stanford.edu/image/iiif/wv912mm2332%2Fwv912mm2332_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/wv912mm2332/wv912mm2332_0001/info.json",
     "number": "225",
+    "performer": "Grünfeld, Alfred",
     "publisher": "Welte-Mignon",
     "title": "Schumann/Grünfeld - Traumerei: op. 15, no. 7",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Traumerei: op. 15, no. 7"
   },
   {
+    "arranger": "",
+    "composer": "Schumann, Robert",
     "druid": "mf320jq4997",
-    "image_url": "https://stacks.stanford.edu/image/iiif/mf320jq4997%2Fmf320jq4997_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/mf320jq4997/mf320jq4997_0001/info.json",
     "number": "225",
+    "performer": "Grünfeld, Alfred",
     "publisher": "Welte-Mignon",
     "title": "Schumann/Grünfeld - Träumerei",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Träumerei"
   },
   {
+    "arranger": "",
+    "composer": "Schumann, Robert",
     "druid": "kx695yq4528",
-    "image_url": "https://stacks.stanford.edu/image/iiif/kx695yq4528%2Fkx695yq4528_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/kx695yq4528/kx695yq4528_0001/info.json",
     "number": "1301",
+    "performer": "Lhévinne, Josef",
     "publisher": "Welte-Mignon",
     "title": "Schumann/Lhévinne - Toccata c major, op. 7",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Toccata c major, op. 7"
   },
   {
+    "arranger": "",
+    "composer": "Schumann, Robert",
     "druid": "cw211cn1219",
-    "image_url": "https://stacks.stanford.edu/image/iiif/cw211cn1219%2Fcw211cn1219_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/cw211cn1219/cw211cn1219_0001/info.json",
     "number": "691",
+    "performer": "Neitzel, Otto",
     "publisher": "Welte-Mignon",
     "title": "Schumann/Neitzel - Davidsbündler dances",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Davidsbündler dances"
   },
   {
+    "arranger": "",
+    "composer": "Schumann, Robert",
     "druid": "qw257qp8232",
-    "image_url": "https://stacks.stanford.edu/image/iiif/qw257qp8232%2Fqw257qp8232_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/qw257qp8232/qw257qp8232_0001/info.json",
     "number": "690",
+    "performer": "Neitzel, Otto",
     "publisher": "Welte-Mignon",
     "title": "Schumann/Neitzel - Symphonische etüde",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Symphonische etüde"
   },
   {
+    "arranger": "",
+    "composer": "Schumann, Robert",
     "druid": "xj540rr2929",
-    "image_url": "https://stacks.stanford.edu/image/iiif/xj540rr2929%2Fxj540rr2929_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/xj540rr2929/xj540rr2929_0001/info.json",
     "number": "1208",
+    "performer": "Pachmann, Vladimir de",
     "publisher": "Welte-Mignon",
     "title": "Schumann/Pachmann - Vogel als prophet",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Vogel als prophet"
   },
   {
+    "arranger": "",
+    "composer": "Schumann, Robert",
     "druid": "jk211zx0169",
-    "image_url": "https://stacks.stanford.edu/image/iiif/jk211zx0169%2Fjk211zx0169_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/jk211zx0169/jk211zx0169_0001/info.json",
     "number": "525",
+    "performer": "Petri, Egon",
     "publisher": "Welte-Mignon",
     "title": "Schumann/Petri - Abegg varationen: op. 1",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Abegg varationen: op. 1"
   },
   {
+    "arranger": "",
+    "composer": "Schumann, Robert",
     "druid": "xw872bc8052",
-    "image_url": "https://stacks.stanford.edu/image/iiif/xw872bc8052%2Fxw872bc8052_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/xw872bc8052/xw872bc8052_0001/info.json",
     "number": "321",
+    "performer": "Reisenauer, Alfred",
     "publisher": "Welte-Mignon",
     "title": "Schumann/Reisenauer - Carneval part. 1",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Carneval part. 1"
   },
   {
+    "arranger": "",
+    "composer": "Schumann, Robert",
     "druid": "zt739gs4926",
-    "image_url": "https://stacks.stanford.edu/image/iiif/zt739gs4926%2Fzt739gs4926_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/zt739gs4926/zt739gs4926_0001/info.json",
     "number": "321",
+    "performer": "Reisenauer, Alfred",
     "publisher": "Welte-Mignon",
     "title": "Schumann/Reisenauer - Carneval: Part. 1",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Carneval: Part. 1"
   },
   {
+    "arranger": "",
+    "composer": "Schumann, Robert",
     "druid": "wk320bj4724",
-    "image_url": "https://stacks.stanford.edu/image/iiif/wk320bj4724%2Fwk320bj4724_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/wk320bj4724/wk320bj4724_0001/info.json",
     "number": "322",
+    "performer": "Reisenauer, Alfred",
     "publisher": "Welte-Mignon",
     "title": "Schumann/Reisenauer - Carneval: Part. 2",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Carneval: Part. 2"
   },
   {
+    "arranger": "",
+    "composer": "Schumann, Robert",
     "druid": "cs175wr2428",
-    "image_url": "https://stacks.stanford.edu/image/iiif/cs175wr2428%2Fcs175wr2428_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/cs175wr2428/cs175wr2428_0001/info.json",
     "number": "248",
+    "performer": "Scharwenka, Xaver",
     "publisher": "Welte-Mignon",
     "title": "Schumann/Scharwenka - Kreisleriana",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Kreisleriana"
   },
   {
+    "arranger": "",
+    "composer": "Schumann, Robert",
     "druid": "hy749gh2331",
-    "image_url": "https://stacks.stanford.edu/image/iiif/hy749gh2331%2Fhy749gh2331_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/hy749gh2331/hy749gh2331_0001/info.json",
     "number": "2086",
+    "performer": "Schorr, David",
     "publisher": "Welte-Mignon",
     "title": "Schumann/Schorr - Schlummerlied",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Schlummerlied"
   },
   {
+    "arranger": "",
+    "composer": "Schytte, Ludvig",
     "druid": "dz678wd2724",
-    "image_url": "https://stacks.stanford.edu/image/iiif/dz678wd2724%2Fdz678wd2724_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/dz678wd2724/dz678wd2724_0001/info.json",
     "number": "970",
+    "performer": "Schytte, Anna Jutta",
     "publisher": "Welte-Mignon",
     "title": "Schytte/Schytte - Berceuse op. 26, nr. 7",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Berceuse op. 26, nr. 7"
   },
   {
+    "arranger": "",
+    "composer": "Schütt, Eduard",
     "druid": "pb026mb0704",
-    "image_url": "https://stacks.stanford.edu/image/iiif/pb026mb0704%2Fpb026mb0704_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/pb026mb0704/pb026mb0704_0001/info.json",
     "number": "921",
+    "performer": "Conne, Paul de",
     "publisher": "Welte-Mignon",
     "title": "Schütt/Conne - Kunstlerleben waltz: concert paraphrase",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Kunstlerleben waltz: concert paraphrase"
   },
   {
+    "arranger": "",
+    "composer": "Schütt, Eduard",
     "druid": "ny937ph6981",
-    "image_url": "https://stacks.stanford.edu/image/iiif/ny937ph6981%2Fny937ph6981_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/ny937ph6981/ny937ph6981_0001/info.json",
     "number": "3745",
+    "performer": "Danziger, Laura",
     "publisher": "Welte-Mignon",
     "title": "Schütt/Danziger - Romance op. 38, no. 2",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Romance op. 38, no. 2"
   },
   {
+    "arranger": "",
+    "composer": "Schütt, Eduard",
     "druid": "sp773vt2651",
-    "image_url": "https://stacks.stanford.edu/image/iiif/sp773vt2651%2Fsp773vt2651_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/sp773vt2651/sp773vt2651_0001/info.json",
     "number": "3695",
+    "performer": "Seckendorf Popper, Lillian",
     "publisher": "Welte-Mignon",
     "title": "Schütt/Seckendorf Popper - Carnaval mignon: scènes pantomimiques: op. 48",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Carnaval mignon: scènes pantomimiques : op. 48"
   },
   {
+    "arranger": "",
+    "composer": "Sciammarella, Rodolfo",
     "druid": "vq862qw5039",
-    "image_url": "https://stacks.stanford.edu/image/iiif/vq862qw5039%2Fvq862qw5039_0002/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/vq862qw5039/vq862qw5039_0002/info.json",
     "number": "40011",
+    "performer": "",
     "publisher": "Princesa",
     "title": "Sciammarella - No te engañes corazón: tango",
-    "type": "88-note"
+    "type": "88-note",
+    "work": "No te engañes corazón: tango"
   },
   {
+    "arranger": "",
+    "composer": "Scott, Cyril",
     "druid": "vf252dc4872",
-    "image_url": "https://stacks.stanford.edu/image/iiif/vf252dc4872%2Fvf252dc4872_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/vf252dc4872/vf252dc4872_0001/info.json",
     "number": "1697",
+    "performer": "Scott, Cyril",
     "publisher": "Welte-Mignon",
     "title": "Scott/Scott - A Song from the east: Danse nègre",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "A Song from the east: Danse nègre"
   },
   {
+    "arranger": "",
+    "composer": "Scriabin, Aleksandr Nikolayevich",
     "druid": "br324td1538",
-    "image_url": "https://stacks.stanford.edu/image/iiif/br324td1538%2Fbr324td1538_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/br324td1538/br324td1538_0001/info.json",
     "number": "C7602",
+    "performer": "Pouishnoff, Leff",
     "publisher": "De Luxe",
     "title": "Scriabin/Pouishnoff - Poeme op. 32, no. 1",
-    "type": "welte-licensee"
+    "type": "welte-licensee",
+    "work": "Poeme op. 32, no. 1"
   },
   {
+    "arranger": "",
+    "composer": "Scriabin, Aleksandr Nikolayevich",
     "druid": "zf673fy4620",
-    "image_url": "https://stacks.stanford.edu/image/iiif/zf673fy4620%2Fzf673fy4620_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/zf673fy4620/zf673fy4620_0001/info.json",
     "number": "2068",
+    "performer": "Scriabin, Aleksandr Nikolayevich",
     "publisher": "Welte-Mignon",
     "title": "Scriabin/Scriabin - Poême: op. 32, no. 1",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Poême: op. 32, no. 1"
   },
   {
+    "arranger": "",
+    "composer": "Scriabin, Aleksandr Nikolayevich",
     "druid": "sk925fn6049",
-    "image_url": "https://stacks.stanford.edu/image/iiif/sk925fn6049%2Fsk925fn6049_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/sk925fn6049/sk925fn6049_0001/info.json",
     "number": "2021",
+    "performer": "Vengerova, Isabelle",
     "publisher": "Welte-Mignon",
     "title": "Scriabin/Vengerova - Prelude für die linke hand",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Prelude für die linke hand"
   },
   {
+    "arranger": "",
+    "composer": "Sibelius, Jean",
     "druid": "vg335rq3648",
-    "image_url": "https://stacks.stanford.edu/image/iiif/vg335rq3648%2Fvg335rq3648_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/vg335rq3648/vg335rq3648_0001/info.json",
     "number": "2634",
+    "performer": "Di Benici, Tosta",
     "publisher": "Welte-Mignon",
     "title": "Sibelius/Di Benici - Caprice f minor",
-    "type": "welte-green"
+    "type": "welte-green",
+    "work": "Caprice f minor"
   },
   {
+    "arranger": "",
+    "composer": "Sibelius, Jean",
     "druid": "vp438dy0628",
-    "image_url": "https://stacks.stanford.edu/image/iiif/vp438dy0628%2Fvp438dy0628_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/vp438dy0628/vp438dy0628_0001/info.json",
     "number": "3356",
+    "performer": "Flohr, Hubert",
     "publisher": "Welte-Mignon",
     "title": "Sibelius/Flohr - Finlandia",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Finlandia"
   },
   {
+    "arranger": "",
+    "composer": "Silésu, Lao",
     "druid": "zw828tx0197",
-    "image_url": "https://stacks.stanford.edu/image/iiif/zw828tx0197%2Fzw828tx0197_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/zw828tx0197/zw828tx0197_0001/info.json",
     "number": "3537",
+    "performer": "Daly, William",
     "publisher": "Welte-Mignon",
     "title": "Silésu/Daly - Un Peu d'amour: popular song",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Un Peu d'amour: popular song"
   },
   {
+    "arranger": "",
+    "composer": "Sinding, Christian",
     "druid": "qg041hb4569",
-    "image_url": "https://stacks.stanford.edu/image/iiif/qg041hb4569%2Fqg041hb4569_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/qg041hb4569/qg041hb4569_0001/info.json",
     "number": "2993",
+    "performer": "Albert, Eugen d'",
     "publisher": "Welte-Mignon",
     "title": "Sinding/Albert - March grotesque",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "March grotesque"
   },
   {
+    "arranger": "",
+    "composer": "Sinding, Christian",
     "druid": "qk333zc6515",
-    "image_url": "https://stacks.stanford.edu/image/iiif/qk333zc6515%2Fqk333zc6515_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/qk333zc6515/qk333zc6515_0001/info.json",
     "number": "2637",
+    "performer": "Di Benici, Tosta",
     "publisher": "Welte-Mignon",
     "title": "Sinding/Di Benici - Frühlingsrauschen: op. 32, no. 3",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Frühlingsrauschen: op. 32, no. 3"
   },
   {
+    "arranger": "",
+    "composer": "Sinding, Christian",
     "druid": "gq990gn6753",
-    "image_url": "https://stacks.stanford.edu/image/iiif/gq990gn6753%2Fgq990gn6753_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/gq990gn6753/gq990gn6753_0001/info.json",
     "number": "375",
+    "performer": "Wendling, Carl",
     "publisher": "Welte-Mignon",
     "title": "Sinding/Wendling - Rustle of spring: op. 32, no. 3",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Rustle of spring: op. 32, no. 3"
   },
   {
+    "arranger": "",
+    "composer": "Steinway, Charles H",
     "druid": "fr396nf3639",
-    "image_url": "https://stacks.stanford.edu/image/iiif/fr396nf3639%2Ffr396nf3639_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/fr396nf3639/fr396nf3639_0001/info.json",
     "number": "1539",
+    "performer": "Brightwell, Edward",
     "publisher": "Welte-Mignon",
     "title": "Steinway/Brightwell - Madeleine: valse poetique",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Madeleine: valse poetique"
   },
   {
+    "arranger": "",
+    "composer": "Straus, Oscar",
     "druid": "jt308hp0877",
-    "image_url": "https://stacks.stanford.edu/image/iiif/jt308hp0877%2Fjt308hp0877_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/jt308hp0877/jt308hp0877_0001/info.json",
     "number": "2198",
+    "performer": "Burkard, Heinrich",
     "publisher": "Welte-Mignon",
     "title": "Straus/Burkard - Walzer: der tapfere Soldat",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Walzer: der tapfere Soldat"
   },
   {
+    "arranger": "",
+    "composer": "Straus, Oscar",
     "druid": "qp421cd7297",
-    "image_url": "https://stacks.stanford.edu/image/iiif/qp421cd7297%2Fqp421cd7297_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/qp421cd7297/qp421cd7297_0001/info.json",
     "number": "2613",
+    "performer": "Goodall, B",
     "publisher": "Welte-Mignon",
     "title": "Straus/Goodall - The Chocolate soldier: selection 1",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "The Chocolate soldier: selection 1"
   },
   {
+    "arranger": "Grünfeld, Alfred",
+    "composer": "Strauss, Josef",
     "druid": "sv842td3290",
-    "image_url": "https://stacks.stanford.edu/image/iiif/sv842td3290%2Fsv842td3290_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/sv842td3290/sv842td3290_0001/info.json",
     "number": "4190",
+    "performer": "Serkin, Rudolf",
     "publisher": "Welte-Mignon",
     "title": "Strauss-Grünfeld/Serkin - Delirien-walzer",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Delirien-walzer"
   },
   {
+    "arranger": "Tausig, Carl",
+    "composer": "Strauss, Johann",
     "druid": "kp368nb7707",
-    "image_url": "https://stacks.stanford.edu/image/iiif/kp368nb7707%2Fkp368nb7707_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/kp368nb7707/kp368nb7707_0001/info.json",
     "number": "532",
+    "performer": "Zadora, Michael",
     "publisher": "Welte-Mignon",
     "title": "Strauss-Tausig/Zadora - Man lives but once",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Man lives but once"
   },
   {
+    "arranger": "",
+    "composer": "Strauss, Johann",
     "druid": "rn154dd5329",
-    "image_url": "https://stacks.stanford.edu/image/iiif/rn154dd5329%2Frn154dd5329_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/rn154dd5329/rn154dd5329_0001/info.json",
     "number": "357",
+    "performer": "Brzeziński, Franciszek",
     "publisher": "Welte-Mignon",
     "title": "Strauss/Brzeziński - An der schönen blauen donau",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "An der schönen blauen donau"
   },
   {
+    "arranger": "",
+    "composer": "Strauss, Johann",
     "druid": "sj250cc6451",
-    "image_url": "https://stacks.stanford.edu/image/iiif/sj250cc6451%2Fsj250cc6451_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/sj250cc6451/sj250cc6451_0001/info.json",
     "number": "277",
+    "performer": "Brzeziński, Franciszek",
     "publisher": "Welte-Mignon",
     "title": "Strauss/Brzeziński - Rosen a. d. süden",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Rosen a. d. süden"
   },
   {
+    "arranger": "",
+    "composer": "Strauss, Johann",
     "druid": "sk565bp3463",
-    "image_url": "https://stacks.stanford.edu/image/iiif/sk565bp3463%2Fsk565bp3463_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/sk565bp3463/sk565bp3463_0001/info.json",
     "number": "349",
+    "performer": "Kupfernagel, Albrecht",
     "publisher": "Welte-Mignon",
     "title": "Strauss/Kupfernagel - Wiener blut: Walzer",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Wiener blut: Walzer"
   },
   {
+    "arranger": "",
+    "composer": "Strauss, Johann",
     "druid": "qp506dy4541",
-    "image_url": "https://stacks.stanford.edu/image/iiif/qp506dy4541%2Fqp506dy4541_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/qp506dy4541/qp506dy4541_0001/info.json",
     "number": "1398",
+    "performer": "Orlando, N",
     "publisher": "Welte-Mignon",
     "title": "Strauss/Orlando - Du und du: aus Fledermaus: Walzer",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Du und du: aus Fledermaus : Walzer"
   },
   {
+    "arranger": "",
+    "composer": "Strauss, Josef",
     "druid": "kt568yb8982",
-    "image_url": "https://stacks.stanford.edu/image/iiif/kt568yb8982%2Fkt568yb8982_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/kt568yb8982/kt568yb8982_0001/info.json",
     "number": "382",
+    "performer": "Schnabel, Artur",
     "publisher": "Welte-Mignon",
     "title": "Strauss/Schnabel - Village swallows",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Village swallows"
   },
   {
+    "arranger": "",
+    "composer": "Strauss, Richard",
     "druid": "zw485gh6070",
-    "image_url": "https://stacks.stanford.edu/image/iiif/zw485gh6070%2Fzw485gh6070_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/zw485gh6070/zw485gh6070_0001/info.json",
     "number": "1184",
+    "performer": "Strauss, Richard",
     "publisher": "Welte-Mignon",
     "title": "Strauss/Strauss - Liebesscene a. \"heldenleben\"",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Liebesscene a. \"heldenleben\""
   },
   {
+    "arranger": "",
+    "composer": "Stravinsky, Igor",
     "druid": "ds528dg7725",
-    "image_url": "https://stacks.stanford.edu/image/iiif/ds528dg7725%2Fds528dg7725_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/ds528dg7725/ds528dg7725_0001/info.json",
     "number": "D-759",
+    "performer": "Stravinsky, Igor",
     "publisher": "Aeolian Co., Ltd.",
     "title": "Stravinsky/Stravinsky - My life and music: First series: To 'The fire-bird,' in six rolls",
-    "type": "duo-art"
+    "type": "duo-art",
+    "work": "My life and music: First series: To 'The fire-bird,' in six rolls"
   },
   {
+    "arranger": "",
+    "composer": "Stravinsky, Igor",
     "druid": "gk717vy6323",
-    "image_url": "https://stacks.stanford.edu/image/iiif/gk717vy6323%2Fgk717vy6323_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/gk717vy6323/gk717vy6323_0001/info.json",
     "number": "D-759",
+    "performer": "Stravinsky, Igor",
     "publisher": "Aeolian Co., Ltd.",
     "title": "Stravinsky/Stravinsky - My life and music: First series: To 'The fire-bird,' in six rolls",
-    "type": "duo-art"
+    "type": "duo-art",
+    "work": "My life and music: First series: To 'The fire-bird,' in six rolls"
   },
   {
+    "arranger": "",
+    "composer": "Stravinsky, Igor",
     "druid": "kk651ck1593",
-    "image_url": "https://stacks.stanford.edu/image/iiif/kk651ck1593%2Fkk651ck1593_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/kk651ck1593/kk651ck1593_0001/info.json",
     "number": "D-759",
+    "performer": "Stravinsky, Igor",
     "publisher": "Aeolian Co., Ltd.",
     "title": "Stravinsky/Stravinsky - My life and music: First series: To 'The fire-bird,' in six rolls",
-    "type": "duo-art"
+    "type": "duo-art",
+    "work": "My life and music: First series: To 'The fire-bird,' in six rolls"
   },
   {
+    "arranger": "",
+    "composer": "Stravinsky, Igor",
     "druid": "rb863nd0220",
-    "image_url": "https://stacks.stanford.edu/image/iiif/rb863nd0220%2Frb863nd0220_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/rb863nd0220/rb863nd0220_0001/info.json",
     "number": "D-759",
+    "performer": "Stravinsky, Igor",
     "publisher": "Aeolian Co., Ltd.",
     "title": "Stravinsky/Stravinsky - My life and music: First series: To 'The fire-bird,' in six rolls",
-    "type": "duo-art"
+    "type": "duo-art",
+    "work": "My life and music: First series: To 'The fire-bird,' in six rolls"
   },
   {
+    "arranger": "",
+    "composer": "Stravinsky, Igor",
     "druid": "zc672fb8379",
-    "image_url": "https://stacks.stanford.edu/image/iiif/zc672fb8379%2Fzc672fb8379_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/zc672fb8379/zc672fb8379_0001/info.json",
     "number": "D-759",
+    "performer": "Stravinsky, Igor",
     "publisher": "Aeolian Co., Ltd.",
     "title": "Stravinsky/Stravinsky - My life and music: First series: To 'The fire-bird,' in six rolls",
-    "type": "duo-art"
+    "type": "duo-art",
+    "work": "My life and music: First series: To 'The fire-bird,' in six rolls"
   },
   {
+    "arranger": "",
+    "composer": "Sullivan, Arthur",
+    "druid": "xg228jc5213",
+    "image_url": "https://stacks.stanford.edu/image/iiif/xg228jc5213/xg228jc5213_0001/info.json",
+    "number": "2616",
+    "performer": "Goodall, B",
+    "publisher": "Welte-Mignon",
+    "title": "Sullivan/Goodall - The   Mikado, or the town of titibu: I (Selection)",
+    "type": "welte-red",
+    "work": "The   Mikado, or the town of titibu: I (Selection)"
+  },
+  {
+    "arranger": "",
+    "composer": "Sullivan, Arthur",
     "druid": "rh801bs4556",
-    "image_url": "https://stacks.stanford.edu/image/iiif/rh801bs4556%2Frh801bs4556_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/rh801bs4556/rh801bs4556_0001/info.json",
     "number": "2615",
+    "performer": "Goodall, B",
     "publisher": "Welte-Mignon",
     "title": "Sullivan/Goodall - The Gondoliers, or the king of barataria",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "The Gondoliers, or the king of barataria"
   },
   {
-    "druid": "xg228jc5213",
-    "image_url": "https://stacks.stanford.edu/image/iiif/xg228jc5213%2Fxg228jc5213_0001/info.json",
-    "number": "2616",
-    "publisher": "Welte-Mignon",
-    "title": "Sullivan/Goodall - The Mikado, or the town of titibu: I (Selection)",
-    "type": "welte-red"
-  },
-  {
+    "arranger": "",
+    "composer": "Sullivan, Arthur",
     "druid": "zp424ps8426",
-    "image_url": "https://stacks.stanford.edu/image/iiif/zp424ps8426%2Fzp424ps8426_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/zp424ps8426/zp424ps8426_0001/info.json",
     "number": "2617",
+    "performer": "Goodall, B",
     "publisher": "Welte-Mignon",
     "title": "Sullivan/Goodall - The Mikado, or the town of titibu: II (Selection)",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "The Mikado, or the town of titibu: II (Selection)"
   },
   {
+    "arranger": "",
+    "composer": "Sullivan, Arthur",
     "druid": "fg895gs1373",
-    "image_url": "https://stacks.stanford.edu/image/iiif/fg895gs1373%2Ffg895gs1373_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/fg895gs1373/fg895gs1373_0001/info.json",
     "number": "2618",
+    "performer": "Goodall, B",
     "publisher": "Welte-Mignon",
     "title": "Sullivan/Goodall - The Yeomen of the guard, or the merry man and his maid",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "The Yeomen of the guard, or the merry man and his maid"
   },
   {
+    "arranger": "",
+    "composer": "Tchaikovsky, Peter Ilich",
     "druid": "zc118hn1152",
-    "image_url": "https://stacks.stanford.edu/image/iiif/zc118hn1152%2Fzc118hn1152_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/zc118hn1152/zc118hn1152_0001/info.json",
     "number": "2995",
+    "performer": "Albert, Eugen d'",
     "publisher": "Welte-Mignon",
     "title": "Tchaikovsky/Albert - Casse noisette suite op. 71, i. teil",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Casse noisette suite op. 71, i. teil"
   },
   {
+    "arranger": "",
+    "composer": "Tchaikovsky, Peter Ilich",
     "druid": "fk960pq3086",
-    "image_url": "https://stacks.stanford.edu/image/iiif/fk960pq3086%2Ffk960pq3086_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/fk960pq3086/fk960pq3086_0001/info.json",
     "number": "2995",
+    "performer": "Albert, Eugen d'",
     "publisher": "Welte-Mignon",
     "title": "Tchaikovsky/Albert - Casse noisette suite: op. 71, part 1",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Casse noisette suite: op. 71, part 1"
   },
   {
+    "arranger": "",
+    "composer": "Tchaikovsky, Peter Ilich",
     "druid": "hk752ck1008",
-    "image_url": "https://stacks.stanford.edu/image/iiif/hk752ck1008%2Fhk752ck1008_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/hk752ck1008/hk752ck1008_0001/info.json",
     "number": "3330",
+    "performer": "Lászlò, Sándor",
     "publisher": "Welte-Mignon",
     "title": "Tchaikovsky/Lászlò - Symphonic pathétic op. 74, no. 6, part ii",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Symphonic pathétic op. 74, no. 6, part ii"
   },
   {
+    "arranger": "",
+    "composer": "Tchaikovsky, Peter Ilich",
     "druid": "bk297ff8944",
-    "image_url": "https://stacks.stanford.edu/image/iiif/bk297ff8944%2Fbk297ff8944_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/bk297ff8944/bk297ff8944_0001/info.json",
     "number": "3329",
+    "performer": "Lászlò, Sándor",
     "publisher": "Welte-Mignon",
     "title": "Tchaikovsky/Lászlò - Symphonic pathétic op. 74, part. i (final)",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Symphonic pathétic op. 74, part. i (final)"
   },
   {
+    "arranger": "",
+    "composer": "Tchaikovsky, Peter Ilich",
     "druid": "rv766dc1369",
-    "image_url": "https://stacks.stanford.edu/image/iiif/rv766dc1369%2Frv766dc1369_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/rv766dc1369/rv766dc1369_0001/info.json",
     "number": "3328",
+    "performer": "Lászlò, Sándor",
     "publisher": "Welte-Mignon",
     "title": "Tchaikovsky/Lászlò - Symphony pathétique op. 74, no. 6, part i",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Symphony pathétique op. 74, no. 6, part i"
   },
   {
+    "arranger": "",
+    "composer": "Tchaikovsky, Peter Ilich",
     "druid": "gr136pc5388",
-    "image_url": "https://stacks.stanford.edu/image/iiif/gr136pc5388%2Fgr136pc5388_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/gr136pc5388/gr136pc5388_0001/info.json",
     "number": "3331",
+    "performer": "Lászlò, Sándor",
     "publisher": "Welte-Mignon",
     "title": "Tchaikovsky/Lászlò - Symphony pathétique op. 74, no. 6, part iii",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Symphony pathétique op. 74, no. 6, part iii"
   },
   {
+    "arranger": "",
+    "composer": "Tchaikovsky, Peter Ilich",
     "druid": "qm069fy5200",
-    "image_url": "https://stacks.stanford.edu/image/iiif/qm069fy5200%2Fqm069fy5200_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/qm069fy5200/qm069fy5200_0001/info.json",
     "number": "3332",
+    "performer": "Lászlò, Sándor",
     "publisher": "Welte-Mignon",
     "title": "Tchaikovsky/Lászlò - Symphony pathétique op. 74, no. 6, part iv",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Symphony pathétique op. 74, no. 6, part iv"
   },
   {
+    "arranger": "",
+    "composer": "Texidor, Jaime, 1884-1957",
     "druid": "jv485mx5227",
-    "image_url": "https://stacks.stanford.edu/image/iiif/jv485mx5227%2Fjv485mx5227_0002/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/jv485mx5227/jv485mx5227_0002/info.json",
     "number": "40003",
+    "performer": "",
     "publisher": "Princesa",
     "title": "Texidor - Amparito roca: pasodoble",
-    "type": "88-note"
+    "type": "88-note",
+    "work": "Amparito roca: pasodoble"
   },
   {
+    "arranger": "",
+    "composer": "Thalberg, Sigismond",
     "druid": "vj052cw2158",
-    "image_url": "https://stacks.stanford.edu/image/iiif/vj052cw2158%2Fvj052cw2158_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/vj052cw2158/vj052cw2158_0001/info.json",
     "number": "1534",
+    "performer": "Brightwell, Edward",
     "publisher": "Welte-Mignon",
     "title": "Thalberg/Brightwell - Home sweet home",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Home sweet home"
   },
   {
+    "arranger": "",
+    "composer": "Toselli, Enrico",
     "druid": "xg924dm1245",
-    "image_url": "https://stacks.stanford.edu/image/iiif/xg924dm1245%2Fxg924dm1245_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/xg924dm1245/xg924dm1245_0001/info.json",
     "number": "3430",
+    "performer": "Haass, Hans",
     "publisher": "Welte-Mignon",
     "title": "Toselli/Haass - Serenade",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Serenade"
   },
   {
+    "arranger": "",
+    "composer": "Verdi, Giuseppe, 1813-1901",
     "druid": "cw746gb6753",
-    "image_url": "https://stacks.stanford.edu/image/iiif/cw746gb6753%2Fcw746gb6753_0002/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/cw746gb6753/cw746gb6753_0002/info.json",
     "number": "473",
+    "performer": "",
     "publisher": "Princesa",
     "title": "Verdi - Aida: Acto II: Gran marcha triunfal",
-    "type": "88-note"
+    "type": "88-note",
+    "work": "Aida: Acto II: Gran marcha triunfal"
   },
   {
+    "arranger": "Liszt, Franz, 1811-1886",
+    "composer": "Verdi, Giuseppe, 1813-1901",
     "druid": "mf443ns5829",
-    "image_url": "https://stacks.stanford.edu/image/iiif/mf443ns5829%2Fmf443ns5829_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/mf443ns5829/mf443ns5829_0001/info.json",
     "number": "445",
+    "performer": "Busoni, Ferruccio, 1866-1924",
     "publisher": "Welte-Mignon",
     "title": "Verdi-Liszt/Busoni - Rigoletto: (paraphrase)",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Rigoletto: (paraphrase)"
   },
   {
+    "arranger": "",
+    "composer": "Verdi, Giuseppe",
     "druid": "np204br1080",
-    "image_url": "https://stacks.stanford.edu/image/iiif/np204br1080%2Fnp204br1080_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/np204br1080/np204br1080_0001/info.json",
     "number": "2844",
+    "performer": "Gayraud, P",
     "publisher": "Welte-Mignon",
     "title": "Verdi/Gayraud - Rigoletto: Fantasie",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Rigoletto: Fantasie"
   },
   {
+    "arranger": "",
+    "composer": "Verdi, Giuseppe",
     "druid": "sr577gv4813",
-    "image_url": "https://stacks.stanford.edu/image/iiif/sr577gv4813%2Fsr577gv4813_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/sr577gv4813/sr577gv4813_0001/info.json",
     "number": "2844",
+    "performer": "Gayraud, P",
     "publisher": "Welte-Mignon",
     "title": "Verdi/Gayraud - Rigoletto: fantasia",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Rigoletto: fantasia"
   },
   {
+    "arranger": "",
+    "composer": "Verdi, Giuseppe",
     "druid": "nq190zp1066",
-    "image_url": "https://stacks.stanford.edu/image/iiif/nq190zp1066%2Fnq190zp1066_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/nq190zp1066/nq190zp1066_0001/info.json",
     "number": "1341",
+    "performer": "Starke, Gustav",
     "publisher": "Welte-Mignon",
     "title": "Verdi/Starke - Aïda: Fantasie",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Aïda: Fantasie"
   },
   {
+    "arranger": "",
+    "composer": "Verdi, Giuseppe",
     "druid": "nx970yn7253",
-    "image_url": "https://stacks.stanford.edu/image/iiif/nx970yn7253%2Fnx970yn7253_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/nx970yn7253/nx970yn7253_0001/info.json",
     "number": "1339",
+    "performer": "Starke, Gustav",
     "publisher": "Welte-Mignon",
     "title": "Verdi/Starke - La Traviata: fantasie",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "La Traviata: fantasie"
   },
   {
+    "arranger": "",
+    "composer": "Verdi, Giuseppe",
     "druid": "tw054jm0773",
-    "image_url": "https://stacks.stanford.edu/image/iiif/tw054jm0773%2Ftw054jm0773_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/tw054jm0773/tw054jm0773_0001/info.json",
     "number": "1339",
+    "performer": "Starke, Gustav",
     "publisher": "Welte-Mignon",
     "title": "Verdi/Starke - La Traviata: fantasie",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "La Traviata: fantasie"
   },
   {
+    "arranger": "",
+    "composer": "Vidal, Ramón (Composer)",
     "druid": "vr247rd6766",
-    "image_url": "https://stacks.stanford.edu/image/iiif/vr247rd6766%2Fvr247rd6766_0002/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/vr247rd6766/vr247rd6766_0002/info.json",
     "number": "4312",
+    "performer": "",
     "publisher": " Princesa",
     "title": "Vidal - Porque era negro: tango",
-    "type": "88-note"
+    "type": "88-note",
+    "work": "Porque era negro: tango"
   },
   {
+    "arranger": "",
+    "composer": "Viladomat, Joan, 1885-1940",
     "druid": "tp613xb9088",
-    "image_url": "https://stacks.stanford.edu/image/iiif/tp613xb9088%2Ftp613xb9088_0002/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/tp613xb9088/tp613xb9088_0002/info.json",
     "number": "4518",
+    "performer": "",
     "publisher": "Princesa",
     "title": "Viladomat - El Tango de la cocaína",
-    "type": "88-note"
+    "type": "88-note",
+    "work": "El Tango de la cocaína"
   },
   {
+    "arranger": "",
+    "composer": "Villa, Ricardo, 1873-1935",
     "druid": "ps866sb0637",
-    "image_url": "https://stacks.stanford.edu/image/iiif/ps866sb0637%2Fps866sb0637_0002/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/ps866sb0637/ps866sb0637_0002/info.json",
     "number": "2841",
+    "performer": "",
     "publisher": "Princesa",
     "title": "Villa - Cantos asturianos: no. 1: Andante, allegro non molto",
-    "type": "88-note"
+    "type": "88-note",
+    "work": "Cantos asturianos: no. 1: Andante, allegro non molto"
   },
   {
+    "arranger": "",
+    "composer": "Vives, Amadeo, 1871-1932",
     "druid": "sm344xv2220",
-    "image_url": "https://stacks.stanford.edu/image/iiif/sm344xv2220%2Fsm344xv2220_0002/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/sm344xv2220/sm344xv2220_0002/info.json",
     "number": "357",
+    "performer": "",
     "publisher": "Princesa",
     "title": "Vives - Bohemios: Escena y coro",
-    "type": "88-note"
+    "type": "88-note",
+    "work": "Bohemios: Escena y coro"
   },
   {
+    "arranger": "",
+    "composer": "Vogrich, Max",
     "druid": "gh208gz5033",
-    "image_url": "https://stacks.stanford.edu/image/iiif/gh208gz5033%2Fgh208gz5033_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/gh208gz5033/gh208gz5033_0001/info.json",
     "number": "763",
+    "performer": "Mero, Yolanda",
     "publisher": "Welte-Mignon",
     "title": "Vogrich/Mero - Staccato caprice",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Staccato caprice"
   },
   {
+    "arranger": "Brassin, Louis",
+    "composer": "Wagner, Richard",
     "druid": "dj406yq6980",
-    "image_url": "https://stacks.stanford.edu/image/iiif/dj406yq6980%2Fdj406yq6980_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/dj406yq6980/dj406yq6980_0001/info.json",
     "number": "663",
+    "performer": "Hofmann, Josef",
     "publisher": "Welte-Mignon",
     "title": "Wagner-Brassin/Hofmann - Feuerzauber",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Feuerzauber"
   },
   {
+    "arranger": "Bülow, Hans von",
+    "composer": "Wagner, Richard",
     "druid": "fd660zf8362",
-    "image_url": "https://stacks.stanford.edu/image/iiif/fd660zf8362%2Ffd660zf8362_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/fd660zf8362/fd660zf8362_0001/info.json",
     "number": "990",
+    "performer": "Elvyn, Myrtle",
     "publisher": "Welte-Mignon",
     "title": "Wagner-Bülow/Elvyn - Meistersinger von nürnberg: Vorspiel",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Meistersinger von nürnberg: Vorspiel"
   },
   {
+    "arranger": "Liszt, Franz",
+    "composer": "Wagner, Richard",
     "druid": "bs173rx9307",
-    "image_url": "https://stacks.stanford.edu/image/iiif/bs173rx9307%2Fbs173rx9307_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/bs173rx9307/bs173rx9307_0001/info.json",
     "number": "188",
+    "performer": "Grünfeld, Alfred",
     "publisher": "Welte-Mignon",
     "title": "Wagner-Liszt/Grünfeld - Isoldens liebestod",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Isoldens liebestod"
   },
   {
+    "arranger": "Liszt, Franz",
+    "composer": "Wagner, Richard",
     "druid": "qf751dd5412",
-    "image_url": "https://stacks.stanford.edu/image/iiif/qf751dd5412%2Fqf751dd5412_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/qf751dd5412/qf751dd5412_0001/info.json",
     "number": "662",
+    "performer": "Hofmann, Josef",
     "publisher": "Welte-Mignon",
     "title": "Wagner-Liszt/Hofmann - Tannhauser overture",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Tannhauser overture"
   },
   {
+    "arranger": "Liszt, Franz",
+    "composer": "Wagner, Richard",
     "druid": "hh095vc8073",
-    "image_url": "https://stacks.stanford.edu/image/iiif/hh095vc8073%2Fhh095vc8073_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/hh095vc8073/hh095vc8073_0001/info.json",
     "number": "662",
+    "performer": "Hofmann, Josef",
     "publisher": "Welte-Mignon",
     "title": "Wagner-Liszt/Hofmann - Tannhäuser overture",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Tannhäuser overture"
   },
   {
+    "arranger": "Rybner, Cornelius, 1855-1929",
+    "composer": "Wagner, Richard, 1813-1883",
     "druid": "hg709nf1997",
-    "image_url": "https://stacks.stanford.edu/image/iiif/hg709nf1997%2Fhg709nf1997_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/hg709nf1997/hg709nf1997_0001/info.json",
     "number": "3019",
+    "performer": "Rybner, Cornelius, 1855-1929",
     "publisher": "Welte-Mignon",
     "title": "Wagner-Rybner/Rybner - Die Meistersinger von nürnberg: Konzert-Paraphrase",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Die Meistersinger von nürnberg: Konzert-Paraphrase"
   },
   {
+    "arranger": "Spindler, Fritz",
+    "composer": "Wagner, Richard",
     "druid": "yr287jf4422",
-    "image_url": "https://stacks.stanford.edu/image/iiif/yr287jf4422%2Fyr287jf4422_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/yr287jf4422/yr287jf4422_0001/info.json",
     "number": "144",
+    "performer": "Adam-Benard, Eugenie",
     "publisher": "Welte-Mignon",
     "title": "Wagner-Spindler/Adam-Benard - Lied a. d. abendstern: a. Tannhäuser op. 94",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Lied a. d. abendstern: a. Tannhäuser op. 94"
   },
   {
+    "arranger": "",
+    "composer": "Wagner, Richard",
     "druid": "ys288dd6430",
-    "image_url": "https://stacks.stanford.edu/image/iiif/ys288dd6430%2Fys288dd6430_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/ys288dd6430/ys288dd6430_0001/info.json",
     "number": "118",
+    "performer": "Adam-Benard, Eugenie",
     "publisher": "Welte-Mignon",
     "title": "Wagner/Adam-Benard - Schwanenlied aus lohengrin",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Schwanenlied aus lohengrin"
   },
   {
+    "arranger": "",
+    "composer": "Wagner, Richard",
     "druid": "dr835xg3992",
-    "image_url": "https://stacks.stanford.edu/image/iiif/dr835xg3992%2Fdr835xg3992_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/dr835xg3992/dr835xg3992_0001/info.json",
     "number": "3335",
+    "performer": "Lászlò, Sándor",
     "publisher": "Welte-Mignon",
     "title": "Wagner/Lászlò - Rienzi: Ouverture",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Rienzi: Ouverture"
   },
   {
+    "arranger": "",
+    "composer": "Wagner, Richard",
     "druid": "rp146dk0477",
-    "image_url": "https://stacks.stanford.edu/image/iiif/rp146dk0477%2Frp146dk0477_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/rp146dk0477/rp146dk0477_0001/info.json",
     "number": "1352",
+    "performer": "Mottl, Felix",
     "publisher": "Welte-Mignon",
     "title": "Wagner/Mottl - Am stillen herd zur winterszeit: a. die Meistersinger von Nürnberg",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Am stillen herd zur winterszeit: a. die Meistersinger von Nürnberg"
   },
   {
+    "arranger": "",
+    "composer": "Wagner, Richard",
     "druid": "mg285ps6787",
-    "image_url": "https://stacks.stanford.edu/image/iiif/mg285ps6787%2Fmg285ps6787_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/mg285ps6787/mg285ps6787_0001/info.json",
     "number": "1352",
+    "performer": "Mottl, Felix",
     "publisher": "Welte-Mignon",
     "title": "Wagner/Mottl - Die Meistersinger von nürnberg: Am stillen Herd zur Winterszeit",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Die Meistersinger von nürnberg: Am stillen Herd zur Winterszeit"
   },
   {
+    "arranger": "",
+    "composer": "Wagner, Richard",
     "druid": "jn038xx9588",
-    "image_url": "https://stacks.stanford.edu/image/iiif/jn038xx9588%2Fjn038xx9588_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/jn038xx9588/jn038xx9588_0001/info.json",
     "number": "1348",
+    "performer": "Mottl, Felix",
     "publisher": "Welte-Mignon",
     "title": "Wagner/Mottl - Lohengrin: Bridal chorus",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Lohengrin: Bridal chorus"
   },
   {
+    "arranger": "",
+    "composer": "Wagner, Richard",
     "druid": "dt046tz6296",
-    "image_url": "https://stacks.stanford.edu/image/iiif/dt046tz6296%2Fdt046tz6296_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/dt046tz6296/dt046tz6296_0001/info.json",
     "number": "1349",
+    "performer": "Mottl, Felix",
     "publisher": "Welte-Mignon",
     "title": "Wagner/Mottl - Lohengrin: Elsa's dream",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Lohengrin: Elsa's dream"
   },
   {
+    "arranger": "",
+    "composer": "Wagner, Richard",
     "druid": "nn203bm7432",
-    "image_url": "https://stacks.stanford.edu/image/iiif/nn203bm7432%2Fnn203bm7432_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/nn203bm7432/nn203bm7432_0001/info.json",
     "number": "1347",
+    "performer": "Mottl, Felix",
     "publisher": "Welte-Mignon",
     "title": "Wagner/Mottl - Tristan und isolde: Vorspiel",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Tristan und isolde: Vorspiel"
   },
   {
+    "arranger": "",
+    "composer": "Wagner, Richard",
     "druid": "xx912rs1788",
-    "image_url": "https://stacks.stanford.edu/image/iiif/xx912rs1788%2Fxx912rs1788_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/xx912rs1788/xx912rs1788_0001/info.json",
     "number": "1346",
+    "performer": "Mottl, Felix",
     "publisher": "Welte-Mignon",
     "title": "Wagner/Mottl - Vorspiel zu parsival",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Vorspiel zu parsival"
   },
   {
+    "arranger": "",
+    "composer": "Waldteufel, Emil, 1837-1915",
     "druid": "xy736dn5214",
-    "image_url": "https://stacks.stanford.edu/image/iiif/xy736dn5214%2Fxy736dn5214_0002/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/xy736dn5214/xy736dn5214_0002/info.json",
     "number": "2539",
+    "performer": "",
     "publisher": "N/A",
     "title": "Waldteufel - Très jolie: suite de valses",
-    "type": "65-note"
+    "type": "65-note",
+    "work": "Très jolie: suite de valses"
   },
   {
+    "arranger": "",
+    "composer": "Waldteufel, Emil",
     "druid": "xg670df7262",
-    "image_url": "https://stacks.stanford.edu/image/iiif/xg670df7262%2Fxg670df7262_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/xg670df7262/xg670df7262_0001/info.json",
     "number": "2466",
+    "performer": "Dubois, M",
     "publisher": "Welte-Mignon",
     "title": "Waldteufel/Dubois - Immer oder nimmer: Walzer",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Immer oder nimmer: Walzer"
   },
   {
+    "arranger": "",
+    "composer": "Weber, Carl Maria von",
     "druid": "jn782fq7439",
-    "image_url": "https://stacks.stanford.edu/image/iiif/jn782fq7439%2Fjn782fq7439_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/jn782fq7439/jn782fq7439_0001/info.json",
     "number": "134",
+    "performer": "Adam-Benard, Eugenie",
     "publisher": "Welte-Mignon",
     "title": "Weber/Adam-Benard - Rondo brillante op. 62",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Rondo brillante op. 62"
   },
   {
+    "arranger": "",
+    "composer": "Whiteman, Paul",
     "druid": "jd143sb1087",
-    "image_url": "https://stacks.stanford.edu/image/iiif/jd143sb1087%2Fjd143sb1087_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/jd143sb1087/jd143sb1087_0001/info.json",
     "number": "5553",
+    "performer": "Wolf, Alfred",
     "publisher": "Welte-Mignon",
     "title": "Whiteman/Wolf - Wonderful one: waltz song",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Wonderful one: waltz song"
   },
   {
+    "arranger": "",
+    "composer": "Youmans, Vincent",
     "druid": "sx275gw8801",
-    "image_url": "https://stacks.stanford.edu/image/iiif/sx275gw8801%2Fsx275gw8801_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/sx275gw8801/sx275gw8801_0001/info.json",
     "number": "5675",
+    "performer": "Johnson, Edward",
     "publisher": "Welte-Mignon",
     "title": "Youmans/Johnson - Tea for two: fox-trot",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Tea for two: fox-trot"
   },
   {
+    "arranger": "",
+    "composer": "Youmans, Vincent",
     "druid": "yk645sm6970",
-    "image_url": "https://stacks.stanford.edu/image/iiif/yk645sm6970%2Fyk645sm6970_0001/info.json",
+    "image_url": "https://stacks.stanford.edu/image/iiif/yk645sm6970/yk645sm6970_0001/info.json",
     "number": "5905",
+    "performer": "Sommer, Hans",
     "publisher": "Welte-Mignon",
     "title": "Youmans/Sommer - Hallelujah!: fox-trot from \"Hit the deck\"",
-    "type": "welte-red"
+    "type": "welte-red",
+    "work": "Hallelujah!: fox-trot from \"Hit the deck\""
   }
 ]


### PR DESCRIPTION
Merging this to `staging` now, but the changes are already in `master`. The additional metadata in `catalog.json` is intended to help run a standalone search and browse page with distinct, sortable columns for the different roll metadata fields.