### PR TITLE
Fix disapearing control strip in Chrome

### DIFF
--- a/src/Pianolatron.svelte
+++ b/src/Pianolatron.svelte
@@ -26,7 +26,8 @@
 
   #roll {
     position: relative;
-    flex: 1 0 auto;
+    display: flex;
+    flex-direction: column;
     grid-area: center;
   }
 


### PR DESCRIPTION

Fixes weird issue when dragging the roll the viewer jumps up and pushes the control strip behind the header.
Only in Chrome. 
