### PR TITLE
188 fix startstop markers should reset when choosing a new roll from the drop down perform mode only

### DIFF
--- a/src/Pianolatron.svelte
+++ b/src/Pianolatron.svelte
@@ -221,7 +221,10 @@
 
     Promise.all([mididataReady, metadataReady, pianoReady]).then(
       ([, metadataJson]) => {
-        metadata = (({ holeData: _, ...obj }) => obj)({...metadataJson, druid: rollDruid});
+        metadata = (({ holeData: _, ...obj }) => obj)({
+          ...metadataJson,
+          druid: rollDruid,
+        });
         holeData = metadataJson.holeData;
         annotateHoleData(holeData, $rollMetadata, $scrollDownwards);
         buildHolesIntervalTree();
@@ -236,6 +239,10 @@
         const params = new URLSearchParams(window.location.search);
         if (params.has("druid") && params.get("druid") !== currentRoll.druid) {
           const url = new URL(window.location);
+          url.searchParams.delete("start");
+          url.searchParams.delete("end");
+          playbackProgressStart.reset();
+          playbackProgressEnd.reset();
           url.searchParams.set("druid", currentRoll.druid);
           window.history.pushState({ roll: currentRoll }, "", url);
         }
@@ -278,12 +285,16 @@
 
       if (params.has("start")) {
         playbackProgressStart.set(validateStartParam(params.get("start")));
+      } else {
+        playbackProgressStart.reset();
       }
 
       if (params.has("end")) {
         playbackProgressEnd.set(
           validateEndParam(params.get("end"), $playbackProgressStart),
         );
+      } else {
+        playbackProgressEnd.reset();
       }
     } else {
       currentRoll =

--- a/src/components/RollPlayerControls.svelte
+++ b/src/components/RollPlayerControls.svelte
@@ -66,6 +66,10 @@
       playbackProgressStart.reset();
     } else {
       playbackProgressStart.set($playbackProgress);
+      // if the start is bigger than the end, delete the end
+      if ($playbackProgress > $playbackProgressEnd) {
+        playbackProgressEnd.reset();
+      }
     }
   };
   const markEnd = () => {
@@ -73,6 +77,10 @@
       playbackProgressEnd.reset();
     } else {
       playbackProgressEnd.set($playbackProgress);
+      // if the end is less than the start, delete the start.
+      if ($playbackProgress < $playbackProgressStart) {
+        playbackProgressStart.reset();
+      }
     }
   };
 

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -218,7 +218,7 @@
 
     svg.setAttribute("width", "100%");
     svg.setAttribute("height", "100%");
-    svg.setAttribute("style", "pointer-events: none; margin: 0 5px;");
+    svg.setAttribute("style", "pointer-events: none; margin: 0 10px;");
     svg.appendChild(g);
 
     // start line/
@@ -259,10 +259,14 @@
         "http://www.w3.org/2000/svg",
         "rect",
       );
+
+      const height = $scrollDownwards ? endPx - startPx : startPx - endPx;
+      const boxStart = $scrollDownwards ? startPx : endPx;
+
       rect.setAttribute("x", 0);
-      rect.setAttribute("y", startPx);
+      rect.setAttribute("y", boxStart);
       rect.setAttribute("width", "100%");
-      rect.setAttribute("height", endPx - startPx);
+      rect.setAttribute("height", height);
       rect.setAttribute("fill", `hsla(304, 97%, 58%, 0.26)`);
       rect.setAttribute("class", "selection");
       g.appendChild(rect);
@@ -298,9 +302,11 @@
     if (viewport === undefined) {
       return;
     }
+    const holesBeginPx = $scrollDownwards ? firstHolePx : lastHolePx;
+    const holesEndPx = $scrollDownwards ? lastHolePx : firstHolePx;
 
     if (selectionSvg !== undefined) {
-      svgPartitions.remove(firstHolePx, lastHolePx, selectionSvg);
+      svgPartitions.remove(holesBeginPx, holesEndPx, selectionSvg);
     }
 
     let startLinePx = -1;
@@ -339,7 +345,7 @@
       endLinePx,
       selectionConfig,
     );
-    svgPartitions.insert(firstHolePx, lastHolePx, selectionSvg);
+    svgPartitions.insert(holesBeginPx, holesEndPx, selectionSvg);
   };
 
   const createHolesOverlaySvg = (holes) => {

--- a/src/components/SamplePlayer.svelte
+++ b/src/components/SamplePlayer.svelte
@@ -126,14 +126,13 @@
   const getElapsedTimeAtTick = (tick) => {
     let ticksPerSecond;
     let prevTempo = null;
-    let thisTick;
-    let thisTempo;
+    let thisTick = 0;
+    let thisTempo = DEFAULT_TEMPO;
     let i = 0;
     let tempoStartTick;
     let elapsedTime = 0;
     while (tempoMap[i][0] <= tick) {
       [thisTick, thisTempo] = tempoMap[i];
-      i += 1;
       if (prevTempo === null) {
         prevTempo = thisTempo;
         tempoStartTick = thisTick;
@@ -145,6 +144,7 @@
         tempoStartTick = thisTick;
         prevTempo = thisTempo;
       }
+      i += 1;
       if (i >= tempoMap.length) break;
     }
     ticksPerSecond = (prevTempo * $tempoCoefficient * midiTPQ) / 60.0;


### PR DESCRIPTION

This fixes the issue with start/stop markers persisting after using the roll selector drop-down.
Also adds some fixes for backwards rolls. 