### PR TITLE
140 ability to bookmark a roll druid start and end points via url query parameters for both listener and performer veiws

### DIFF
--- a/src/components/BasicSettings.svelte
+++ b/src/components/BasicSettings.svelte
@@ -6,10 +6,10 @@
     trebleVolumeCoefficient,
     tempoCoefficient,
     playbackProgress,
+    playbackProgressEnd
   } from "../stores";
   import { defaultControlsConfig as controlsConfig } from "../config/controls-config";
   import SliderControl from "../ui-components/SliderControl.svelte";
-
   export let skipToPercentage;
 </script>
 
@@ -93,6 +93,19 @@
     <svelte:fragment slot="label">Progress:</svelte:fragment>
     <svelte:fragment slot="value"
       >{($playbackProgress * 100).toFixed(2)}%</svelte:fragment
+    >
+  </SliderControl>
+  <SliderControl
+    bind:value={$playbackProgressEnd}
+    min="0"
+    max="1"
+    step="0.001"
+    name="progressEnd"
+    mousewheel={false}
+  >
+    <svelte:fragment slot="label">End Selection:</svelte:fragment>
+    <svelte:fragment slot="value"
+      >{($playbackProgressEnd * 100).toFixed(2)}%</svelte:fragment
     >
   </SliderControl>
 </div>

--- a/src/stores.js
+++ b/src/stores.js
@@ -79,6 +79,7 @@ export const midiOutputs = createStore([]);
 // Playback State
 export const currentTick = createStore(0);
 export const playbackProgress = createStore(0);
+export const playbackProgressEnd = createStore(1);
 export const activeNotes = createSetStore();
 
 // User Settings

--- a/src/ui-components/CopyUrlButton.svelte
+++ b/src/ui-components/CopyUrlButton.svelte
@@ -20,15 +20,21 @@
     export let linkText = "Copy URL";
     export let copiedText = "Copied";
     let copied = false;
+    let disabled = withProgress ? true : false;
 
     const copy = () => {
         const urlToCopy = new URL(window.location);
-        if ( withProgress ) {
-            const start = ($playbackProgress * 100).toFixed(2);
-            const end = ($playbackProgressEnd * 100).toFixed(2);
-            const params = Object.fromEntries(new URLSearchParams(urlToCopy.search));
-            urlToCopy.search = new URLSearchParams({...params, start, end});
+        const params = Object.fromEntries(new URLSearchParams(urlToCopy.search));
+        delete params.start;
+        delete params.end;
+
+        if ( withProgress && $playbackProgress > 0 ) {
+            params.start = ($playbackProgress * 100).toFixed(2);
         }
+        if ( withProgress && $playbackProgressEnd < 1 ) {
+            params.end = ($playbackProgressEnd * 100).toFixed(2);
+        }
+        urlToCopy.search = new URLSearchParams(params);
         window.navigator.clipboard.writeText(urlToCopy.toString()); 
         copied = true;
         setTimeout(function () {
@@ -36,10 +42,13 @@
         }, 1000);
     }
 
+    $: disabled = ( withProgress && !(  $playbackProgress > 0  || $playbackProgressEnd < 1 ) );
+
 </script>
 
 <button
   on:click="{copy}"
+  {disabled}
   class="{$$props.class} copy-button"
 >
     {#if !copied}

--- a/src/ui-components/CopyUrlButton.svelte
+++ b/src/ui-components/CopyUrlButton.svelte
@@ -1,0 +1,65 @@
+<style>
+    .copy-button {
+        outline: none;
+        border: none;
+        background: none;
+        color: inherit;
+        font-family: inherit;
+        font-size: 14px;
+        transition: all 120ms ease-out;
+    }
+    .copy-button svg {
+        width: 14px;
+        height: 14px;
+    }
+</style>
+
+<script>
+    import { playbackProgress, playbackProgressEnd } from "../stores";
+    export let withProgress = false;
+    export let linkText = "Copy URL";
+    export let copiedText = "Copied";
+    let copied = false;
+
+    const copy = () => {
+        const urlToCopy = new URL(window.location);
+        if ( withProgress ) {
+            const start = ($playbackProgress * 100).toFixed(2);
+            const end = ($playbackProgressEnd * 100).toFixed(2);
+            const params = Object.fromEntries(new URLSearchParams(urlToCopy.search));
+            urlToCopy.search = new URLSearchParams({...params, start, end});
+        }
+        window.navigator.clipboard.writeText(urlToCopy.toString()); 
+        copied = true;
+        setTimeout(function () {
+            copied = false;
+        }, 1000);
+    }
+
+</script>
+
+<button
+  on:click="{copy}"
+  class="{$$props.class} copy-button"
+>
+    {#if !copied}
+        <svg viewBox="0 0 16 14" aria-hidden="true"><path
+            fill-rule="evenodd"
+            d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"
+        ></path></svg>
+         <span>{linkText}</span>
+    {:else}
+        <svg
+        viewBox="0 0 512 512"
+        style="enable-background:new 0 0 512 512;"
+        xml:space="preserve"
+        >
+        <path
+            d="M504.502,75.496c-9.997-9.998-26.205-9.998-36.204,0L161.594,382.203L43.702,264.311c-9.997-9.998-26.205-9.997-36.204,0
+            c-9.998,9.997-9.998,26.205,0,36.203l135.994,135.992c9.994,9.997,26.214,9.99,36.204,0L504.502,111.7
+            C514.5,101.703,514.499,85.494,504.502,75.496z"
+        ></path>
+        </svg>
+        <span>{copiedText}</span>
+    {/if}
+</button>


### PR DESCRIPTION

Adds start and end get params to provide links that start at certain points in the roll. 
?start=49.90&end=49.30&druid=ft746ns5736

There are two basic "Copy URL" buttons on the right, one just to the roll and one with the current start ( and end if set ).

You can play with setting the end param in the perform view. Below the progress slider, there is an "End Selection" slider.
Not much validation here, but if the roll progress reaches the end point, the player will pause.

Very basic validation on the params as well...makes sure they are valid 0-100 ranges. If they are invalid, they are ignored. 
 If end is before start, it is ignored. 

