### PR TITLE
138 hide the ruler by default in the performer view and add a checkbox to show it in the advanced options menu probably under visualization settings

### DIFF
--- a/src/Pianolatron.svelte
+++ b/src/Pianolatron.svelte
@@ -318,7 +318,7 @@
           {holeData}
           {holesByTickInterval}
           {skipToTick}
-          showScaleBar={isPerform}
+          showScaleBar={( isPerform && $userSettings.showRuler )}
         />
       {/if}
       {#if $userSettings.showKeyboard && $userSettings.overlayKeyboard}

--- a/src/components/AdvancedSettings.svelte
+++ b/src/components/AdvancedSettings.svelte
@@ -73,6 +73,13 @@
         bind:checked={$userSettings.highlightEnabledHoles}
       />
     </div>
+    <div class="setting">
+      Show Roll Viewer Scale Bar
+      <input
+        type="checkbox"
+        bind:checked={$userSettings.showRuler}
+      />
+    </div>
   </fieldset>
 
   <fieldset>

--- a/src/stores.js
+++ b/src/stores.js
@@ -91,6 +91,7 @@ export const userSettings = createPersistedStore("userSettings", {
   overlayKeyboard: false,
   welcomeScreenInhibited: false,
   useWebMidi: false,
+  showRuler: false
 });
 
 // Browser State


### PR DESCRIPTION

In the perform view, there is an option in the user setting -> visual settings to show the roll viewer scale bar, AKA The Ruler.
The ruler is disabled in the listen view. 

 