### PR TITLE
153 add a transposition controller

### DIFF
--- a/src/components/BasicSettings.svelte
+++ b/src/components/BasicSettings.svelte
@@ -5,6 +5,7 @@
     bassVolumeCoefficient,
     trebleVolumeCoefficient,
     tempoCoefficient,
+    transposeHalfStep,
     playbackProgress,
   } from "../stores";
   import { defaultControlsConfig as controlsConfig } from "../config/controls-config";
@@ -80,6 +81,15 @@
       <kbd class:depressed={$keyMap.TEMPO_UP.active}>{$keyMap.TEMPO_UP.key}</kbd
       >↑
     </svelte:fragment>
+  </SliderControl>
+  <SliderControl
+    bind:value={$transposeHalfStep}
+    min={controlsConfig.transpose.min}
+    max={controlsConfig.transpose.max}
+    step={controlsConfig.transpose.delta}
+    name="transpose"
+  >
+    <svelte:fragment slot="label">Transpose (half steps):</svelte:fragment>
   </SliderControl>
   <SliderControl
     value={$playbackProgress}

--- a/src/components/Keyboard.svelte
+++ b/src/components/Keyboard.svelte
@@ -40,7 +40,9 @@
       height: $felt-strip-height;
       left: 0;
       right: 0;
-      box-shadow: 0 1px 1px rgba(0, 0, 0, 0.7), 1px 0 1px rgba(0, 0, 0, 0.7),
+      box-shadow:
+        0 1px 1px rgba(0, 0, 0, 0.7),
+        1px 0 1px rgba(0, 0, 0, 0.7),
         -1px 0 1px rgba(0, 0, 0, 0.7);
       z-index: 1;
     }
@@ -54,8 +56,12 @@
         background: linear-gradient(-30deg, #f5f5f5, #fff);
         border-radius: 0 0 4% 4%;
         border: 1px solid #ccc;
-        box-shadow: inset 0 1px 0 #fff, inset 0 -1px 0 #fff, inset 1px 0 0 #fff,
-          inset -1px 0 0 #fff, 0 4px 3px rgba(0, 0, 0, 0.7);
+        box-shadow:
+          inset 0 1px 0 #fff,
+          inset 0 -1px 0 #fff,
+          inset 1px 0 0 #fff,
+          inset -1px 0 0 #fff,
+          0 4px 3px rgba(0, 0, 0, 0.7);
         display: block;
         height: 100%;
       }
@@ -98,7 +104,8 @@
         border-radius: 0 0 3% 3%;
         border-style: solid;
         border-width: 1px 2px 7px;
-        box-shadow: inset 0 -1px 2px rgba(255, 255, 255, 0.4),
+        box-shadow:
+          inset 0 -1px 2px rgba(255, 255, 255, 0.4),
           0 2px 3px rgba(0, 0, 0, 0.4);
         height: 56%;
         left: 100%;
@@ -112,14 +119,16 @@
       :global(:nth-child(2).depressed) {
         background: $active-key-highlight;
         border-bottom-width: 2px;
-        box-shadow: inset 0 -1px 1px rgba(255, 255, 255, 0.4),
-          0 1px 0 rgba(0, 0, 0, 0.8), 0 2px 2px rgba(0, 0, 0, 0.4),
+        box-shadow:
+          inset 0 -1px 1px rgba(255, 255, 255, 0.4),
+          0 1px 0 rgba(0, 0, 0, 0.8),
+          0 2px 2px rgba(0, 0, 0, 0.4),
           0 -1px 0 #000;
         height: 57%;
       }
     }
   }
-  
+
   button.pedal {
     // SVG pedals were previously wrapped in <div/> tags because SVG animation performance sucks
     //  so badly on Chromium-based browsers on Mac OS that the whole app suffers.
@@ -152,6 +161,7 @@
 <script>
   import KeyboardControls from "./KeyboardControls.svelte";
   import { activeNotes, softOnOff, sustainOnOff } from "../stores";
+  import { NoteSource } from "../lib/utils";
 
   export let keyCount = 88;
   export let startNote;
@@ -195,7 +205,9 @@
   let mouseDown = false;
   let playing = new Set();
   const stopPlaying = () => {
-    playing.forEach((midiNumber) => stopNote(midiNumber));
+    playing.forEach((midiNumber) =>
+      stopNote(midiNumber, undefined, NoteSource.Keyboard),
+    );
     playing = new Set();
   };
 </script>
@@ -208,13 +220,13 @@
       const note = parseInt(target.dataset.key, 10);
       mouseDown = true;
       playing = playing.add(note);
-      startNote(note);
+      startNote(note, undefined, NoteSource.Keyboard);
     }}
     on:mouseup|preventDefault={({ target }) => {
       const note = parseInt(target.dataset.key, 10);
       playing.delete(note);
       playing = playing;
-      stopNote(note);
+      stopNote(note, NoteSource.Keyboard);
     }}
     on:mousemove|preventDefault={({ target }) => {
       if (mouseDown) {
@@ -222,7 +234,7 @@
         if (note && !playing.has(note)) {
           stopPlaying();
           playing = playing.add(note);
-          startNote(note);
+          startNote(note, undefined, NoteSource.Keyboard);
         }
       }
     }}

--- a/src/components/SamplePlayer.svelte
+++ b/src/components/SamplePlayer.svelte
@@ -4,7 +4,7 @@
   import { createEventDispatcher } from "svelte";
   import { Piano } from "../lib/pianolatron-piano";
   import { notify } from "../ui-components/Notification.svelte";
-  import { getPathJoiner } from "../lib/utils";
+  import { getPathJoiner, NoteSource } from "../lib/utils";
   import {
     rollMetadata,
     softOnOff,
@@ -28,6 +28,7 @@
     velocityCurveMid,
     velocityCurveHigh,
     userSettings,
+    transposeHalfStep,
   } from "../stores";
   import WebMidi from "./WebMidi.svelte";
 
@@ -176,7 +177,10 @@
     loadSampleVelocities();
   };
 
-  const startNote = (noteNumber, velocity, fromMidi) => {
+  const startNote = (noteNumber, velocity, noteSource) => {
+    if (noteSource == NoteSource.Midi) {
+      noteNumber = noteNumber + $transposeHalfStep;
+    }
     activeNotes.add(noteNumber);
     let baseVelocity =
       (($playExpressionsOnOff && velocity) || DEFAULT_NOTE_VELOCITY) / 100;
@@ -213,15 +217,18 @@
         velocity: modifiedVelocity * (($softOnOff && SOFT_PEDAL_RATIO) || 1),
       });
     }
-    if (!fromMidi) {
+    if (noteSource != NoteSource.WebMidi) {
       webMidi?.sendMidiMsg("NOTE_ON", noteNumber, modifiedVelocity);
     }
   };
 
-  const stopNote = (noteNumber, fromMidi) => {
+  const stopNote = (noteNumber, noteSource) => {
+    if (noteSource == NoteSource.Midi) {
+      noteNumber = noteNumber + $transposeHalfStep;
+    }
     activeNotes.delete(noteNumber);
     piano.keyUp({ midi: noteNumber });
-    if (!fromMidi) {
+    if (noteSource != NoteSource.WebMidi) {
       webMidi?.sendMidiMsg("NOTE_OFF", noteNumber, 0);
     }
   };
@@ -346,9 +353,9 @@
     ({ name, value, number, noteNumber, velocity, data }) => {
       if (name === "Note on") {
         if (velocity === 0) {
-          stopNote(noteNumber);
+          stopNote(noteNumber, NoteSource.Midi);
         } else {
-          startNote(noteNumber, velocity);
+          startNote(noteNumber, velocity, NoteSource.Midi);
         }
       } else if (name === "Controller Change" && $rollPedalingOnOff) {
         if (number === SUSTAIN_PEDAL) {
@@ -373,6 +380,8 @@
   $: piano.updateVolumes($sampleVolumes);
   $: piano.updateReverb($reverbWetDry);
   $: $sampleVelocities, updateSampleVelocities();
+  // Brutal but if we transpose while playing, notes will never get correct stopNote and will just hang.
+  $: $sampleVelocities, stopAllNotes();
 
   export {
     midiSamplePlayer,

--- a/src/components/WebMidi.svelte
+++ b/src/components/WebMidi.svelte
@@ -1,6 +1,6 @@
 <script>
   import { onMount } from "svelte";
-  import { clamp } from "../lib/utils";
+  import { clamp, NoteSource } from "../lib/utils";
   import { midiInputs, midiOutputs } from "../stores";
 
   export let startNote;
@@ -54,13 +54,13 @@
           startNote(
             entity,
             parseInt((parseFloat(value) / 127) * 100, 10),
-            /* fromMidi = */ true,
+            NoteSource.WebMidi,
           );
         }
         break;
 
       case midiBytes.NOTE_OFF:
-        stopNote(entity, /* fromMidi = */ true);
+        stopNote(entity, NoteSource.WebMidi);
         break;
 
       default:

--- a/src/config/controls-config.js
+++ b/src/config/controls-config.js
@@ -34,6 +34,13 @@ export const defaultControlsConfig = {
     augmentedDelta: 0.1,
     precision: 2,
   },
+  transpose: {
+    min: -6,
+    max: 6,
+    delta: 1,
+    augmentedDelta: 1,
+    precision: 0
+  }
 };
 
 export const controlsStores = {

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,5 +1,12 @@
 import { rollProfile } from "../config/roll-config";
 
+// An enum for where notes are coming from
+export const NoteSource = {
+  Keyboard: 0,
+  Midi: 1,
+  WebMidi: 2
+}
+
 const profiles = new Set(["perform", "listen"]);
 export const getProfile = (profile) =>
   profiles.has(profile) ? profile : "perform";
@@ -139,13 +146,13 @@ export const annotateHoleData = (
 
   const getNoteHoleColor = ({ v: velocity }) =>
     holeColorMap[
-      Math.round(
-        mapToRange(
-          normalizeInRange(velocity, minNoteVelocity, maxNoteVelocity),
-          0,
-          holeColorMap.length - 1,
-        ),
-      )
+    Math.round(
+      mapToRange(
+        normalizeInRange(velocity, minNoteVelocity, maxNoteVelocity),
+        0,
+        holeColorMap.length - 1,
+      ),
+    )
     ];
 
   const imageLengthPx = parseInt(imageLength, 10);

--- a/src/stores.js
+++ b/src/stores.js
@@ -45,6 +45,7 @@ export const bassVolumeCoefficient = createStore(1);
 export const trebleVolumeCoefficient = createStore(1);
 
 export const tempoCoefficient = createStore(1);
+export const transposeHalfStep = createStore(0);
 
 export const playExpressionsOnOff = createStore(true);
 export const rollPedalingOnOff = createStore(true);


### PR DESCRIPTION

Adding a transpose slider. 
It appears in the Basic Setting pane of the Perform view ( below Tempo, above Progress )
Increment 1 between -6 and 6 ( default is 0 ), with each value being a half step.  
When enabled, notes played from Midi should be shifted half-step up or down. The keys visualized on keyboard should follow.

Notes played directly on the keyboard or via WebMidi should not be transposed. 