### PR TITLE
Adds Styling to Player Buttons

### DIFF
--- a/src/components/RollPlayerControls.svelte
+++ b/src/components/RollPlayerControls.svelte
@@ -1,11 +1,8 @@
 <style>
-.player-buttons {
+.player-button-container {
     padding: 2px;
     text-align: center;
 }
-
-
-
 </style>
 
 <script>
@@ -54,9 +51,9 @@
 
 </script>
 
-<div class="player-buttons">
+<div class="player-button-container">
 <IconButton
-    class={ $playRepeat ? "overlay" : ""}
+    class={ $playRepeat ? "overlay player-button" : "player-button"}
     disabled={false}
     on:mousedown={togglePlayRepeat}
     iconName="replay"
@@ -65,7 +62,7 @@
     width="24"
   />
 <IconButton
-    class=""
+    class={"player-button"}
     disabled={false}
     on:mousedown={resetPlayback}
     iconName="rewind"
@@ -74,6 +71,7 @@
     width="24"
   />
  <IconButton
+    class={"player-button"}
     disabled={false}
     on:mousedown={() => {
       skipFromCurrent(-1500);
@@ -85,6 +83,7 @@
   />
  {#if !showPause }
  <IconButton
+    class={"player-button"}
     disabled={false}
     on:mousedown={togglePlayPause}
     iconName="play"
@@ -94,7 +93,7 @@
   />
  {:else }
  <IconButton
-    class="overlay"
+    class={"pause player-button"}
     disabled={false}
     on:mousedown={togglePlayPause}
     iconName="pause"
@@ -104,16 +103,17 @@
   />
  {/if}
  <IconButton
-    class={ isRecording ? "overlay" : "" }
+    class={ isRecording ? "overlay player-button record" : "player-button record" }
     disabled={false}
     on:mousedown={toggleRecording}
     iconName="record"
     label="Record"
     height="24"
     width="24"
+    title="Record"
   />
   <IconButton
-    class=""
+    class={"player-button"}
     disabled={false}
     on:mousedown={() => skipFromCurrent()}
     iconName="skipForward"
@@ -122,7 +122,7 @@
     width="24"
   />
   <IconButton
-    class={ startMarked ? "overlay" : "" }
+    class={ startMarked ? "overlay player-button" : "player-button" }
     disabled={false}
     on:mousedown={markStart}
     iconName="markStart"
@@ -131,7 +131,7 @@
     width="24"
   />
   <IconButton
-    class={ endMarked ? "overlay" : "" }
+    class={ endMarked ? "overlay player-button" : "player-button" }
     disabled={false}
     on:mousedown={markEnd}
     iconName="markEnd"

--- a/src/ui-components/Icon.svelte
+++ b/src/ui-components/Icon.svelte
@@ -171,18 +171,20 @@
       svg: `
       <path d="M8.46448 7.75739L7.05026 9.1716L9.87869 12L7.05029 14.8284L8.46451 16.2426L12.7071 12L8.46448 7.75739Z" fill="currentColor" /><path d="M11.2929 9.1716L12.7071 7.75739L16.9498 12L12.7071 16.2426L11.2929 14.8284L14.1213 12L11.2929 9.1716Z" fill="currentColor" /><path fill-rule="evenodd" clip-rule="evenodd" d="M1 12C1 18.0751 5.92487 23 12 23C18.0751 23 23 18.0751 23 12C23 5.92487 18.0751 1 12 1C5.92487 1 1 5.92487 1 12ZM3 12C3 16.9706 7.02944 21 12 21C16.9706 21 21 16.9706 21 12C21 7.02944 16.9706 3 12 3C7.02944 3 3 7.02944 3 12Z" fill="currentColor" />
       `,
+      attribs: { "stroke-width": 0.5},
     },
     skipBack: {
       svg: `
       <path d="M12.7071 9.1716L11.2929 7.75739L7.05024 12L11.2929 16.2426L12.7071 14.8284L9.87869 12L12.7071 9.1716Z" fill="currentColor" /><path d="M15.5355 7.75739L16.9497 9.1716L14.1213 12L16.9497 14.8284L15.5355 16.2426L11.2929 12L15.5355 7.75739Z" fill="currentColor" /><path fill-rule="evenodd" clip-rule="evenodd" d="M23 12C23 18.0751 18.0751 23 12 23C5.92487 23 1 18.0751 1 12C1 5.92487 5.92487 1 12 1C18.0751 1 23 5.92487 23 12ZM21 12C21 16.9706 16.9706 21 12 21C7.02944 21 3 16.9706 3 12C3 7.02944 7.02944 3 12 3C16.9706 3 21 7.02944 21 12Z" fill="currentColor" />
       `,
+      attribs: { "stroke-width": 0.5},
     },
     replay: {
       svg: `
         <path d="M4.56079 10.6418L6.35394 3.94971L8.25402 5.84979C11.7312 3.6588 16.3814 4.07764 19.41 7.1063L17.9958 8.52052C15.7536 6.27827 12.3686 5.87519 9.71551 7.31128L11.2529 8.84869L4.56079 10.6418Z" fill="currentColor" />
         <path d="M19.4392 13.3581L17.646 20.0502L15.7459 18.1501C12.2688 20.3411 7.61857 19.9223 4.58991 16.8936L6.00413 15.4794C8.24638 17.7217 11.6313 18.1247 14.2844 16.6887L12.747 15.1512L19.4392 13.3581Z" fill="currentColor" />
       `,
-      attribs: { "stroke-width": 1.5 },
+      attribs: { "stroke-width": 0.5},
     },
     rewind: {
       svg: `
@@ -190,6 +192,7 @@
         <path d="M6 12L13.0023 7.00003V17L6 12Z" fill="currentColor" />
         <path d="M21.0023 7.00003L14 12L21.0023 17V7.00003Z" fill="currentColor" />
       `,
+      attribs: { "stroke-width": 0.5},
     },
     play: {
       svg: `
@@ -201,6 +204,7 @@
         />
         <path d="M16 12L10 16.3301V7.66987L16 12Z" fill="currentColor" />
       `,
+      attribs: { "stroke-width": 0.5},
     },
     pause: {
       svg: `
@@ -213,11 +217,13 @@
           fill="currentColor"
         />
       `,
+      attribs: { "stroke-width": 0.5},
     },
     record: {
       svg: `
         <path d="M12 15C13.6569 15 15 13.6569 15 12C15 10.3431 13.6569 9 12 9C10.3431 9 9 10.3431 9 12C9 13.6569 10.3431 15 12 15Z" fill="currentColor" /><path fill-rule="evenodd" clip-rule="evenodd" d="M22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12ZM20 12C20 16.4183 16.4183 20 12 20C7.58172 20 4 16.4183 4 12C4 7.58172 7.58172 4 12 4C16.4183 4 20 7.58172 20 12Z" fill="currentColor" />      
       `,
+      attribs: { "stroke-width": 0.5},
     },
     markStart: {
       svg: `
@@ -227,6 +233,7 @@
         />
         <path d="M3 18V6H1V18H3Z" fill="currentColor" />
       `,
+      attribs: { "stroke-width": 0.5},
     },
     markEnd: {
       svg: `
@@ -236,6 +243,7 @@
         />
         <path d="M20.2877 6V18H22.2877V6H20.2877Z" fill="currentColor" />
       `,
+      attribs: { "stroke-width": 0.5},
     },
 
   };

--- a/src/ui-components/IconButton.svelte
+++ b/src/ui-components/IconButton.svelte
@@ -17,27 +17,34 @@
       opacity: 0.5;
     }
 
-    &.overlay {
-      color: #ffffff;
+    &.player-button {
+      filter: drop-shadow(2px 2px 1px #a4a4a4);
       padding: 0.35em 0.8em;
+
+      &:active {
+        color: white;
+        filter: drop-shadow(1px 1px 1px #a4a4a4);
+      }
 
       &:focus,
       &:active {
         outline: 0;
       }
 
-      &:hover {
+      &:hover,
+      &.pause {
         color: white;
-        outline: 1px solid white;
-      }
-
-      &:active {
-        color: grey;
       }
 
       &:disabled {
         color: grey;
         cursor: not-allowed;
+      }
+
+      &.record:active,
+      &.record:hover,
+      &.record:focus {
+        color: red;
       }
     }
   }

--- a/src/ui-components/IconButton.svelte
+++ b/src/ui-components/IconButton.svelte
@@ -74,6 +74,7 @@
   on:click
   on:mousedown
   bind:this={ref}
+  title={label}
 >
   <Icon name={iconName} {height} {width} aria-hidden="true" focusable="false" />
 </button>


### PR DESCRIPTION
This adds some simple styling to the player icons for the app. Probably still a work in progress, would appreciate feedback!

untouched
![Screenshot 2023-11-02 at 5 00 17 PM](https://github.com/sul-cidr/pianolatron/assets/2965712/d06d928a-a11e-47ad-b39a-324df8c8e4c0)
hover over Play button
![Screenshot 2023-11-02 at 5 02 10 PM](https://github.com/sul-cidr/pianolatron/assets/2965712/52d9ccb9-63d9-4574-91e8-c7411e8bfd5f)
hover over Repeat button
![Screenshot 2023-11-02 at 5 01 55 PM](https://github.com/sul-cidr/pianolatron/assets/2965712/ab445075-a5b3-4b6f-8b1e-33a3573607e8)
Record turns red when pressed
![Screenshot 2023-11-02 at 5 00 34 PM](https://github.com/sul-cidr/pianolatron/assets/2965712/76b1dd6e-55cd-4aa8-9d7e-3a81a4249b00)
play (pause) button stays white while playing
![Screenshot 2023-11-02 at 5 00 25 PM](https://github.com/sul-cidr/pianolatron/assets/2965712/bf6e8d08-efd3-4911-9fef-dc65f43362fd)
