### PR TITLE
155 integrate the playback lag warning

### DIFF
--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -97,10 +97,12 @@
     playExpressionsOnOff,
     rollPedalingOnOff,
     playbackProgress,
+    showLatencyWarning,
   } from "../stores";
   import { clamp, getHoleLabel } from "../lib/utils";
   import RollViewerControls from "./RollViewerControls.svelte";
   import RollViewerScaleBar from "./RollViewerScaleBar.svelte";
+  import LatencyWarning from "../ui-components/LatencyWarning.svelte";
 
   export let showScaleBar = true;
   export let imageUrl;
@@ -623,4 +625,8 @@
       {panHorizontal}
     />
   {/if}
+  {#if $showLatencyWarning}
+    <LatencyWarning />
+  {/if}
+
 </div>

--- a/src/components/SamplePlayer.svelte
+++ b/src/components/SamplePlayer.svelte
@@ -28,6 +28,7 @@
     velocityCurveMid,
     velocityCurveHigh,
     userSettings,
+    showLatencyWarning,
   } from "../stores";
   import WebMidi from "./WebMidi.svelte";
 
@@ -254,10 +255,9 @@
           getElapsedTimeAtTick(tick) - getElapsedTimeAtTick(playbackStartTick);
         const elapsedTimeDiff = elapsedTime - expectedElapsedTime;
         if (elapsedTimeDiff > 0.1) {
-          latentNotes = [
-            ...latentNotes.filter((n) => n >= $currentTick - latencyThreshold),
-            tick,
-          ];
+          latentNotes = [ ...latentNotes, tick ];
+        } else if ( $showLatencyWarning) {
+          latentNotes = latentNotes.filter((n) => n >= $currentTick - latencyThreshold);
         }
       } else {
         console.log(
@@ -429,7 +429,9 @@
 
   const checkLatency = () => {
     if (latentNotes.length > 10) {
-      console.log("We are Laggy! " + latentNotes.length);
+      $showLatencyWarning = true;
+    } else {
+      $showLatencyWarning = false;
     }
   };
 

--- a/src/stores.js
+++ b/src/stores.js
@@ -101,3 +101,5 @@ export const media = watchMedia({
   wide: "(min-width: 1400px)",
   hover: "(hover: hover)",
 });
+
+export const showLatencyWarning = createStore(false);

--- a/src/ui-components/LatencyWarning.svelte
+++ b/src/ui-components/LatencyWarning.svelte
@@ -1,0 +1,78 @@
+<style lang="scss">
+  $aspect-ratio: 2.848;
+  $container-height: 20vh;
+  $container-width: unquote("min(800px, 80vw)");
+
+  #lag-warning {
+    background-color: rgba(white, 0.2);
+    color: var(--primary-accent);
+    display: grid;
+    font-size: 1.4em;
+    height: 100%;
+    left: 0;
+    place-content: center;
+    pointer-events: none;
+    position: absolute;
+    text-align: center;
+    text-shadow: 0px 0px 8px white;
+    top: 0;
+    width: 100%;
+    z-index: 9;
+
+    > div {
+      background-color: rgba(white, 0.6);
+      border-radius: 0.5em;
+      box-shadow: 0 0 10px white;
+      display: flex;
+      flex-direction: column;
+      gap: 1em;
+      padding: 1em;
+      transform: translate3d(0, -80%, 0);
+      width: $container-width;
+
+      > div {
+        height: $container-height;
+        overflow: hidden;
+        position: relative;
+      }
+    }
+
+    &:global(.fade-out) {
+      opacity: 0;
+      transition: opacity 1s ease;
+    }
+
+    p {
+        z-index: 50;
+    }
+  }
+
+  @keyframes scroll {
+    100% {
+      transform: translateY(calc(#{$container-width} * #{$aspect-ratio} * -1));
+    }
+  }
+
+  span {
+    display: grid;
+    place-items: center;
+    text-shadow: 0px 0px 8px white;
+  }
+</style>
+
+<script>
+  import { fade } from "svelte/transition";
+
+</script>
+
+<div id="lag-warning" transition:fade>
+    <div>
+        <div>
+            <span>Latency Warning!</span>
+   <p>
+    Your web browser seems to be having difficulty playing this roll, and as a result some notes may not be sounding when they should. Please consider following the suggestions in <a href="google.com" target="blank">the documentation</a> to attempt to improve the performance.
+   </p>
+
+        </div>
+    </div>
+</div>


### PR DESCRIPTION

Starting point for the latency warning. 
The SamplePlayer keeps a list of notes that lagged. If there's a certain number ( 10? ) within a relatively recent period ( 1% of the total ticks ) of the current tick, we consider this enough latency to do something ( right now, put a message in the console ).

Just guessing about the numbers at this point. 

Using Chrome Dev Tools -> CPU Throttle -> 6x slow down should trigger the warning ( cranking up tempo and disabling Chrome's access to GPU also helps ).

