### PR TITLE
Add UI functionality to note tranposition

### DIFF
--- a/src/components/Keyboard.svelte
+++ b/src/components/Keyboard.svelte
@@ -160,7 +160,13 @@
 
 <script>
   import KeyboardControls from "./KeyboardControls.svelte";
-  import { activeNotes, softOnOff, sustainOnOff } from "../stores";
+  import {
+    activeNotes,
+    isPlaying,
+    softOnOff,
+    sustainOnOff,
+    transposeHalfStep,
+  } from "../stores";
   import { NoteSource } from "../lib/utils";
 
   export let keyCount = 88;
@@ -210,6 +216,20 @@
     );
     playing = new Set();
   };
+
+  // when playing, we dump the active notes and those incoming are transposed
+  // the keyboard doesn't need to do anythign with tranpose in that situation.
+  // if we're not playing, the activeNotes will stay in place ( untransposed )
+  // so the keyboard needs to update its depressed keys.
+  let transposeCoefficient = 0;
+  const updateTransposeCoefficient = () => {
+    if (!$isPlaying) {
+      transposeCoefficient = $transposeHalfStep;
+    }
+  };
+
+  $: $transposeHalfStep, updateTransposeCoefficient();
+  $: if ($isPlaying && transposeCoefficient != 0) transposeCoefficient = 0;
 </script>
 
 <div id="keyboard">
@@ -247,7 +267,8 @@
             role="button"
             tabindex="0"
             data-key={note}
-            class:depressed={$activeNotes.has(note) || playing.has(note)}
+            class:depressed={$activeNotes.has(note - transposeCoefficient) ||
+              playing.has(note)}
           />
         {/each}
       </div>

--- a/src/components/SamplePlayer.svelte
+++ b/src/components/SamplePlayer.svelte
@@ -265,7 +265,9 @@
       1,
     );
     if (modifiedVelocity) {
-      if (notesMap.search(tick, tick).includes(noteNumber)) {
+      if (
+        notesMap.search(tick, tick).includes(noteNumber - $transposeHalfStep)
+      ) {
         const thisTime = Date.now();
         const elapsedTime = (thisTime - playbackStartTime) / 1000;
         const expectedElapsedTime =
@@ -466,6 +468,13 @@
 
   midiSamplePlayer.on("endOfFile", pausePlaybackOrLoop);
 
+  const updateTranspose = () => {
+    // if we're playing just dump everything and let the updates roll in
+    if ($isPlaying) {
+      stopAllNotes();
+    }
+  };
+
   const checkLatency = () => {
     if (latentNotes.length > 10) {
       $latencyDetected = true;
@@ -483,8 +492,7 @@
   $: piano.updateVolumes($sampleVolumes);
   $: piano.updateReverb($reverbWetDry);
   $: $sampleVelocities, updateSampleVelocities();
-  // Brutal but if we transpose while playing, notes will never get correct stopNote and will just hang.
-  $: $sampleVelocities, stopAllNotes();
+  $: $transposeHalfStep, updateTranspose();
   $: latentNotes, checkLatency();
 
   export {


### PR DESCRIPTION

This adds transpose functionality to the UI. 
When the transpose slider moves:

- Depressed keys will reflect transposition
- Note labels in the roll viewer will also reflect the update when hovered


Also fixes a few bugs that were the result of the transposed notes not being found in the noteMap. 