### PR TITLE
Update Stacked Headers

### DIFF
--- a/src/layouts/subHeader.astro
+++ b/src/layouts/subHeader.astro
@@ -1,0 +1,128 @@
+<header class="masthead image-masthead" role="banner">
+  <span
+    class="background-container"
+    style="background-image: url('https://exhibits.stanford.edu/images/5262/14,130,584,58/1800,180/0/default.jpg')"
+  ></span>
+  <span class="background-container-gradient"></span>
+
+  <div class="container site-title-container">
+    <div class="site-title-wrapper">
+      <h1 class="site-title h2">Stanford University Piano Roll Archive</h1>
+    </div>
+  </div>
+  <div
+    id="exhibit-navbar"
+    class="exhibit-navbar navbar navbar-light navbar-expand-md"
+    role="navigation"
+    aria-label="Exhibit navigation"
+  >
+    <div class="container flex-column flex-md-row">
+      <ul class="navbar-nav mr-auto">
+        <li class="nav-item active">
+          <a class="nav-link" href="https://exhibits.stanford.edu/supra">Home</a
+          >
+        </li>
+        <li class="nav-item dropdown">
+          <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown"
+            >Roll Archive Features</a
+          >
+        </li>
+
+        <li class="nav-item">
+          <a class="nav-link" href="/search">Search</a>
+        </li>
+
+        <li class="nav-item">
+          <a class="nav-link" href="/homepage">Home</a>
+        </li>
+      </ul>
+    </div>
+  </div>
+</header>
+
+<style>
+  .masthead {
+    background-color: #2e2d29;
+    border-bottom: 1px solid #dee2e6;
+    margin-bottom: 1.5rem;
+    padding: 0;
+    position: relative;
+  }
+  .background-container {
+    position: absolute;
+    left: 0;
+    right: 0;
+    display: block;
+    width: auto;
+    height: inherit;
+    background-repeat: no-repeat;
+    background-size: cover;
+    border-right: 1px solid #2e2d29;
+    filter: blur(1px);
+    height: 100%;
+    margin-left: -1px;
+    margin-top: -1px;
+    overflow: hidden;
+  }
+  .background-container-gradient {
+    position: absolute;
+    left: 0;
+    right: 0;
+    display: block;
+    width: auto;
+    height: inherit;
+    background: linear-gradient(
+      rgba(0, 0, 0, 0),
+      rgba(0, 0, 0, 0.4),
+      rgba(0, 0, 0, 0.5)
+    );
+    height: 100%;
+  }
+  .site-title-container {
+    max-height: 8rem;
+    padding: 0.5rem 1.5rem !important;
+  }
+  .site-title-wrapper {
+    margin-top: 1rem;
+    max-width: 1140px;
+    margin: 0 auto;
+    padding: 1rem;
+    position: relative;
+    color: #fff;
+  }
+  h2 {
+    font-size: 2.125rem;
+    text-shadow: 1px 1px 0 #212529;
+  }
+  .navbar {
+    position: relative;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.5rem 1rem;
+    margin: 0 auto;
+    background-color: rgba(0, 0, 0, 0.25);
+  }
+  .navbar .container {
+    display: flex;
+    flex-wrap: nowrap;
+    align-items: center;
+    justify-content: space-between;
+    flex-direction: row !important;
+    width: 1140px;
+    padding: 0 1rem;
+    margin: 0 auto;
+  }
+  .navbar-nav {
+    display: flex;
+    flex-direction: row;
+    padding-left: 0;
+    margin: 0;
+    list-style: none;
+  }
+  .navbar-nav li a {
+    color: #fff;
+    padding: 0 0.5rem;
+  }
+</style>

--- a/src/layouts/topHeader.astro
+++ b/src/layouts/topHeader.astro
@@ -1,0 +1,54 @@
+<nav
+  class="navbar navbar-expand-md navbar-dark bg-dark topbar"
+  role="navigation"
+  aria-label="Utilities"
+>
+  <div class="container">
+    <a class="mb-0 navbar-brand navbar-logo" href="/"
+      >Stanford University Piano Roll Archive</a
+    >
+  </div>
+</nav>
+
+<style>
+  .topbar {
+    background-color: var(--cardinal-red);
+    height: 35px;
+    width: 100%;
+  }
+  .container {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    max-width: 1140px;
+    height: 35px;
+    width: 100%;
+    padding-right: 15px;
+    padding-left: 15px;
+    margin-right: auto;
+    margin-left: auto;
+  }
+  .navbar {
+    position: relative;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+  }
+  .topbar .navbar-brand {
+    background: transparent
+      url(https://exhibits.stanford.edu/assets/StanfordLibraries-logo-whitetext-b8ed4a7bafd7eed5b09f6aa8819959340afd9d4c976fe311f7a1a95bf69eff89.svg)
+      no-repeat center left;
+    background-size: contain;
+    font: 0/0 a;
+    color: transparent;
+    text-shadow: none;
+    background-color: transparent;
+    border: 0;
+    height: 35px;
+    margin: 0;
+    padding: 0.5rem;
+    width: 189px;
+  }
+</style>

--- a/src/pages/newHeader.astro
+++ b/src/pages/newHeader.astro
@@ -1,0 +1,10 @@
+---
+import BaseLayout from "../layouts/base.astro";
+import TopHeader from "../layouts/topHeader.astro";
+import SubHeader from "../layouts/subHeader.astro";
+---
+
+<BaseLayout title="Pianolatron">
+  <TopHeader />
+  <SubHeader />
+</BaseLayout>


### PR DESCRIPTION
You can access it if you specify the `newheader/` URL

This can be used either as just a top header or use both to make a full header.

Not 100% sure all of the links are where we want them to be.

Will be addressing fonts in a different ticket.