### PR TITLE
Move Player Buttons for Perform View

### DIFF
--- a/src/Pianolatron.svelte
+++ b/src/Pianolatron.svelte
@@ -45,7 +45,7 @@
     bottom: 0;
     width: calc(100% - var(--navigator-width));
     opacity: 0.5;
-    z-index: z($main-context, keyboard-overlay);
+    // z-index: z($main-context, keyboard-overlay);
   }
 </style>
 

--- a/src/Pianolatron.svelte
+++ b/src/Pianolatron.svelte
@@ -137,10 +137,8 @@
 
   // redundant, but the way the BasicSettings comp is built requires we define the func
   // here, as it won't update the ref.
-  const skipToPercentage = (percentage = 0) => {
-    console.log("skipping");
+  const skipToPercentage = (percentage = 0) =>
     skipToTick(progressPercentageToTick(percentage));
-  };
 
   const rollListItems = catalog.map((item) => ({
     ...item,

--- a/src/Pianolatron.svelte
+++ b/src/Pianolatron.svelte
@@ -137,8 +137,10 @@
 
   // redundant, but the way the BasicSettings comp is built requires we define the func
   // here, as it won't update the ref.
-  const skipToPercentage = (percentage = 0) =>
+  const skipToPercentage = (percentage = 0) => {
+    console.log("skipping");
     skipToTick(progressPercentageToTick(percentage));
+  };
 
   const rollListItems = catalog.map((item) => ({
     ...item,
@@ -194,7 +196,6 @@
     trebleVolumeCoefficient.reset();
     holesByTickInterval = new IntervalTree();
   };
-
 
   const loadRoll = (roll) => {
     appWaiting = true;
@@ -403,7 +404,7 @@
             {recordingControl}
           />
         {:else}
-          <ListenerPanel {playPauseApp} {stopApp} />
+          <ListenerPanel {skipToTick} {playPauseApp} {stopApp} />
         {/if}
       {/if}
     </FlexCollapsible>

--- a/src/Pianolatron.svelte
+++ b/src/Pianolatron.svelte
@@ -66,6 +66,8 @@
     isReproducingRoll,
     scrollDownwards,
     playExpressionsOnOff,
+    recordingInBuffer,
+    recordingOnOff,
     rollPedalingOnOff,
     userSettings,
     playRepeat,
@@ -75,6 +77,7 @@
     clamp,
     getPathJoiner,
     getProfile,
+    RecordingActions,
   } from "./lib/utils";
   import SamplePlayer from "./components/SamplePlayer.svelte";
   import RollSelector from "./components/RollSelector.svelte";
@@ -309,6 +312,40 @@
     }
   };
 
+  const exportRecordingMIDI = () =>
+    recordingControl(RecordingActions.ExportMIDI);
+  const exportRecordingWAV = () => recordingControl(RecordingActions.ExportWAV);
+  const clearRecording = () => recordingControl(RecordingActions.Clear);
+
+  const toggleRecording = () => {
+    $recordingOnOff = !$recordingOnOff;
+    if ($recordingInBuffer && !$recordingOnOff) {
+      notify({
+        title: "Recording Complete.",
+        message: "",
+        closable: true,
+        actions: [
+          {
+            label: "Export MIDI Recording ",
+            fn: exportRecordingMIDI,
+          },
+          {
+            label: "Export WAV Recording ",
+            fn: exportRecordingWAV,
+          },
+          {
+            label: "Clear Recording",
+            fn: clearRecording,
+          },
+          {
+            label: "Continue",
+            fn: clearNotification,
+          },
+        ],
+      });
+    }
+  };
+
   onMount(async () => {
     document.querySelector("#loading span").textContent =
       "Loading resources...";
@@ -354,7 +391,7 @@
 
 <div id="app">
   <div>
-    <FlexCollapsible id="left-sidebar" width="20vw">
+    <FlexCollapsible id="left-sidebar" width="20vw" hidden={false}>
       {#if isPerform}<RollSelector bind:currentRoll {rollListItems} />{/if}
       {#if appReady}
         <RollDetails {metadata} />
@@ -372,7 +409,7 @@
           {skipToTick}
           {resetPlayback}
           {playPauseApp}
-          {recordingControl}
+          {toggleRecording}
           {isPerform}
         />
         <RollViewer
@@ -392,7 +429,12 @@
         </div>
       {/if}
     </div>
-    <FlexCollapsible id="right-sidebar" width="20vw" position="left">
+    <FlexCollapsible
+      id="right-sidebar"
+      width="20vw"
+      position="left"
+      hidden={!isPerform}
+    >
       {#if appReady}
         {#if isPerform}
           <TabbedPanel
@@ -428,6 +470,7 @@
   {stopApp}
   {updateTickByViewportIncrement}
   {panHorizontal}
+  {toggleRecording}
 />
 <KeyboardShortcutEditor />
 <Notification />

--- a/src/components/KeyboardShortcuts.svelte
+++ b/src/components/KeyboardShortcuts.svelte
@@ -29,6 +29,7 @@
   export let stopApp;
   export let updateTickByViewportIncrement;
   export let panHorizontal;
+  export let toggleRecording;
 
   let actionInterval;
   let leftHandAugment = false;
@@ -97,6 +98,8 @@
     PAN_LEFT: () => keydownRepeatAction(() => panHorizontal(/* left = */ true)),
     PAN_RIGHT: () =>
       keydownRepeatAction(() => panHorizontal(/* left = */ false)),
+
+    TOGGLE_RECORD: toggleRecording,
   };
 
   const keyupCommandMap = {

--- a/src/components/ListenerPanel.svelte
+++ b/src/components/ListenerPanel.svelte
@@ -53,6 +53,7 @@
 
   export let playPauseApp;
   export let stopApp;
+  export let skipToTick;
   const isPerform = false;
 
 </script>
@@ -77,4 +78,4 @@
     </SliderControl>
   </div>
 </div>
-<PlaybackControls {playPauseApp} {stopApp} {isPerform} />
+<PlaybackControls {skipToTick} {playPauseApp} {stopApp} {isPerform} />

--- a/src/components/PlaybackControls.svelte
+++ b/src/components/PlaybackControls.svelte
@@ -34,7 +34,7 @@
     flex-wrap: wrap;
 
     button {
-      @include button;
+      // @include button;
       flex-grow: 1;
       min-width: 120px;
       width: 50%;
@@ -59,70 +59,71 @@
 
   export let playPauseApp;
   export let stopApp;
+
   // Fewer controls for listener than performer
-  export let isPerform = true;
+  // Not entirely sure how this is supposed to work - commented out for now
+  // export let isPerform = true;
 </script>
 
 <div id="playback-controls">
-  <div>
-    {#key $isPlaying}
+  <!-- {#if isPerform} -->
+    <div>
+      {#key $isPlaying}
+        <IconButton
+          class="overlay"
+          disabled={false}
+          on:click={playPauseApp}
+          iconName={$isPlaying ? "pause" : "play"}
+          label={$isPlaying ? "Pause" : "Play"}
+          tooltip={$isPlaying ? "Pause (key: 7)" : "Play (key: 7)"}
+        >
+          <kbd class:depressed={$keyMap.PLAY_PAUSE.active}
+            >{$keyMap.PLAY_PAUSE.key}</kbd
+          >
+        </IconButton>
+      {/key}
+      </div>
+      <div>
       <IconButton
         class="overlay"
         disabled={false}
-        on:click={playPauseApp}
-        iconName={$isPlaying ? "pause" : "play"}
-        label={$isPlaying ? "Pause" : "Play"}
-        tooltip={$isPlaying ? "Pause (key: 7)" : "Play (key: 7)"}
-        height="48"
-        width="48"
+        on:click={stopApp}
+        iconName="stop"
+        label="Stop/Rewind"
+        tooltip="Stop/Rewind (key: backspace)"
       >
-        <kbd class:depressed={$keyMap.PLAY_PAUSE.active}
-          >{$keyMap.PLAY_PAUSE.key}</kbd
-        >
+        <kbd class:depressed={$keyMap.REWIND.active}>{$keyMap.REWIND.key}</kbd>
       </IconButton>
-    {/key}
+    </div>
 
-    <IconButton
-      class="overlay"
-      disabled={false}
-      on:click={stopApp}
-      iconName="stop"
-      label="Stop/Rewind"
-      tooltip="Stop/Rewind (key: backspace)"
-      height="48"
-      width="48"
-    >
-      <kbd class:depressed={$keyMap.REWIND.active}>{$keyMap.REWIND.key}</kbd>
-    </IconButton>
-  </div>
-
-  <div>
-    <button
-      type="button"
-      class:pedal-on={$softOnOff}
-      aria-pressed={$softOnOff}
-      on:click={() => ($softOnOff = !$softOnOff)}
-      >Soft
-      <kbd class:depressed={$softOnOff}>{$keyMap.SOFT.key}</kbd></button
-    >
-    <button
-      type="button"
-      class:pedal-on={$sustainOnOff}
-      aria-pressed={$sustainOnOff}
-      on:click={() => ($sustainOnOff = !$sustainOnOff)}
-      >Sustain
-      <kbd class:depressed={$sustainOnOff}>{$keyMap.SUSTAIN.key}</kbd></button
-    >
-    <br />
-    <button
-      type="button"
-      style="width:100%"
-      class:pedal-on={$accentOnOff}
-      aria-pressed={$accentOnOff}
-      on:mousedown={() => ($accentOnOff = true)}
-      >Accent
-      <kbd class:depressed={$accentOnOff}>{$keyMap.ACCENT.key}</kbd></button
-    >
-  </div>
+    <div>
+      <button
+        type="button"
+        class:pedal-on={$softOnOff}
+        aria-pressed={$softOnOff}
+        on:click={() => ($softOnOff = !$softOnOff)}
+        >Soft
+        <kbd class:depressed={$softOnOff}>{$keyMap.SOFT.key}</kbd></button
+      >
+      <button
+        type="button"
+        class:pedal-on={$sustainOnOff}
+        aria-pressed={$sustainOnOff}
+        on:click={() => ($sustainOnOff = !$sustainOnOff)}
+        >Sustain
+        <kbd class:depressed={$sustainOnOff}>{$keyMap.SUSTAIN.key}</kbd></button
+      >
+      <br />
+      <button
+        type="button"
+        style="width:100%"
+        class:pedal-on={$accentOnOff}
+        aria-pressed={$accentOnOff}
+        on:mousedown={() => ($accentOnOff = true)}
+        >Accent
+        <kbd class:depressed={$accentOnOff}>{$keyMap.ACCENT.key}</kbd></button
+      >
+    </div>
+  <!-- {/if} -->
 </div>
 <svelte:window on:mouseup={() => ($accentOnOff = false)} />

--- a/src/components/PlaybackControls.svelte
+++ b/src/components/PlaybackControls.svelte
@@ -15,9 +15,12 @@
 
       :global(kbd) {
         bottom: 0.35rem;
-        opacity: 0.4;
         position: absolute;
         right: 0rem;
+      }
+
+      :global(kbd:not(.depressed)) {
+        opacity: 0.6;
       }
 
       &:hover :global(kbd) {

--- a/src/components/PlaybackControls.svelte
+++ b/src/components/PlaybackControls.svelte
@@ -1,109 +1,114 @@
 <style lang="scss">
-  #playback-controls {
-    margin: 0 0.5em;
-  }
 
-  #playback-controls > div:first-child {
-    background-color: var(--cardinal-red-light);
-    border-color: var(--cardinal-red);
-  }
+  #perform-controls {
+    :global(kbd) {
+      bottom: 0.35rem;
+      position: absolute;
+      right: 0rem;
+    }
 
-  #playback-controls {
-      :global(kbd) {
-        bottom: 0.35rem;
-        position: absolute;
-        right: 0rem;
-      }
+    :global(kbd:not(.depressed)) {
+      opacity: 0.6;
+    }
 
-      :global(kbd:not(.depressed)) {
-        opacity: 0.6;
-      }
+    &:hover :global(kbd) {
+      opacity: 1;
+    }
 
-      &:hover :global(kbd) {
-        opacity: 1;
-      }
+    font-family: SourceSans3, sans-serif;
 
-    &.is-perform {
-      display: flex;
-      flex-direction: column;
-
-      & .play-pause-button {
-        border-radius: 4px;
-        display: flex;
-        flex-direction: row;
-        justify-content: center;
-        align-items: center;
-        margin: 0 0 0.5rem;
-        position: relative;
-        cursor: pointer;
-      }
-
-      & .half {
+    & .play-pause-button, .accent-button {
+      background-color: var(--cardinal-red-light);
+      border-color: var(--cardinal-red);
+      border-radius: 4px;
       display: flex;
       flex-direction: row;
-      gap: 1rem;
       justify-content: center;
+      align-items: center;
       margin: 0 0 0.5rem;
-        & > div {
-          border-radius: 4px;
-          position: relative;
-          flex: 1;
-        }
-        & .record-button {
-          background-color: var(--cardinal-red-light);
-          border-color: var(--cardinal-red);
-        }
-        & .start-over-button {
-          background-color: var(--cool-grey);
-          border-color: var(--black);
-        }
-        & .skip-button {
-          background-color: var(--black);
-          border-color: var(--black);
-        }
-
-      }
-    }
-  }
-
-  #playback-controls > div:last-child {
-    display: flex;
-    flex-wrap: wrap;
-
-    button {
-      background-color: var(--cool-grey);
-      color: var(--white);
-      border-radius: 4px;
-      border-style: solid;
-      height: 2rem;
       position: relative;
-      flex-grow: 1;
-      min-width: 120px;
-      width: 50%;
+      cursor: pointer;
+    }
+
+    & .accent-button {
+      background-color: var(--cool-grey);
+      border-color: var(--cool-grey);
+      border-style: solid;
+      color: var(--white);
+      height: 2rem;
 
       &.pedal-on {
         background-color: var(--cool-grey);
         border-color: yellow;
         color: yellow;
+        font-weight: 500;
       }
+    }
 
-      kbd {
-        position: absolute;
-        right: 0rem;
-        bottom: 0.2rem;
+    & .half {
+      display: flex;
+      flex-direction: row;
+      gap: 0.5rem;
+      justify-content: center;
+      margin: 0 0 0.5rem;
+
+      &.performer-accent-buttons {
+        & button {
+          background-color: var(--cool-grey);
+          border-radius: 4px;
+          border: 1px solid var(--cool-grey);
+          color: var(--white);
+          cursor: pointer;
+          flex-grow: 1;
+          height: 2rem;
+          min-width: 120px;
+          position: relative;
+          width: 100%;
+
+          &.pedal-on {
+            background-color: var(--cool-grey);
+            border-color: yellow;
+            color: yellow;
+            font-weight: 500;
+          }
+        }
+      }
+      & > div {
+        border-radius: 4px;
+        position: relative;
+        flex: 1;
+      }
+      & .record-button {
+        // if we have the ability to record, use this:
+        // background-color: var(--cardinal-red-light);
+        background-color: #ccc;
+        border: 1px solid var(--cardinal-red-light);
+      }
+      & .start-over-button {
+        background-color: var(--cool-grey);
+        border: 1px solid var(--cool-grey);
+      }
+      & .skip-button {
+        background-color: var(--black);
+        border: 1px solid var(--black);
       }
     }
   }
 </style>
 
 <script>
+  import { tick as sweep } from "svelte";
   import { keyMap } from "./KeyboardShortcuts.svelte";
-  import { currentTick, isPlaying, softOnOff, sustainOnOff, accentOnOff } from "../stores";
+  import { 
+    currentTick,
+    isPlaying, 
+    softOnOff, 
+    sustainOnOff, 
+    accentOnOff, } from "../stores";
   import IconButton from "../ui-components/IconButton.svelte";
 
   export let playPauseApp;
   export let stopApp;
-  export let resetPlayback;
   export let skipToTick;
 
   let isRecording = false;
@@ -116,12 +121,17 @@
     skipToTick($currentTick + tickIncrement);
   };
 
+  const togglePlayPause = async () => {
+    playPauseApp();
+    await sweep();
+  };
+
   // Fewer controls for listener than performer
   // Not entirely sure how this is supposed to work - commented out for now
   // export let isPerform = true;
 </script>
 
-<div id="playback-controls" class="is-perform">
+<div id="perform-controls">
   <!-- {#if isPerform} -->
     <div class="play-pause-button">
       {#key $isPlaying}
@@ -130,7 +140,7 @@
           disabled={false}
           height="48"
           width="48"
-          on:click={playPauseApp}
+          on:click={togglePlayPause}
           iconName={$isPlaying ? "pause" : "play"}
           label={$isPlaying ? "Pause" : "Play"}
           tooltip={$isPlaying ? `Pause (key: ${$keyMap.PLAY_PAUSE.key})` : `Play (key: ${$keyMap.PLAY_PAUSE.key})`}
@@ -147,12 +157,13 @@
           class={isRecording
             ? "overlay performer-button"
             : "performer-button"}
-          disabled={false}
+          disabled={true}
           on:mousedown={toggleRecording}
           iconName="record"
           label="Record"
           height="24"
           title="Record"
+          tooltip="Record (TBD)"
         />
       </div>
       <div class="start-over-button">
@@ -199,9 +210,7 @@
         </IconButton>
       </div>
     </div>
-
-    <div class="performer-accent-buttons">
-      <div class="half">
+    <div class="performer-accent-buttons half">
         <button
           type="button"
           class:pedal-on={$softOnOff}
@@ -220,10 +229,12 @@
         >
       </div>
 
+    <div class="performer-accent-buttons">
       <button
         type="button"
         style="width:100%"
         class:pedal-on={$accentOnOff}
+        class="accent-button"
         aria-pressed={$accentOnOff}
         on:mousedown={() => ($accentOnOff = true)}
         >Accent

--- a/src/components/PlaybackControls.svelte
+++ b/src/components/PlaybackControls.svelte
@@ -3,24 +3,56 @@
     margin: 0 0.5em;
   }
 
-  button {
-    @include button;
+  #playback-controls > div:first-child {
+    background: rgba(0, 0, 0, 0.5);
+    border-radius: 4px;
+    display: flex;
+    justify-content: space-around;
+    padding: 8px;
 
-    &.pedal-on {
-      background-color: yellow;
-      border-color: var(--primary-accent);
-      color: var(--primary-accent);
+    :global(.overlay) {
+      position: relative;
+
+      :global(kbd) {
+        bottom: 0.35rem;
+        opacity: 0.4;
+        position: absolute;
+        right: 0rem;
+      }
+
+      &:hover :global(kbd) {
+        opacity: 1;
+      }
     }
+  }
 
-    kbd {
-      margin: 0 -0.4em 0 0.4em;
+  #playback-controls > div:last-child {
+    display: flex;
+    flex-wrap: wrap;
+
+    button {
+      @include button;
+      flex-grow: 1;
+      min-width: 120px;
+      width: 50%;
+
+      &.pedal-on {
+        background-color: yellow;
+        border-color: var(--primary-accent);
+        color: var(--primary-accent);
+      }
+
+      kbd {
+        margin: 0 -0.4em 0 0.4em;
+      }
     }
   }
 </style>
 
 <script>
   import { keyMap } from "./KeyboardShortcuts.svelte";
-  import { softOnOff, sustainOnOff, accentOnOff } from "../stores";
+  import { isPlaying, softOnOff, sustainOnOff, accentOnOff } from "../stores";
+  import IconButton from "../ui-components/IconButton.svelte";
 
   export let playPauseApp;
   export let stopApp;
@@ -29,34 +61,55 @@
 </script>
 
 <div id="playback-controls">
-  <button type="button" on:click={playPauseApp}
-    >Play/Pause
-    <kbd class:depressed={$keyMap.PLAY_PAUSE.active}
-      >{$keyMap.PLAY_PAUSE.key}</kbd
-    ></button
-  >
-  <button type="button" on:click={stopApp}
-    >Rewind
-    <kbd class:depressed={$keyMap.REWIND.active}>{$keyMap.REWIND.key}</kbd
-    ></button
-  >
-  {#if isPerform}
+  <div>
+    {#key $isPlaying}
+      <IconButton
+        class="overlay"
+        disabled={false}
+        on:click={playPauseApp}
+        iconName={$isPlaying ? "pause" : "play"}
+        label={$isPlaying ? "Pause" : "Play"}
+        tooltip={$isPlaying ? "Pause (key: 7)" : "Play (key: 7)"}
+        height="48"
+        width="48"
+      >
+        <kbd class:depressed={$keyMap.PLAY_PAUSE.active}
+          >{$keyMap.PLAY_PAUSE.key}</kbd
+        >
+      </IconButton>
+    {/key}
+
+    <IconButton
+      class="overlay"
+      disabled={false}
+      on:click={stopApp}
+      iconName="stop"
+      label="Stop/Rewind"
+      tooltip="Stop/Rewind (key: backspace)"
+      height="48"
+      width="48"
+    >
+      <kbd class:depressed={$keyMap.REWIND.active}>{$keyMap.REWIND.key}</kbd>
+    </IconButton>
+  </div>
+
+  <div>
     <button
       type="button"
       class:pedal-on={$softOnOff}
       aria-pressed={$softOnOff}
       on:click={() => ($softOnOff = !$softOnOff)}
       >Soft
-      <kbd class:depressed={$softOnOff}>{$keyMap.SOFT.key}</kbd>
-    </button>
+      <kbd class:depressed={$softOnOff}>{$keyMap.SOFT.key}</kbd></button
+    >
     <button
       type="button"
       class:pedal-on={$sustainOnOff}
       aria-pressed={$sustainOnOff}
       on:click={() => ($sustainOnOff = !$sustainOnOff)}
       >Sustain
-      <kbd class:depressed={$sustainOnOff}>{$keyMap.SUSTAIN.key}</kbd>
-    </button>
+      <kbd class:depressed={$sustainOnOff}>{$keyMap.SUSTAIN.key}</kbd></button
+    >
     <br />
     <button
       type="button"
@@ -65,8 +118,8 @@
       aria-pressed={$accentOnOff}
       on:mousedown={() => ($accentOnOff = true)}
       >Accent
-      <kbd class:depressed={$accentOnOff}>{$keyMap.ACCENT.key}</kbd>
-    </button>
-  {/if}
+      <kbd class:depressed={$accentOnOff}>{$keyMap.ACCENT.key}</kbd></button
+    >
+  </div>
 </div>
 <svelte:window on:mouseup={() => ($accentOnOff = false)} />

--- a/src/components/PlaybackControls.svelte
+++ b/src/components/PlaybackControls.svelte
@@ -4,15 +4,11 @@
   }
 
   #playback-controls > div:first-child {
-    background: rgba(0, 0, 0, 0.5);
-    border-radius: 4px;
-    display: flex;
-    justify-content: space-around;
-    padding: 8px;
+    background-color: var(--cardinal-red-light);
+    border-color: var(--cardinal-red);
+  }
 
-    :global(.overlay) {
-      position: relative;
-
+  #playback-controls {
       :global(kbd) {
         bottom: 0.35rem;
         position: absolute;
@@ -26,6 +22,47 @@
       &:hover :global(kbd) {
         opacity: 1;
       }
+
+    &.is-perform {
+      display: flex;
+      flex-direction: column;
+
+      & .play-pause-button {
+        border-radius: 4px;
+        display: flex;
+        flex-direction: row;
+        justify-content: center;
+        align-items: center;
+        margin: 0 0 0.5rem;
+        position: relative;
+        cursor: pointer;
+      }
+
+      & .half {
+      display: flex;
+      flex-direction: row;
+      gap: 1rem;
+      justify-content: center;
+      margin: 0 0 0.5rem;
+        & > div {
+          border-radius: 4px;
+          position: relative;
+          flex: 1;
+        }
+        & .record-button {
+          background-color: var(--cardinal-red-light);
+          border-color: var(--cardinal-red);
+        }
+        & .start-over-button {
+          background-color: var(--cool-grey);
+          border-color: var(--black);
+        }
+        & .skip-button {
+          background-color: var(--black);
+          border-color: var(--black);
+        }
+
+      }
     }
   }
 
@@ -34,19 +71,26 @@
     flex-wrap: wrap;
 
     button {
-      // @include button;
+      background-color: var(--cool-grey);
+      color: var(--white);
+      border-radius: 4px;
+      border-style: solid;
+      height: 2rem;
+      position: relative;
       flex-grow: 1;
       min-width: 120px;
       width: 50%;
 
       &.pedal-on {
-        background-color: yellow;
-        border-color: var(--primary-accent);
-        color: var(--primary-accent);
+        background-color: var(--cool-grey);
+        border-color: yellow;
+        color: yellow;
       }
 
       kbd {
-        margin: 0 -0.4em 0 0.4em;
+        position: absolute;
+        right: 0rem;
+        bottom: 0.2rem;
       }
     }
   }
@@ -54,66 +98,128 @@
 
 <script>
   import { keyMap } from "./KeyboardShortcuts.svelte";
-  import { isPlaying, softOnOff, sustainOnOff, accentOnOff } from "../stores";
+  import { currentTick, isPlaying, softOnOff, sustainOnOff, accentOnOff } from "../stores";
   import IconButton from "../ui-components/IconButton.svelte";
 
   export let playPauseApp;
   export let stopApp;
+  export let resetPlayback;
+  export let skipToTick;
+
+  let isRecording = false;
+
+  const toggleRecording = async () => {
+    isRecording = !isRecording;
+  };
+
+  const skipFromCurrent = (tickIncrement = 1500) => {
+    skipToTick($currentTick + tickIncrement);
+  };
 
   // Fewer controls for listener than performer
   // Not entirely sure how this is supposed to work - commented out for now
   // export let isPerform = true;
 </script>
 
-<div id="playback-controls">
+<div id="playback-controls" class="is-perform">
   <!-- {#if isPerform} -->
-    <div>
+    <div class="play-pause-button">
       {#key $isPlaying}
         <IconButton
-          class="overlay"
+          class="overlay performer-button"
           disabled={false}
+          height="48"
+          width="48"
           on:click={playPauseApp}
           iconName={$isPlaying ? "pause" : "play"}
           label={$isPlaying ? "Pause" : "Play"}
-          tooltip={$isPlaying ? "Pause (key: 7)" : "Play (key: 7)"}
+          tooltip={$isPlaying ? `Pause (key: ${$keyMap.PLAY_PAUSE.key})` : `Play (key: ${$keyMap.PLAY_PAUSE.key})`}
         >
           <kbd class:depressed={$keyMap.PLAY_PAUSE.active}
             >{$keyMap.PLAY_PAUSE.key}</kbd
           >
         </IconButton>
       {/key}
+    </div>
+    <div class="half">
+      <div class="record-button">
+        <IconButton
+          class={isRecording
+            ? "overlay performer-button"
+            : "performer-button"}
+          disabled={false}
+          on:mousedown={toggleRecording}
+          iconName="record"
+          label="Record"
+          height="24"
+          title="Record"
+        />
       </div>
-      <div>
-      <IconButton
-        class="overlay"
-        disabled={false}
-        on:click={stopApp}
-        iconName="stop"
-        label="Stop/Rewind"
-        tooltip="Stop/Rewind (key: backspace)"
-      >
-        <kbd class:depressed={$keyMap.REWIND.active}>{$keyMap.REWIND.key}</kbd>
-      </IconButton>
+      <div class="start-over-button">
+        <IconButton
+          class="overlay performer-button"
+          disabled={false}
+          on:click={stopApp}
+          iconName="rewind"
+          label="Rewind"
+          tooltip="Rewind (key: {$keyMap.REWIND.key})"
+          height="24"
+        >
+          <kbd class:depressed={$keyMap.REWIND.active}>{$keyMap.REWIND.key}</kbd>
+        </IconButton>
+      </div>
+    </div>
+    <div class="half">
+      <div class="skip-back-button skip-button">
+        <IconButton
+          class={"overlay performer-button"}
+          disabled={false}
+          on:mousedown={() => {
+            skipFromCurrent(-1500);
+          }}
+          iconName="skipBack"
+          label="Skip Back"
+          height="24"
+          tooltip="Skip Back (key: {$keyMap.BACKWARD.key})"
+        >
+          <kbd class:depressed={$keyMap.BACKWARD.active}>{$keyMap.BACKWARD.key}</kbd>
+        </IconButton>
+      </div>
+      <div class="skip-forward-button skip-button">
+        <IconButton
+          class={"overlay performer-button"}
+          disabled={false}
+          on:mousedown={() => skipFromCurrent()}
+          iconName="skipForward"
+          label="Skip Ahead"
+          height="24"
+          tooltip="Skip Ahead (key: {$keyMap.FORWARD.key})"
+        >
+          <kbd class:depressed={$keyMap.FORWARD.active}>{$keyMap.FORWARD.key}</kbd>
+        </IconButton>
+      </div>
     </div>
 
-    <div>
-      <button
-        type="button"
-        class:pedal-on={$softOnOff}
-        aria-pressed={$softOnOff}
-        on:click={() => ($softOnOff = !$softOnOff)}
-        >Soft
-        <kbd class:depressed={$softOnOff}>{$keyMap.SOFT.key}</kbd></button
-      >
-      <button
-        type="button"
-        class:pedal-on={$sustainOnOff}
-        aria-pressed={$sustainOnOff}
-        on:click={() => ($sustainOnOff = !$sustainOnOff)}
-        >Sustain
-        <kbd class:depressed={$sustainOnOff}>{$keyMap.SUSTAIN.key}</kbd></button
-      >
-      <br />
+    <div class="performer-accent-buttons">
+      <div class="half">
+        <button
+          type="button"
+          class:pedal-on={$softOnOff}
+          aria-pressed={$softOnOff}
+          on:click={() => ($softOnOff = !$softOnOff)}
+          >Soft
+          <kbd class:depressed={$softOnOff}>{$keyMap.SOFT.key}</kbd></button
+        >
+        <button
+          type="button"
+          class:pedal-on={$sustainOnOff}
+          aria-pressed={$sustainOnOff}
+          on:click={() => ($sustainOnOff = !$sustainOnOff)}
+          >Sustain
+          <kbd class:depressed={$sustainOnOff}>{$keyMap.SUSTAIN.key}</kbd></button
+        >
+      </div>
+
       <button
         type="button"
         style="width:100%"

--- a/src/components/PlaybackControls.svelte
+++ b/src/components/PlaybackControls.svelte
@@ -1,5 +1,4 @@
 <style lang="scss">
-
   #perform-controls {
     :global(kbd) {
       bottom: 0.35rem;
@@ -17,7 +16,8 @@
 
     font-family: SourceSans3, sans-serif;
 
-    & .play-pause-button, .accent-button {
+    & .play-pause-button,
+    .accent-button {
       background-color: var(--cardinal-red-light);
       border-color: var(--cardinal-red);
       border-radius: 4px;
@@ -99,12 +99,13 @@
 <script>
   import { tick as sweep } from "svelte";
   import { keyMap } from "./KeyboardShortcuts.svelte";
-  import { 
+  import {
     currentTick,
-    isPlaying, 
-    softOnOff, 
-    sustainOnOff, 
-    accentOnOff, } from "../stores";
+    isPlaying,
+    softOnOff,
+    sustainOnOff,
+    accentOnOff,
+  } from "../stores";
   import IconButton from "../ui-components/IconButton.svelte";
 
   export let playPauseApp;
@@ -128,12 +129,12 @@
 
   // Fewer controls for listener than performer
   // Not entirely sure how this is supposed to work - commented out for now
-  // export let isPerform = true;
+  export let isPerform = true;
 </script>
 
 <div id="perform-controls">
-  <!-- {#if isPerform} -->
-    <div class="play-pause-button">
+  {#if isPerform}
+    <!-- <div class="play-pause-button">
       {#key $isPlaying}
         <IconButton
           class="overlay performer-button"
@@ -143,7 +144,9 @@
           on:click={togglePlayPause}
           iconName={$isPlaying ? "pause" : "play"}
           label={$isPlaying ? "Pause" : "Play"}
-          tooltip={$isPlaying ? `Pause (key: ${$keyMap.PLAY_PAUSE.key})` : `Play (key: ${$keyMap.PLAY_PAUSE.key})`}
+          tooltip={$isPlaying
+            ? `Pause (key: ${$keyMap.PLAY_PAUSE.key})`
+            : `Play (key: ${$keyMap.PLAY_PAUSE.key})`}
         >
           <kbd class:depressed={$keyMap.PLAY_PAUSE.active}
             >{$keyMap.PLAY_PAUSE.key}</kbd
@@ -154,16 +157,14 @@
     <div class="half">
       <div class="record-button">
         <IconButton
-          class={isRecording
-            ? "overlay performer-button"
-            : "performer-button"}
+          class={isRecording ? "overlay performer-button" : "performer-button"}
           disabled={true}
           on:mousedown={toggleRecording}
           iconName="record"
           label="Record"
           height="24"
           title="Record"
-          tooltip="Record (TBD)"
+          tooltip="Record (key: {$keyMap.TOGGLE_RECORD.key})"
         />
       </div>
       <div class="start-over-button">
@@ -176,7 +177,8 @@
           tooltip="Rewind (key: {$keyMap.REWIND.key})"
           height="24"
         >
-          <kbd class:depressed={$keyMap.REWIND.active}>{$keyMap.REWIND.key}</kbd>
+          <kbd class:depressed={$keyMap.REWIND.active}>{$keyMap.REWIND.key}</kbd
+          >
         </IconButton>
       </div>
     </div>
@@ -193,7 +195,9 @@
           height="24"
           tooltip="Skip Back (key: {$keyMap.BACKWARD.key})"
         >
-          <kbd class:depressed={$keyMap.BACKWARD.active}>{$keyMap.BACKWARD.key}</kbd>
+          <kbd class:depressed={$keyMap.BACKWARD.active}
+            >{$keyMap.BACKWARD.key}</kbd
+          >
         </IconButton>
       </div>
       <div class="skip-forward-button skip-button">
@@ -206,29 +210,32 @@
           height="24"
           tooltip="Skip Ahead (key: {$keyMap.FORWARD.key})"
         >
-          <kbd class:depressed={$keyMap.FORWARD.active}>{$keyMap.FORWARD.key}</kbd>
+          <kbd class:depressed={$keyMap.FORWARD.active}
+            >{$keyMap.FORWARD.key}</kbd
+          >
         </IconButton>
       </div>
-    </div>
+    </div> -->
     <div class="performer-accent-buttons half">
-        <button
-          type="button"
-          class:pedal-on={$softOnOff}
-          aria-pressed={$softOnOff}
-          on:click={() => ($softOnOff = !$softOnOff)}
-          >Soft
-          <kbd class:depressed={$softOnOff}>{$keyMap.SOFT.key}</kbd></button
-        >
-        <button
-          type="button"
-          class:pedal-on={$sustainOnOff}
-          aria-pressed={$sustainOnOff}
-          on:click={() => ($sustainOnOff = !$sustainOnOff)}
-          >Sustain
-          <kbd class:depressed={$sustainOnOff}>{$keyMap.SUSTAIN.key}</kbd></button
-        >
-      </div>
-
+      <button
+        type="button"
+        class:pedal-on={$softOnOff}
+        aria-pressed={$softOnOff}
+        on:click={() => ($softOnOff = !$softOnOff)}
+        title="Soft pedal (key: {$keyMap.SOFT.key})"
+        >Soft
+        <kbd class:depressed={$softOnOff}>{$keyMap.SOFT.key}</kbd></button
+      >
+      <button
+        type="button"
+        class:pedal-on={$sustainOnOff}
+        aria-pressed={$sustainOnOff}
+        on:click={() => ($sustainOnOff = !$sustainOnOff)}
+        title="Sustain pedal (key: {$keyMap.SUSTAIN.key})"
+        >Sustain
+        <kbd class:depressed={$sustainOnOff}>{$keyMap.SUSTAIN.key}</kbd></button
+      >
+    </div>
     <div class="performer-accent-buttons">
       <button
         type="button"
@@ -237,10 +244,11 @@
         class="accent-button"
         aria-pressed={$accentOnOff}
         on:mousedown={() => ($accentOnOff = true)}
+        title="Accent (key: {$keyMap.ACCENT.key})"
         >Accent
         <kbd class:depressed={$accentOnOff}>{$keyMap.ACCENT.key}</kbd></button
       >
     </div>
-  <!-- {/if} -->
+  {/if}
 </div>
 <svelte:window on:mouseup={() => ($accentOnOff = false)} />

--- a/src/components/RollPlayerControls.svelte
+++ b/src/components/RollPlayerControls.svelte
@@ -8,6 +8,7 @@
 <script>
   import { tick as sweep } from "svelte";
   import IconButton from "../ui-components/IconButton.svelte";
+  import { keyMap } from "./KeyboardShortcuts.svelte";
   import Notification, {
     notify,
     clearNotification,
@@ -22,12 +23,11 @@
     recordingOnOff,
     recordingInBuffer,
   } from "../stores";
-  import { RecordingActions } from "../lib/utils";
 
   export let skipToTick;
   export let resetPlayback;
   export let playPauseApp;
-  export let recordingControl;
+  export let toggleRecording;
   export let isPerform = true;
 
   let isBookmarked = false;
@@ -49,40 +49,6 @@
     setTimeout(function () {
       isBookmarked = false;
     }, 1000);
-  };
-
-  const exportRecordingMIDI = () =>
-    recordingControl(RecordingActions.ExportMIDI);
-  const exportRecordingWAV = () => recordingControl(RecordingActions.ExportWAV);
-  const clearRecording = () => recordingControl(RecordingActions.Clear);
-
-  const toggleRecording = () => {
-    $recordingOnOff = !$recordingOnOff;
-    if ($recordingInBuffer && !$recordingOnOff) {
-      notify({
-        title: "Recording Complete.",
-        message: "",
-        closable: true,
-        actions: [
-          {
-            label: "Export MIDI Recording ",
-            fn: exportRecordingMIDI,
-          },
-          {
-            label: "Export WAV Recording ",
-            fn: exportRecordingWAV,
-          },
-          {
-            label: "Clear Recording",
-            fn: clearRecording,
-          },
-          {
-            label: "Continue",
-            fn: clearNotification,
-          },
-        ],
-      });
-    }
   };
 
   const togglePlayPause = async () => {
@@ -161,7 +127,7 @@
     disabled={false}
     on:mousedown={resetPlayback}
     iconName="rewind"
-    label="Rewind"
+    label="Rewind ({$keyMap.REWIND.key})"
     height="24"
     width="24"
   />
@@ -172,7 +138,7 @@
       skipFromCurrent(-1500);
     }}
     iconName="skipBack"
-    label="Skip Back"
+    label="Skip Back ({$keyMap.BACKWARD.key})"
     height="24"
     width="24"
   />
@@ -182,7 +148,7 @@
       disabled={false}
       on:mousedown={togglePlayPause}
       iconName="play"
-      label="Play"
+      label="Play ({$keyMap.PLAY_PAUSE.key})"
       height="24"
       width="24"
     />
@@ -192,7 +158,7 @@
       disabled={false}
       on:mousedown={togglePlayPause}
       iconName="pause"
-      label="Pause"
+      label="Pause ({$keyMap.PLAY_PAUSE.key})"
       height="24"
       width="24"
     />
@@ -201,25 +167,25 @@
     {#if !$recordingOnOff}
       {#if $recordingInBuffer}
         <IconButton
-          class="player-button record"
+          class="player-button continue-record"
           disabled={false}
           on:mousedown={toggleRecording}
-          iconName={"record-continue"}
-          label={"Continue Recording"}
+          iconName="record"
+          label="Continue Recording ({$keyMap.TOGGLE_RECORD.key})"
           height="24"
           width="24"
-          title={"Continue Recording"}
+          title="Continue Recording ({$keyMap.TOGGLE_RECORD.key})"
         />
       {:else}
         <IconButton
           class="player-button record"
           disabled={false}
           on:mousedown={toggleRecording}
-          iconName={"record"}
-          label={"Record"}
+          iconName="record"
+          label="Record ({$keyMap.TOGGLE_RECORD.key})"
           height="24"
           width="24"
-          title={"Record"}
+          title="Record ({$keyMap.TOGGLE_RECORD.key})"
         />
       {/if}
     {:else}
@@ -228,10 +194,10 @@
         disabled={false}
         on:mousedown={toggleRecording}
         iconName="pause"
-        label="Pause Record"
+        label="Pause Recording ({$keyMap.TOGGLE_RECORD.key})"
         height="24"
         width="24"
-        title="Pause Record"
+        title="Pause Recording ({$keyMap.TOGGLE_RECORD.key})"
       />
     {/if}
   {/if}
@@ -240,7 +206,7 @@
     disabled={false}
     on:mousedown={() => skipFromCurrent()}
     iconName="skipForward"
-    label="Skip Ahead"
+    label="Skip Ahead ({$keyMap.FORWARD.key})"
     height="24"
     width="24"
   />

--- a/src/components/SamplePlayer.svelte
+++ b/src/components/SamplePlayer.svelte
@@ -7,6 +7,7 @@
   import { notify } from "../ui-components/Notification.svelte";
   import { getPathJoiner, NoteSource, RecordingActions } from "../lib/utils";
   import {
+    isPlaying,
     rollMetadata,
     softOnOff,
     sustainOnOff,
@@ -343,13 +344,14 @@
     softOnOff.reset();
     sustainOnOff.reset();
     accentOnOff.reset();
-    midiSamplePlayer.triggerPlayerEvent("stop");
+    $isPlaying = false;
   };
 
   const pausePlayback = () => {
     midiSamplePlayer.pause();
     midiSamplePlayer.triggerPlayerEvent("pause");
     stopAllNotes();
+    $isPlaying = false;
   };
 
   const pausePlaybackOrLoop = async () => {
@@ -367,6 +369,7 @@
     if ($currentTick < 0) resetPlayback();
     updatePlayer();
     midiSamplePlayer.play();
+    $isPlaying = true;
   };
 
   const buildTempoMap = (metadataTrack) =>
@@ -500,7 +503,7 @@
         audioRecorder.exportRecording();
         break;
       default:
-        console.log("Unknown recording action: " + action)
+        console.log("Unknown recording action: " + action);
     }
   };
 

--- a/src/components/SamplePlayer.svelte
+++ b/src/components/SamplePlayer.svelte
@@ -22,7 +22,6 @@
     softFromExternalMidi,
     useMidiTempoEventsOnOff,
     activeNotes,
-    isPlaying,
     currentTick,
     sampleVolumes,
     sampleVelocities,

--- a/src/components/TabbedPanel.svelte
+++ b/src/components/TabbedPanel.svelte
@@ -50,8 +50,8 @@
   import ViewerMetrics from "./ViewerMetrics.svelte";
 
   export let playPauseApp;
-  export let skipToPercentage;
   export let stopApp;
+  export let skipToPercentage;
   export let recordingControl;
 
   const panels = {

--- a/src/config/keyboard-shortcut-config.js
+++ b/src/config/keyboard-shortcut-config.js
@@ -24,6 +24,8 @@ export const defaultKeyMap = {
   PAN_DOWN: { code: "ArrowDown", key: "↓" },
   PAN_LEFT: { code: "ArrowLeft", key: "←" },
   PAN_RIGHT: { code: "ArrowRight", key: "→" },
+
+  TOGGLE_RECORD: { code: "KeyS", key: "S" },
 };
 
 export const keyMapMeta = {
@@ -114,6 +116,10 @@ export const keyMapMeta = {
   PAN_RIGHT: {
     description: "Pan Right",
     help: "Pan the roll rightwards (hold to accelerate)",
+  },
+  TOGGLE_RECORD: {
+    description: "Start/Stop Recording",
+    help: "Start recording or pause and open dialog to export/clear/resume recording",
   },
 };
 

--- a/src/lib/Tooltip.svelte
+++ b/src/lib/Tooltip.svelte
@@ -17,32 +17,25 @@
     padding: 7px;
     position: relative;
     text-align: center;
-    transform: translate(0, -5px);
+    top: -10px;
     white-space: pre-line;
     width: max-content;
-
-    &::after {
-      border-left: 5px solid transparent;
-      border-right: 5px solid transparent;
-      border-top: 5px solid hsla(0, 0%, 20%, 0.9);
-      top: 100%;
-      content: " ";
-      font-size: 0;
-      left: 50%;
-      line-height: 0;
-      position: absolute;
-      width: 0;
-    }
+  }
+  [data-popper-arrow] {
+    border-left: 5px solid transparent;
+    border-right: 5px solid transparent;
+    border-top: 5px solid hsla(0, 0%, 20%, 0.9);
+    top: 100%;
   }
 
   @keyframes tooltip {
     from {
       opacity: 0;
-      transform: translate(0, 0);
+      top: 0;
     }
     to {
       opacity: 1;
-      transform: translate(0, -5px);
+      top: -10px;
     }
   }
 </style>
@@ -53,5 +46,8 @@
 </script>
 
 <div bind:this={element}>
-  <span>{text}</span>
+  <span>
+    {text}
+    <div data-popper-arrow />
+  </span>
 </div>

--- a/src/lib/tooltip-action.js
+++ b/src/lib/tooltip-action.js
@@ -1,4 +1,6 @@
 import { createPopper } from "@popperjs/core/lib/popper-lite";
+import preventOverflow from "@popperjs/core/lib/modifiers/preventOverflow";
+import arrow from "@popperjs/core/lib/modifiers/arrow";
 import Tooltip from "./Tooltip.svelte";
 
 export const tooltip = (node, text) => {
@@ -14,6 +16,16 @@ export const tooltip = (node, text) => {
 
     popperInstance = createPopper(node, componentInstance.element, {
       placement: "top",
+      modifiers: [
+        preventOverflow,
+        {
+          name: "preventOverflow",
+          options: {
+            padding: 8,
+          },
+        },
+        arrow,
+      ],
     });
   };
 

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -10,8 +10,9 @@ export const NoteSource = {
 export const RecordingActions = {
   Clear: 0,
   ExportMIDI: 1,
-  ExportWAV: 2
-}
+  ExportWAV: 2,
+  Toggle: 3,
+};
 
 const profiles = new Set(["perform", "listen"]);
 export const getProfile = (profile) =>
@@ -152,13 +153,13 @@ export const annotateHoleData = (
 
   const getNoteHoleColor = ({ v: velocity }) =>
     holeColorMap[
-    Math.round(
-      mapToRange(
-        normalizeInRange(velocity, minNoteVelocity, maxNoteVelocity),
-        0,
-        holeColorMap.length - 1,
-      ),
-    )
+      Math.round(
+        mapToRange(
+          normalizeInRange(velocity, minNoteVelocity, maxNoteVelocity),
+          0,
+          holeColorMap.length - 1,
+        ),
+      )
     ];
 
   const imageLengthPx = parseInt(imageLength, 10);

--- a/src/stores.js
+++ b/src/stores.js
@@ -88,6 +88,7 @@ export const recordingInBuffer = createStore(false);
 export const recordingDuration = createStore(0);
 
 // Playback State
+export const isPlaying = createStore(false);
 export const currentTick = createStore(0);
 export const playbackProgress = createStore(0);
 export const playbackProgressStart = createStore();

--- a/src/stores.js
+++ b/src/stores.js
@@ -95,7 +95,6 @@ export const playbackProgressStart = createStore();
 export const playbackProgressEnd = createStore(1);
 export const activeNotes = createSetStore();
 export const playRepeat = createStore(false);
-export const isPlaying = createStore(false);
 
 // User Settings
 export const userSettings = createPersistedStore("userSettings", {

--- a/src/ui-components/FlexCollapsible.svelte
+++ b/src/ui-components/FlexCollapsible.svelte
@@ -82,7 +82,7 @@
   export let id;
   export let width;
   export let position = "right";
-  let hidden = false;
+  export let hidden = false;
 </script>
 
 <div
@@ -92,7 +92,7 @@
   style={`width: ${hidden ? 0 : width};`}
 >
   <input type="checkbox" id={`${id}_collapse`} bind:checked={hidden} />
-  <label for={`${id}_collapse`} />
+  <label for={`${id}_collapse`} title={`${hidden ? "show" : "hide"}`} />
   <div style={`width: ${width};`}>
     <slot />
   </div>

--- a/src/ui-components/Icon.svelte
+++ b/src/ui-components/Icon.svelte
@@ -167,123 +167,17 @@
       `,
       attribs: { viewBox: "0 0 712 266", fill: "currentColor" },
     },
-    skipForward: {
-      svg: `
-      <path d="M8.46448 7.75739L7.05026 9.1716L9.87869 12L7.05029 14.8284L8.46451 16.2426L12.7071 12L8.46448 7.75739Z" fill="currentColor" /><path d="M11.2929 9.1716L12.7071 7.75739L16.9498 12L12.7071 16.2426L11.2929 14.8284L14.1213 12L11.2929 9.1716Z" fill="currentColor" /><path fill-rule="evenodd" clip-rule="evenodd" d="M1 12C1 18.0751 5.92487 23 12 23C18.0751 23 23 18.0751 23 12C23 5.92487 18.0751 1 12 1C5.92487 1 1 5.92487 1 12ZM3 12C3 16.9706 7.02944 21 12 21C16.9706 21 21 16.9706 21 12C21 7.02944 16.9706 3 12 3C7.02944 3 3 7.02944 3 12Z" fill="currentColor" />
-      `,
-      attribs: {
-        viewBox: "0 0 24 24",
-        "stroke-width": 0.5,
-      },
-    },
-    skipBack: {
-      svg: `
-      <path d="M12.7071 9.1716L11.2929 7.75739L7.05024 12L11.2929 16.2426L12.7071 14.8284L9.87869 12L12.7071 9.1716Z" fill="currentColor" /><path d="M15.5355 7.75739L16.9497 9.1716L14.1213 12L16.9497 14.8284L15.5355 16.2426L11.2929 12L15.5355 7.75739Z" fill="currentColor" /><path fill-rule="evenodd" clip-rule="evenodd" d="M23 12C23 18.0751 18.0751 23 12 23C5.92487 23 1 18.0751 1 12C1 5.92487 5.92487 1 12 1C18.0751 1 23 5.92487 23 12ZM21 12C21 16.9706 16.9706 21 12 21C7.02944 21 3 16.9706 3 12C3 7.02944 7.02944 3 12 3C16.9706 3 21 7.02944 21 12Z" fill="currentColor" />
-      `,
-      attribs: {
-        viewBox: "0 0 24 24",
-        "stroke-width": 0.5,
-      },
-    },
-    bookmark: {
-      svg: `
-        <path fill-rule="evenodd" clip-rule="evenodd" d="M19 20H17.1717L12.7072 15.5354C12.3166 15.1449 11.6835 15.1449 11.2929 15.5354L6.82843 20L5 20V7C5 5.34315 6.34315 4 8 4H16C17.6569 4 19 5.34314 19 7V20ZM17 7C17 6.44772 16.5523 6 16 6H8C7.44772 6 7 6.44772 7 7V17L9.87873 14.1212C11.0503 12.9497 12.9498 12.9497 14.1214 14.1212L17 16.9999V7Z" fill="currentColor" />
-      `,
-      attribs: { "stroke-width": 0.5 },
-    },
-    check: {
-      svg: `
-        <path d="M10.2426 16.3137L6 12.071L7.41421 10.6568L10.2426 13.4853L15.8995 7.8284L17.3137 9.24262L10.2426 16.3137Z" fill="currentColor" />
-        <path fill-rule="evenodd" clip-rule="evenodd" d="M1 12C1 5.92487 5.92487 1 12 1C18.0751 1 23 5.92487 23 12C23 18.0751 18.0751 23 12 23C5.92487 23 1 18.0751 1 12ZM12 21C7.02944 21 3 16.9706 3 12C3 7.02944 7.02944 3 12 3C16.9706 3 21 7.02944 21 12C21 16.9706 16.9706 21 12 21Z" fill="currentColor" />
-      `,
-      attribs: { "stroke-width": 0.5 },
-    },
-    replay: {
-      svg: `
-        <path d="M4.56079 10.6418L6.35394 3.94971L8.25402 5.84979C11.7312 3.6588 16.3814 4.07764 19.41 7.1063L17.9958 8.52052C15.7536 6.27827 12.3686 5.87519 9.71551 7.31128L11.2529 8.84869L4.56079 10.6418Z" fill="currentColor" />
-        <path d="M19.4392 13.3581L17.646 20.0502L15.7459 18.1501C12.2688 20.3411 7.61857 19.9223 4.58991 16.8936L6.00413 15.4794C8.24638 17.7217 11.6313 18.1247 14.2844 16.6887L12.747 15.1512L19.4392 13.3581Z" fill="currentColor" />
-      `,
-      attribs: { "stroke-width": 0.5 },
-    },
-    rewind: {
-      svg: `
-        <path d="M2 7H5V17H2V7Z" fill="currentColor" />
-        <path d="M6 12L13.0023 7.00003V17L6 12Z" fill="currentColor" />
-        <path d="M21.0023 7.00003L14 12L21.0023 17V7.00003Z" fill="currentColor" />
-      `,
-      attribs: {
-        viewBox: "0 0 24 24",
-        "stroke-width": 0.5,
-      },
-    },
     play: {
-      svg: `
-        <path
-          fill-rule="evenodd"
-          clip-rule="evenodd"
-          d="M12 21C16.9706 21 21 16.9706 21 12C21 7.02944 16.9706 3 12 3C7.02944 3 3 7.02944 3 12C3 16.9706 7.02944 21 12 21ZM12 23C18.0751 23 23 18.0751 23 12C23 5.92487 18.0751 1 12 1C5.92487 1 1 5.92487 1 12C1 18.0751 5.92487 23 12 23Z"
-          fill="currentColor"
-        />
-        <path d="M16 12L10 16.3301V7.66987L16 12Z" fill="currentColor" />
-      `,
-      attribs: {
-        viewBox: "0 0 24 24",
-        "stroke-width": 0.5,
-      },
+      svg: `<path d="M7 4v16l13 -8z" />`,
     },
     pause: {
       svg: `
-        <path d="M9 9H11V15H9V9Z" fill="currentColor" />
-        <path d="M15 15H13V9H15V15Z" fill="currentColor" />
-        <path
-          fill-rule="evenodd"
-          clip-rule="evenodd"
-          d="M23 12C23 18.0751 18.0751 23 12 23C5.92487 23 1 18.0751 1 12C1 5.92487 5.92487 1 12 1C18.0751 1 23 5.92487 23 12ZM21 12C21 16.9706 16.9706 21 12 21C7.02944 21 3 16.9706 3 12C3 7.02944 7.02944 3 12 3C16.9706 3 21 7.02944 21 12Z"
-          fill="currentColor"
-        />
+        <rect x="6" y="5" width="4" height="14" rx="1" />
+        <rect x="14" y="5" width="4" height="14" rx="1" />
       `,
-      attribs: {
-        viewBox: "0 0 24 24",
-        "stroke-width": 0.5,
-      },
     },
-    record: {
-      svg: `
-        <path d="M12 15C13.6569 15 15 13.6569 15 12C15 10.3431 13.6569 9 12 9C10.3431 9 9 10.3431 9 12C9 13.6569 10.3431 15 12 15Z" fill="currentColor" /><path fill-rule="evenodd" clip-rule="evenodd" d="M22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12ZM20 12C20 16.4183 16.4183 20 12 20C7.58172 20 4 16.4183 4 12C4 7.58172 7.58172 4 12 4C16.4183 4 20 7.58172 20 12Z" fill="currentColor" />      
-      `,
-      attribs: {
-        viewBox: "0 0 24 24",
-        "stroke-width": 0.5,
-      },
-    },
-    "record-continue": {
-      svg: `
-        <path d="M12 15C13.6569 15 15 13.6569 15 12C15 10.3431 13.6569 9 12 9C10.3431 9 9 10.3431 9 12C9 13.6569 10.3431 15 12 15Z" fill="red" /><path fill-rule="evenodd" clip-rule="evenodd" d="M22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12ZM20 12C20 16.4183 16.4183 20 12 20C7.58172 20 4 16.4183 4 12C4 7.58172 7.58172 4 12 4C16.4183 4 20 7.58172 20 12Z" fill="currentColor" />
-      `,
-      attribs: {
-        viewBox: "0 0 24 24",
-        "stroke-width": 0.5,
-      },
-    },
-    markStart: {
-      svg: `
-        <path
-          d="M22.2877 11.0001V13.0001H7.80237L11.045 16.2428L9.63079 17.657L3.97394 12.0001L9.63079 6.34326L11.045 7.75748L7.80236 11.0001H22.2877Z"
-          fill="currentColor"
-        />
-        <path d="M3 18V6H1V18H3Z" fill="currentColor" />
-      `,
-      attribs: { "stroke-width": 0.5 },
-    },
-    markEnd: {
-      svg: `
-        <path
-          d="M1 12.9999V10.9999H15.4853L12.2427 7.75724L13.6569 6.34303L19.3137 11.9999L13.6569 17.6567L12.2427 16.2425L15.4853 12.9999H1Z"
-          fill="currentColor"
-        />
-        <path d="M20.2877 6V18H22.2877V6H20.2877Z" fill="currentColor" />
-      `,
-      attribs: { "stroke-width": 0.5 },
+    stop: {
+      svg: `<rect x="5" y="5" width="14" height="14" rx="2" />`,
     },
   };
   const { attribs, svg } = icons[name];

--- a/src/ui-components/Icon.svelte
+++ b/src/ui-components/Icon.svelte
@@ -167,17 +167,96 @@
       `,
       attribs: { viewBox: "0 0 712 266", fill: "currentColor" },
     },
+    skipForward: {
+      svg: `
+      <path d="M8.46448 7.75739L7.05026 9.1716L9.87869 12L7.05029 14.8284L8.46451 16.2426L12.7071 12L8.46448 7.75739Z" fill="currentColor" /><path d="M11.2929 9.1716L12.7071 7.75739L16.9498 12L12.7071 16.2426L11.2929 14.8284L14.1213 12L11.2929 9.1716Z" fill="currentColor" /><path fill-rule="evenodd" clip-rule="evenodd" d="M1 12C1 18.0751 5.92487 23 12 23C18.0751 23 23 18.0751 23 12C23 5.92487 18.0751 1 12 1C5.92487 1 1 5.92487 1 12ZM3 12C3 16.9706 7.02944 21 12 21C16.9706 21 21 16.9706 21 12C21 7.02944 16.9706 3 12 3C7.02944 3 3 7.02944 3 12Z" fill="currentColor" />
+      `,
+      attribs: { "stroke-width": 0.5 },
+    },
+    skipBack: {
+      svg: `
+      <path d="M12.7071 9.1716L11.2929 7.75739L7.05024 12L11.2929 16.2426L12.7071 14.8284L9.87869 12L12.7071 9.1716Z" fill="currentColor" /><path d="M15.5355 7.75739L16.9497 9.1716L14.1213 12L16.9497 14.8284L15.5355 16.2426L11.2929 12L15.5355 7.75739Z" fill="currentColor" /><path fill-rule="evenodd" clip-rule="evenodd" d="M23 12C23 18.0751 18.0751 23 12 23C5.92487 23 1 18.0751 1 12C1 5.92487 5.92487 1 12 1C18.0751 1 23 5.92487 23 12ZM21 12C21 16.9706 16.9706 21 12 21C7.02944 21 3 16.9706 3 12C3 7.02944 7.02944 3 12 3C16.9706 3 21 7.02944 21 12Z" fill="currentColor" />
+      `,
+      attribs: { "stroke-width": 0.5 },
+    },
+    bookmark: {
+      svg: `
+        <path fill-rule="evenodd" clip-rule="evenodd" d="M19 20H17.1717L12.7072 15.5354C12.3166 15.1449 11.6835 15.1449 11.2929 15.5354L6.82843 20L5 20V7C5 5.34315 6.34315 4 8 4H16C17.6569 4 19 5.34314 19 7V20ZM17 7C17 6.44772 16.5523 6 16 6H8C7.44772 6 7 6.44772 7 7V17L9.87873 14.1212C11.0503 12.9497 12.9498 12.9497 14.1214 14.1212L17 16.9999V7Z" fill="currentColor" />
+      `,
+      attribs: { "stroke-width": 0.5 },
+    },
+    check: {
+      svg: `
+        <path d="M10.2426 16.3137L6 12.071L7.41421 10.6568L10.2426 13.4853L15.8995 7.8284L17.3137 9.24262L10.2426 16.3137Z" fill="currentColor" />
+        <path fill-rule="evenodd" clip-rule="evenodd" d="M1 12C1 5.92487 5.92487 1 12 1C18.0751 1 23 5.92487 23 12C23 18.0751 18.0751 23 12 23C5.92487 23 1 18.0751 1 12ZM12 21C7.02944 21 3 16.9706 3 12C3 7.02944 7.02944 3 12 3C16.9706 3 21 7.02944 21 12C21 16.9706 16.9706 21 12 21Z" fill="currentColor" />
+      `,
+      attribs: { "stroke-width": 0.5 },
+    },
+    replay: {
+      svg: `
+        <path d="M4.56079 10.6418L6.35394 3.94971L8.25402 5.84979C11.7312 3.6588 16.3814 4.07764 19.41 7.1063L17.9958 8.52052C15.7536 6.27827 12.3686 5.87519 9.71551 7.31128L11.2529 8.84869L4.56079 10.6418Z" fill="currentColor" />
+        <path d="M19.4392 13.3581L17.646 20.0502L15.7459 18.1501C12.2688 20.3411 7.61857 19.9223 4.58991 16.8936L6.00413 15.4794C8.24638 17.7217 11.6313 18.1247 14.2844 16.6887L12.747 15.1512L19.4392 13.3581Z" fill="currentColor" />
+      `,
+      attribs: { "stroke-width": 0.5 },
+    },
+    rewind: {
+      svg: `
+        <path d="M2 7H5V17H2V7Z" fill="currentColor" />
+        <path d="M6 12L13.0023 7.00003V17L6 12Z" fill="currentColor" />
+        <path d="M21.0023 7.00003L14 12L21.0023 17V7.00003Z" fill="currentColor" />
+      `,
+      attribs: { "stroke-width": 0.5 },
+    },
     play: {
-      svg: `<path d="M7 4v16l13 -8z" />`,
+      svg: `
+        <path
+          fill-rule="evenodd"
+          clip-rule="evenodd"
+          d="M12 21C16.9706 21 21 16.9706 21 12C21 7.02944 16.9706 3 12 3C7.02944 3 3 7.02944 3 12C3 16.9706 7.02944 21 12 21ZM12 23C18.0751 23 23 18.0751 23 12C23 5.92487 18.0751 1 12 1C5.92487 1 1 5.92487 1 12C1 18.0751 5.92487 23 12 23Z"
+          fill="currentColor"
+        />
+        <path d="M16 12L10 16.3301V7.66987L16 12Z" fill="currentColor" />
+      `,
+      attribs: { "stroke-width": 0.5 },
     },
     pause: {
       svg: `
-        <rect x="6" y="5" width="4" height="14" rx="1" />
-        <rect x="14" y="5" width="4" height="14" rx="1" />
+        <path d="M9 9H11V15H9V9Z" fill="currentColor" />
+        <path d="M15 15H13V9H15V15Z" fill="currentColor" />
+        <path
+          fill-rule="evenodd"
+          clip-rule="evenodd"
+          d="M23 12C23 18.0751 18.0751 23 12 23C5.92487 23 1 18.0751 1 12C1 5.92487 5.92487 1 12 1C18.0751 1 23 5.92487 23 12ZM21 12C21 16.9706 16.9706 21 12 21C7.02944 21 3 16.9706 3 12C3 7.02944 7.02944 3 12 3C16.9706 3 21 7.02944 21 12Z"
+          fill="currentColor"
+        />
       `,
+      attribs: { "stroke-width": 0.5 },
     },
-    stop: {
-      svg: `<rect x="5" y="5" width="14" height="14" rx="2" />`,
+    record: {
+      svg: `
+        <path d="M12 15C13.6569 15 15 13.6569 15 12C15 10.3431 13.6569 9 12 9C10.3431 9 9 10.3431 9 12C9 13.6569 10.3431 15 12 15Z" fill="currentColor" /><path fill-rule="evenodd" clip-rule="evenodd" d="M22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12ZM20 12C20 16.4183 16.4183 20 12 20C7.58172 20 4 16.4183 4 12C4 7.58172 7.58172 4 12 4C16.4183 4 20 7.58172 20 12Z" fill="currentColor" />      
+      `,
+      attribs: { "stroke-width": 0.5 },
+    },
+    markStart: {
+      svg: `
+        <path
+          d="M22.2877 11.0001V13.0001H7.80237L11.045 16.2428L9.63079 17.657L3.97394 12.0001L9.63079 6.34326L11.045 7.75748L7.80236 11.0001H22.2877Z"
+          fill="currentColor"
+        />
+        <path d="M3 18V6H1V18H3Z" fill="currentColor" />
+      `,
+      attribs: { "stroke-width": 0.5 },
+    },
+    markEnd: {
+      svg: `
+        <path
+          d="M1 12.9999V10.9999H15.4853L12.2427 7.75724L13.6569 6.34303L19.3137 11.9999L13.6569 17.6567L12.2427 16.2425L15.4853 12.9999H1Z"
+          fill="currentColor"
+        />
+        <path d="M20.2877 6V18H22.2877V6H20.2877Z" fill="currentColor" />
+      `,
+      attribs: { "stroke-width": 0.5 },
     },
   };
   const { attribs, svg } = icons[name];

--- a/src/ui-components/IconButton.svelte
+++ b/src/ui-components/IconButton.svelte
@@ -49,6 +49,13 @@
         }
       }
 
+      &.continue-record {
+        color: red;
+        &:active {
+          color: white;
+        }
+      }
+
       &.record:active,
       &.record:hover,
       &.record:focus {
@@ -82,7 +89,6 @@
         color: var(--cool-grey);
         cursor: not-allowed;
       }
-
     }
   }
 </style>

--- a/src/ui-components/IconButton.svelte
+++ b/src/ui-components/IconButton.svelte
@@ -56,12 +56,15 @@
       }
     }
     &.performer-button {
-      color: white;
-      padding: 0.35em 0.8em;
+      align-items: center;
+      color: var(--white);
+      display: flex;
+      justify-content: center;
+      padding: 0.5rem;
       width: 100%;
 
       &:active {
-        color: white;
+        color: var(--white);
       }
 
       &:focus,
@@ -72,11 +75,11 @@
       &:hover,
       &.enabled,
       &.pause {
-        color: white;
+        color: var(--white);
       }
 
       &:disabled {
-        color: grey;
+        color: var(--cool-grey);
         cursor: not-allowed;
       }
 

--- a/src/ui-components/IconButton.svelte
+++ b/src/ui-components/IconButton.svelte
@@ -85,4 +85,5 @@
   title={label}
 >
   <Icon name={iconName} {height} {width} aria-hidden="true" focusable="false" />
+  <slot />
 </button>

--- a/src/ui-components/IconButton.svelte
+++ b/src/ui-components/IconButton.svelte
@@ -55,6 +55,32 @@
         color: red;
       }
     }
+    &.performer-button {
+      color: white;
+      padding: 0.35em 0.8em;
+      width: 100%;
+
+      &:active {
+        color: white;
+      }
+
+      &:focus,
+      &:active {
+        outline: 0;
+      }
+
+      &:hover,
+      &.enabled,
+      &.pause {
+        color: white;
+      }
+
+      &:disabled {
+        color: grey;
+        cursor: not-allowed;
+      }
+
+    }
   }
 </style>
 


### PR DESCRIPTION
This PR re-introduces the player buttons for the perform view, but with some more UX polish.
Addresses issues presented in this ticket: https://github.com/sul-cidr/pianolatron/issues/156

<img width="282" alt="Screenshot 2023-12-03 at 10 12 56 PM" src="https://github.com/sul-cidr/pianolatron/assets/2965712/5b6ac65f-758e-461e-a193-c58910e7542a">
<img width="282" alt="Screenshot 2023-12-03 at 10 12 34 PM" src="https://github.com/sul-cidr/pianolatron/assets/2965712/4b1c3cfc-d9f3-4105-b71e-73a90336a48d">
<img width="283" alt="Screenshot 2023-12-03 at 10 12 23 PM" src="https://github.com/sul-cidr/pianolatron/assets/2965712/368f249e-3629-4708-8429-372adf07dd70">
<img width="284" alt="Screenshot 2023-12-03 at 10 12 13 PM" src="https://github.com/sul-cidr/pianolatron/assets/2965712/37b6d642-bd3f-4aee-a387-abe32339d99d">


This has been done with baseline support from @simonwiles `better-playback-controls` PR here: https://github.com/sul-cidr/pianolatron/tree/better-playback-controls
as well as some feedback from other stakeholders during this process.

*Note - I'm not entirely sure when `isPerform` should be true - I also made a couple of other comments regarding features not yet build out.