### PR TITLE
Add Listener / Performer UIs

### DIFF
--- a/src/Pianolatron.svelte
+++ b/src/Pianolatron.svelte
@@ -87,10 +87,10 @@
 
   import catalog from "./config/catalog.json";
 
-  export let profile = "performer";
+  export let profile = "perform";
 
   const joinPath = getPathJoiner(import.meta.env.BASE_URL);
-  const isPerformer = getProfile(profile) === "performer";
+  const isPerform = getProfile(profile) === "perform";
 
   let firstLoad = true;
   let appReady = false;
@@ -298,7 +298,7 @@
 <div id="app">
   <div>
     <FlexCollapsible id="left-sidebar" width="20vw">
-      {#if isPerformer}<RollSelector bind:currentRoll {rollListItems} />{/if}
+      {#if isPerform}<RollSelector bind:currentRoll {rollListItems} />{/if}
       {#if appReady}
         <RollDetails {metadata} />
         {#if !holesByTickInterval.count}
@@ -318,7 +318,7 @@
           {holeData}
           {holesByTickInterval}
           {skipToTick}
-          showScaleBar={isPerformer}
+          showScaleBar={isPerform}
         />
       {/if}
       {#if $userSettings.showKeyboard && $userSettings.overlayKeyboard}
@@ -328,7 +328,7 @@
       {/if}
     </div>
     <FlexCollapsible id="right-sidebar" width="20vw" position="left">
-      {#if isPerformer }
+      {#if isPerform }
         <TabbedPanel {playPauseApp} {stopApp} {skipToPercentage} />
       {:else }
         <ListenerPanel {playPauseApp} {stopApp} />
@@ -359,7 +359,7 @@
 />
 <KeyboardShortcutEditor />
 <Notification />
-{#if isPerformer && $showWelcomeScreen}<Welcome />{/if}
+{#if isPerform && $showWelcomeScreen}<Welcome />{/if}
 
 <svelte:window
   on:popstate={({ state }) =>

--- a/src/Pianolatron.svelte
+++ b/src/Pianolatron.svelte
@@ -66,7 +66,7 @@
     rollPedalingOnOff,
     userSettings,
   } from "./stores";
-  import { annotateHoleData, clamp, getPathJoiner } from "./lib/utils";
+  import { annotateHoleData, clamp, getPathJoiner, getProfile } from "./lib/utils";
   import SamplePlayer from "./components/SamplePlayer.svelte";
   import RollSelector from "./components/RollSelector.svelte";
   import RollDetails from "./components/RollDetails.svelte";
@@ -76,6 +76,7 @@
   import KeyboardShortcuts from "./components/KeyboardShortcuts.svelte";
   import KeyboardShortcutEditor from "./components/KeyboardShortcutEditor.svelte";
   import TabbedPanel from "./components/TabbedPanel.svelte";
+  import ListenerPanel from "./components/ListenerPanel.svelte";
   import Welcome, { showWelcomeScreen } from "./components/Welcome.svelte";
   import Notification, {
     notify,
@@ -89,8 +90,7 @@
   export let profile = "performer";
 
   const joinPath = getPathJoiner(import.meta.env.BASE_URL);
-  const allowedProfiles = new Set([ "performer", "listener"]);
-  const isPerformer = profile == "performer" || !allowedProfiles.has(profile);
+  const isPerformer = getProfile(profile) === "performer";
 
   let firstLoad = true;
   let appReady = false;
@@ -324,11 +324,13 @@
         </div>
       {/if}
     </div>
-    {#if isPerformer }
-      <FlexCollapsible id="right-sidebar" width="20vw" position="left">
+    <FlexCollapsible id="right-sidebar" width="20vw" position="left">
+      {#if isPerformer }
         <TabbedPanel {playPauseApp} {stopApp} {skipToPercentage} />
-      </FlexCollapsible>
-    {/if}
+      {:else }
+        <ListenerPanel {playPauseApp} {stopApp} />
+      {/if}
+    </FlexCollapsible>
   </div>
   {#if $userSettings.showKeyboard && !$userSettings.overlayKeyboard}
     <div id="keyboard-container" transition:slide>

--- a/src/Pianolatron.svelte
+++ b/src/Pianolatron.svelte
@@ -254,6 +254,9 @@
     } else {
       currentRoll =
         rollListItems[Math.floor(Math.random() * rollListItems.length)];
+      const url = new URL(window.location);
+      url.searchParams.set("druid", currentRoll.druid);
+      window.history.pushState({}, "", url);
     }
   };
 

--- a/src/components/ListenerPanel.svelte
+++ b/src/components/ListenerPanel.svelte
@@ -1,0 +1,80 @@
+<style lang="scss">
+  div {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+    overflow: hidden;
+    position: relative;
+
+    :global(> div) {
+      @include background;
+      display: flex;
+      flex-direction: column;
+      gap: 4%;
+      height: 100%;
+      left: 0;
+      overflow-y: auto;
+      position: absolute;
+      top: 0;
+      width: 100%;
+    }
+
+    :global(.setting + .setting) {
+      margin-top: 1em;
+    }
+
+    :global(fieldset) {
+      border-color: rgba(white, 0.8);
+      padding: 1em 0.75em;
+    }
+
+    :global(legend) {
+      font-family: $primary-typeface;
+      font-size: 1.4em;
+    }
+
+    :global(fieldset div) {
+      display: flex;
+      justify-content: space-between;
+    }
+  }
+</style>
+
+<script>
+  // This will probably change a lot as we make the listener panel look less utilitiarian. 
+  import { keyMap } from "./KeyboardShortcuts.svelte";
+  import PlaybackControls from "./PlaybackControls.svelte";
+  import {
+    tempoCoefficient,
+  } from "../stores";
+  import { defaultControlsConfig as controlsConfig } from "../config/controls-config";
+  import SliderControl from "../ui-components/SliderControl.svelte";
+
+
+  export let playPauseApp;
+  export let stopApp;
+  const isPerformer = false;
+
+</script>
+
+<div id="listener-panel">
+  <div id="listener-playback-settings">
+    <SliderControl
+      bind:value={$tempoCoefficient}
+      min={controlsConfig.tempo.min}
+      max={controlsConfig.tempo.max}
+      step={controlsConfig.tempo.delta}
+      name="tempo"
+    >
+      <svelte:fragment slot="label">
+        Tempo:
+        <kbd class:depressed={$keyMap.TEMPO_DOWN.active}
+          >{$keyMap.TEMPO_DOWN.key}</kbd
+        >↓
+        <kbd class:depressed={$keyMap.TEMPO_UP.active}>{$keyMap.TEMPO_UP.key}</kbd
+        >↑
+      </svelte:fragment>
+    </SliderControl>
+  </div>
+</div>
+<PlaybackControls {playPauseApp} {stopApp} {isPerformer} />

--- a/src/components/ListenerPanel.svelte
+++ b/src/components/ListenerPanel.svelte
@@ -53,7 +53,7 @@
 
   export let playPauseApp;
   export let stopApp;
-  const isPerformer = false;
+  const isPerform = false;
 
 </script>
 
@@ -77,4 +77,4 @@
     </SliderControl>
   </div>
 </div>
-<PlaybackControls {playPauseApp} {stopApp} {isPerformer} />
+<PlaybackControls {playPauseApp} {stopApp} {isPerform} />

--- a/src/components/PlaybackControls.svelte
+++ b/src/components/PlaybackControls.svelte
@@ -24,6 +24,8 @@
 
   export let playPauseApp;
   export let stopApp;
+  // Fewer controls for listener than performer
+  export let isPerformer = true;
 </script>
 
 <div id="playback-controls">
@@ -38,31 +40,33 @@
     <kbd class:depressed={$keyMap.REWIND.active}>{$keyMap.REWIND.key}</kbd
     ></button
   >
-  <button
-    type="button"
-    class:pedal-on={$softOnOff}
-    aria-pressed={$softOnOff}
-    on:click={() => ($softOnOff = !$softOnOff)}
-    >Soft
-    <kbd class:depressed={$softOnOff}>{$keyMap.SOFT.key}</kbd></button
-  >
-  <button
-    type="button"
-    class:pedal-on={$sustainOnOff}
-    aria-pressed={$sustainOnOff}
-    on:click={() => ($sustainOnOff = !$sustainOnOff)}
-    >Sustain
-    <kbd class:depressed={$sustainOnOff}>{$keyMap.SUSTAIN.key}</kbd></button
-  >
-  <br />
-  <button
-    type="button"
-    style="width:100%"
-    class:pedal-on={$accentOnOff}
-    aria-pressed={$accentOnOff}
-    on:mousedown={() => ($accentOnOff = true)}
-    >Accent
-    <kbd class:depressed={$accentOnOff}>{$keyMap.ACCENT.key}</kbd></button
-  >
+  {#if isPerformer}
+    <button
+      type="button"
+      class:pedal-on={$softOnOff}
+      aria-pressed={$softOnOff}
+      on:click={() => ($softOnOff = !$softOnOff)}
+      >Soft
+      <kbd class:depressed={$softOnOff}>{$keyMap.SOFT.key}</kbd>
+    </button>
+    <button
+      type="button"
+      class:pedal-on={$sustainOnOff}
+      aria-pressed={$sustainOnOff}
+      on:click={() => ($sustainOnOff = !$sustainOnOff)}
+      >Sustain
+      <kbd class:depressed={$sustainOnOff}>{$keyMap.SUSTAIN.key}</kbd>
+    </button>
+    <br />
+    <button
+      type="button"
+      style="width:100%"
+      class:pedal-on={$accentOnOff}
+      aria-pressed={$accentOnOff}
+      on:mousedown={() => ($accentOnOff = true)}
+      >Accent
+      <kbd class:depressed={$accentOnOff}>{$keyMap.ACCENT.key}</kbd>
+    </button>
+  {/if}
 </div>
 <svelte:window on:mouseup={() => ($accentOnOff = false)} />

--- a/src/components/PlaybackControls.svelte
+++ b/src/components/PlaybackControls.svelte
@@ -25,7 +25,7 @@
   export let playPauseApp;
   export let stopApp;
   // Fewer controls for listener than performer
-  export let isPerformer = true;
+  export let isPerform = true;
 </script>
 
 <div id="playback-controls">
@@ -40,7 +40,7 @@
     <kbd class:depressed={$keyMap.REWIND.active}>{$keyMap.REWIND.key}</kbd
     ></button
   >
-  {#if isPerformer}
+  {#if isPerform}
     <button
       type="button"
       class:pedal-on={$softOnOff}

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -102,6 +102,7 @@
   import RollViewerControls from "./RollViewerControls.svelte";
   import RollViewerScaleBar from "./RollViewerScaleBar.svelte";
 
+  export let showScaleBar = true;
   export let imageUrl;
   export let holeData;
   export let holesByTickInterval;
@@ -609,7 +610,7 @@
 >
   {#if !rollImageReady}
     <span class="roll-loading" transition:fade>Downloading roll image...</span>
-  {:else}
+  {:else if showScaleBar}
     <RollViewerScaleBar {ppi} />
   {/if}
   {#if showControls}

--- a/src/components/SamplePlayer.svelte
+++ b/src/components/SamplePlayer.svelte
@@ -4,6 +4,7 @@
   import { createEventDispatcher } from "svelte";
   import { Piano } from "../lib/pianolatron-piano";
   import { notify } from "../ui-components/Notification.svelte";
+  import { getPathJoiner } from "../lib/utils";
   import {
     rollMetadata,
     softOnOff,
@@ -48,9 +49,10 @@
   const dispatch = createEventDispatcher();
 
   const midiSamplePlayer = new MidiPlayer.Player();
+  const joinPath = getPathJoiner(import.meta.env.BASE_URL);
 
   const piano = new Piano({
-    url: "samples/",
+    url: joinPath("samples/"),
     velocities: $sampleVelocities,
     release: true,
     pedal: true,

--- a/src/components/Welcome.svelte
+++ b/src/components/Welcome.svelte
@@ -55,6 +55,7 @@
   import { writable, get } from "svelte/store";
   import { fly } from "svelte/transition";
   import { userSettings } from "../stores";
+  import { getPathJoiner } from "../lib/utils";
 
   export const showWelcomeScreen = writable(
     !get(userSettings).welcomeScreenInhibited,
@@ -78,7 +79,7 @@
       title="Center for Interdisciplinary Digital Research @ Stanford Libraries"
     >
       <img
-        src="cidr.trsp.300x176.png"
+        src="{getPathJoiner(import.meta.env.BASE_URL)("cidr.trsp.300x176.png")}"
         alt="CIDR logo"
         on:load={({ target }) => (target.style.opacity = 1)}
       />

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,5 +1,10 @@
 import { rollProfile } from "../config/roll-config";
 
+export const getPathJoiner = (base) => {
+  const no_slash_base = base.replace(/[\/]+$/, "");
+  return (...parts) => [no_slash_base, ...parts].join("/");
+};
+
 export const enforcePrecision = (value, precision) => {
   const multiplier = 10 ** (precision || 0);
   return Math.round(value * multiplier) / multiplier;

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,8 +1,8 @@
 import { rollProfile } from "../config/roll-config";
 
-const profiles = new Set(["performer", "listener"]);
+const profiles = new Set(["perform", "listen"]);
 export const getProfile = (profile) =>
-  profiles.has(profile) ? profile : "performer";
+  profiles.has(profile) ? profile : "perform";
 
 export const getPathJoiner = (base) => {
   const noSlashBase = base.replace(/[/]+$/, "");

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,8 +1,12 @@
 import { rollProfile } from "../config/roll-config";
 
+const profiles = new Set(["performer", "listener"]);
+export const getProfile = (profile) =>
+  profiles.has(profile) ? profile : "performer";
+
 export const getPathJoiner = (base) => {
-  const no_slash_base = base.replace(/[\/]+$/, "");
-  return (...parts) => [no_slash_base, ...parts].join("/");
+  const noSlashBase = base.replace(/[/]+$/, "");
+  return (...parts) => [noSlashBase, ...parts].join("/");
 };
 
 export const enforcePrecision = (value, precision) => {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -9,5 +9,5 @@ import LoadingSpinner from "../ui-components/LoadingSpinner.svelte";
     showLoadingSpinner={true}
     loadingSpinnerText="Loading application..."
   />
-  <Pianolatron client:only />
+  <Pianolatron client:only profile="listener" />
 </BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -9,5 +9,5 @@ import LoadingSpinner from "../ui-components/LoadingSpinner.svelte";
     showLoadingSpinner={true}
     loadingSpinnerText="Loading application..."
   />
-  <Pianolatron client:only profile="listener" />
+  <Pianolatron client:only profile="listen" />
 </BaseLayout>

--- a/src/pages/perform/index.astro
+++ b/src/pages/perform/index.astro
@@ -9,5 +9,5 @@ import LoadingSpinner from "../../ui-components/LoadingSpinner.svelte";
     showLoadingSpinner={true}
     loadingSpinnerText="Loading application..."
   />
-  <Pianolatron client:only profile="performer" />
+  <Pianolatron client:only profile="perform" />
 </BaseLayout>

--- a/src/pages/performer/index.astro
+++ b/src/pages/performer/index.astro
@@ -1,0 +1,13 @@
+---
+import BaseLayout from "../../layouts/base.astro";
+import Pianolatron from "../../Pianolatron.svelte";
+import LoadingSpinner from "../../ui-components/LoadingSpinner.svelte";
+---
+
+<BaseLayout title="Pianolatron">
+  <LoadingSpinner
+    showLoadingSpinner={true}
+    loadingSpinnerText="Loading application..."
+  />
+  <Pianolatron client:only profile="performer" />
+</BaseLayout>


### PR DESCRIPTION
Adds some very basic listener/performer profile functionality

Listener: 
- /?druid=qm069fy5200 
- Locked into a single roll ( no roll search/changing pulldown )
- Few controls ( volume, temp, start, stop ) 
- No welcome screen
- No measuring ruler

Performer:
- /performer/?druid=qm069fy5200
- Just the previous iteration of the UI, but in a new namespace


