### PR TITLE
Some urgent and not-so-urgent fixes for expression emulation

### DIFF
--- a/src/Pianolatron.svelte
+++ b/src/Pianolatron.svelte
@@ -211,6 +211,8 @@
       })
       .then(() => {
         // Configure and hook-up expression box
+        // Including a check for the one (so far) 65-note roll...
+        if ($rollMetadata.ROLL_TYPE === "65-note") $useInAppExpression = false;
         const expressionBoxType = $useInAppExpression
           ? $rollMetadata.ROLL_TYPE
           : "expressiveMidi";

--- a/src/components/ExpressionSettings.svelte
+++ b/src/components/ExpressionSettings.svelte
@@ -14,7 +14,6 @@
 <script>
   import {
     expressionParameters,
-    defaultExpressionParameters,
     rollHasExpressions,
     rollMetadata,
     useInAppExpression,
@@ -28,12 +27,6 @@
   const resetExpressionSettings = (forceReset) => {
     // Load the defaults when the roll type changes or Reset button is clicked
     if (!forceReset && $rollMetadata.ROLL_TYPE === currentRollType) return;
-
-    if ($defaultExpressionParameters !== null) {
-      $expressionParameters = JSON.parse(
-        JSON.stringify($defaultExpressionParameters),
-      );
-    }
     currentRollType = $rollMetadata.ROLL_TYPE;
   };
 

--- a/src/components/ViewerMetrics.svelte
+++ b/src/components/ViewerMetrics.svelte
@@ -19,18 +19,23 @@
 </style>
 
 <script>
-  import { currentTick, ticksPerSecond } from "../stores";
+  import { currentTick, ticksPerSecond, rollMetadata } from "../stores";
 </script>
 
 <div id="viewer-metrics">
   <div class="metric">
     <span>Feet per Minute:</span><span
-      >{(($ticksPerSecond / 300 / 12) * 60).toFixed(2)}</span
+      >{($ticksPerSecond
+        ? ($ticksPerSecond / 300 / 12) * 60
+        : ($rollMetadata.TICKS_PER_QUARTER * 60) / (300 * 12.0)
+      ).toFixed(2)}</span
     >
   </div>
   <div class="metric">
-    <span>Time index:</span><span
-      >{($currentTick / $ticksPerSecond).toFixed(1)}s</span
+    <span>Time Index:</span><span
+      >{($ticksPerSecond ? $currentTick / $ticksPerSecond : 0).toFixed(
+        1,
+      )}s</span
     >
   </div>
 </div>

--- a/src/expression-boxes/duo-art.js
+++ b/src/expression-boxes/duo-art.js
@@ -56,7 +56,7 @@ export default class DuoArtExpressionizer extends PedalingContinuousInput(
 
   // ? TODO: refactor
   // eslint-disable-next-line class-methods-use-this
-  getVelocityAtTime = (time, expState) => {
+  getVelocityAtTime = (_, expState) => {
     const convertStepToPressure = (step, isTheme) => {
       // Mappings from volume "steps" to pressure values are from
       // https://www.youtube.com/watch?v=w-XrDw04P2M&t=218s
@@ -138,10 +138,13 @@ export default class DuoArtExpressionizer extends PedalingContinuousInput(
 
   extendControlHoles = (item) => {
     const ctrlFunc = this.ctrlMap[item.noteNumber];
-    const { tunable: theme_extent, tracker_extension } = this.expParams;
+    const {
+      tunable: { theme_extent },
+      tracker_extension,
+    } = this.expParams;
 
     if (
-      ctrlFunc == null ||
+      ctrlFunc === null ||
       !["acc", "vol+1", "vol+2", "vol+4", "vol+8"].includes(ctrlFunc)
     )
       return item;

--- a/src/expression-boxes/lib/in-app-expressionizer.js
+++ b/src/expression-boxes/lib/in-app-expressionizer.js
@@ -38,6 +38,7 @@ export default class InAppExpressionizer {
   // ?Needs looking at...
   convertTicksAndTime = (input, target) => {
     let wanted = target;
+    // The == is necessary (but probably should be refactored out)
     if (wanted == null) wanted = "time";
 
     if (!get(useMidiTempoEventsOnOff)) {
@@ -117,13 +118,11 @@ export default class InAppExpressionizer {
   }
 
   initializeExpressionizer() {
-    if (!Object.keys(get(expressionParameters)).length)
-      expressionParameters.set(this.defaultExpressionParams);
+    expressionParameters.set(this.defaultExpressionParams);
     this.expParams = this.computeDerivedExpressionParams();
 
     this.tempoMap = this.#buildTempoMap();
     this.noteVelocitiesMap = this.buildNoteVelocitiesMap();
-    this.pedalingMap = this.buildPedalingMap();
     this.notesMap = this.#buildNotesMap();
   }
 
@@ -195,9 +194,9 @@ export default class InAppExpressionizer {
         ctrlTrackMsgs[ctrlTrackMsgs.length - 1].tick,
       );
       const finalTime = this.convertTicksAndTime(finalTick);
+      const finalPanVelocity = this.getVelocityAtTime(finalTime, expState);
 
       if (finalTime > expState.time) {
-        const finalPanVelocity = this.getVelocityAtTime(finalTime, expState);
         panExpMap.insert(expState.time, finalTime, [
           expState.velocity,
           finalPanVelocity,
@@ -240,6 +239,8 @@ export default class InAppExpressionizer {
         expressionCurve.push([expStartTick, startVelocity, startTime]);
         expressionCurve.push([expEndTick, endVelocity, endTime]);
       });
+
+      expressionCurve.push([finalTick, finalPanVelocity, finalTime]);
 
       return expressionCurve;
     };

--- a/src/stores.js
+++ b/src/stores.js
@@ -98,7 +98,6 @@ export const recordingDuration = createStore(0);
 export const bassExpCurve = createStore();
 export const trebleExpCurve = createStore();
 export const expressionParameters = createStore({});
-export const defaultExpressionParameters = createStore({});
 export const expBoxType = createStore(null);
 export const drawVelocityCurves = createStore(false);
 


### PR DESCRIPTION
See commits below.
The long-awaited corrections to the drawing of the expression curves and dynamic level guides will reduce the number of SVGs added to the viewer by... a lot.
Several of the other fixes involve correcting aspects of the in-app expression that got knocked slightly askew during the migration to class-based expression boxes.
And the remaining fixes are relatively minor.