### PR TITLE
Remove End Selection Slider from BasicSettings. Minor spacing

### DIFF
--- a/src/components/BasicSettings.svelte
+++ b/src/components/BasicSettings.svelte
@@ -7,7 +7,6 @@
     tempoCoefficient,
     transposeHalfStep,
     playbackProgress,
-    playbackProgressEnd
   } from "../stores";
   import { defaultControlsConfig as controlsConfig } from "../config/controls-config";
   import SliderControl from "../ui-components/SliderControl.svelte";
@@ -103,19 +102,6 @@
     <svelte:fragment slot="label">Progress:</svelte:fragment>
     <svelte:fragment slot="value"
       >{($playbackProgress * 100).toFixed(2)}%</svelte:fragment
-    >
-  </SliderControl>
-  <SliderControl
-    bind:value={$playbackProgressEnd}
-    min="0"
-    max="1"
-    step="0.001"
-    name="progressEnd"
-    mousewheel={false}
-  >
-    <svelte:fragment slot="label">End Selection:</svelte:fragment>
-    <svelte:fragment slot="value"
-      >{($playbackProgressEnd * 100).toFixed(2)}%</svelte:fragment
     >
   </SliderControl>
 </div>

--- a/src/ui-components/SliderControl.svelte
+++ b/src/ui-components/SliderControl.svelte
@@ -1,7 +1,7 @@
 <style>
   div {
     display: flex;
-    height: 3.5em;
+    min-height: 3.5em;
     justify-content: space-between;
     padding: 0 0.5em 0.5em;
     position: relative;
@@ -10,7 +10,7 @@
   div :global(input[type="range"]) {
     left: 0;
     margin: 0;
-    padding: 2.5em 0 1em 0;
+    padding: 2em 0 1em 0;
     position: absolute;
     top: 0;
   }


### PR DESCRIPTION

Removes the "End Selection" slider from the BasicSettings.
Does some minor spacing adjustments for the sliders, which are getting cramped. 