### PR TITLE
Add start/end markers to image viewer

### DIFF
--- a/src/styles/hole-highlighting.scss
+++ b/src/styles/hole-highlighting.scss
@@ -205,7 +205,7 @@ $highlight-hover-outline-offset: 4px;
 
   // when "Highlight All Holes" is off, don't fill the hole <rect/> elements
   &:not(.highlight-enabled-holes) {
-    svg rect {
+    svg rect:not(.selection) {
       fill: none;
     }
   }


### PR DESCRIPTION

This adds the start/end marker lines to the image viewer. 
Lines will be seen if either start or end markers are set in the roll image viewer.
If both start and end are set, the selection will be highlighted in a purple box. 

Also cleans up and fixes the lines show in the navigation viewer ( the sidebar ). 

