### PR TITLE
Enhancements to how expression box parameters and displayed

### DIFF
--- a/src/Pianolatron.svelte
+++ b/src/Pianolatron.svelte
@@ -74,12 +74,9 @@
     currentTick,
     expressionBox,
     holesIntervalTree,
-    isReproducingRoll,
-    playExpressionsOnOff,
     recordingInBuffer,
     recordingOnOff,
     rollMetadata,
-    rollPedalingOnOff,
     scrollDownwards,
     useInAppExpression,
     userSettings,
@@ -252,10 +249,6 @@
           $scrollDownwards,
           $expressionBox.noteVelocitiesMap,
         );
-        if (doReset) {
-          $playExpressionsOnOff = $isReproducingRoll;
-          $rollPedalingOnOff = $isReproducingRoll;
-        }
         appReady = true;
         appWaiting = false;
         firstLoad = false;

--- a/src/Pianolatron.svelte
+++ b/src/Pianolatron.svelte
@@ -252,8 +252,9 @@
         appReady = true;
         appWaiting = false;
         firstLoad = false;
-        document.querySelector("#loading span").textContent =
-          "Loading roll image...";
+        const loadingSpan = document.querySelector("#loading span");
+        if (loadingSpan !== null)
+          loadingSpan.textContent = "Loading roll image...";
         previousRoll = currentRoll;
         const params = new URLSearchParams(window.location.search);
         if (params.has("druid") && params.get("druid") !== currentRoll.druid) {
@@ -374,8 +375,8 @@
   };
 
   onMount(async () => {
-    document.querySelector("#loading span").textContent =
-      "Loading resources...";
+    const loadingSpan = document.querySelector("#loading span");
+    if (loadingSpan !== null) loadingSpan.textContent = "Loading resources...";
 
     $appMode = getMode(mode);
 
@@ -408,13 +409,13 @@
   $: if (rollViewer)
     ({ adjustZoom, updateTickByViewportIncrement, panHorizontal } = rollViewer);
   $: if (rollImageReady) {
-    document.querySelector("#loading span").textContent = "Loading complete!";
-    document
-      .getElementById("loading")
-      .addEventListener("transitionend", () =>
-        document.getElementById("loading").remove(),
-      );
-    document.getElementById("loading").classList.add("fade-out");
+    const loadingSpan = document.querySelector("#loading span");
+    if (loadingSpan !== null) loadingSpan.textContent = "Loading complete!";
+    const loadingElt = document.getElementById("loading");
+    if (loadingElt !== null) {
+      loadingElt.addEventListener("transitionend", () => loadingElt.remove());
+      loadingElt.classList.add("fade-out");
+    }
     appLoaded = true;
   }
   $: appClass = `${$appMode}-app`;

--- a/src/Pianolatron.svelte
+++ b/src/Pianolatron.svelte
@@ -469,7 +469,7 @@
     >
       {#if appReady}
         {#if $appMode === "perform"}
-          <TabbedPanel {skipToPercentage} {reloadRoll} />
+          <TabbedPanel {reloadRoll} />
         {:else}
           <ListenerPanel {skipToTick} {playPauseApp} {stopApp} />
         {/if}

--- a/src/Pianolatron.svelte
+++ b/src/Pianolatron.svelte
@@ -146,7 +146,7 @@
     updatePlayer(() => midiSamplePlayer.skipToTick($currentTick));
   };
 
-  // redundant, but the way the BasicSettings comp is built requires we define the func
+  // redundant, but the way the SamplePlayer comp is built requires we define the func
   // here, as it won't update the ref.
   const skipToPercentage = (percentage = 0) =>
     skipToTick(progressPercentageToTick(percentage));

--- a/src/Pianolatron.svelte
+++ b/src/Pianolatron.svelte
@@ -227,11 +227,11 @@
         midiSamplePlayer.eventListeners.midiEvent = [
           $expressionBox.midiEventHandler,
         ];
+      })
+      .catch((err) => {
+        notify({ title: "MIDI Data Error!", message: err, type: "error" });
+        currentRoll = previousRoll;
       });
-    // .catch((err) => {
-    //   notify({ title: "MIDI Data Error!", message: err, type: "error" });
-    //   currentRoll = previousRoll;
-    // });
 
     metadataReady = fetch(joinPath("json", `${roll.druid}.json`))
       .then((metadataResponse) => {

--- a/src/components/BasicSettings.svelte
+++ b/src/components/BasicSettings.svelte
@@ -6,12 +6,10 @@
     trebleVolumeCoefficient,
     tempoCoefficient,
     transposeHalfStep,
-    playbackProgress,
+    // playbackProgress,
   } from "../stores";
   import { defaultControlsConfig as controlsConfig } from "../config/controls-config";
   import SliderControl from "../ui-components/SliderControl.svelte";
-
-  export let skipToPercentage;
 </script>
 
 <div id="playback-settings">
@@ -90,19 +88,5 @@
     name="transpose"
   >
     <svelte:fragment slot="label">Transpose (half steps):</svelte:fragment>
-  </SliderControl>
-  <SliderControl
-    value={$playbackProgress}
-    min="0"
-    max="1"
-    step="0.001"
-    name="progress"
-    on:input={({ target: { value } }) => skipToPercentage(value)}
-    mousewheel={false}
-  >
-    <svelte:fragment slot="label">Progress:</svelte:fragment>
-    <svelte:fragment slot="value"
-      >{($playbackProgress * 100).toFixed(2)}%</svelte:fragment
-    >
   </SliderControl>
 </div>

--- a/src/components/ExpressionSettings.svelte
+++ b/src/components/ExpressionSettings.svelte
@@ -4,15 +4,16 @@
   }
   .exp-param {
     align-self: center;
-    margin: 0 10px 0 0;
+    margin: 0 5px 0 0;
   }
   .param-value {
-    max-width: 100px;
+    max-width: 4rem;
   }
 </style>
 
 <script>
   import {
+    appWaiting,
     expressionParameters,
     rollHasExpressions,
     rollMetadata,
@@ -21,17 +22,6 @@
   } from "../stores";
 
   export let reloadRoll;
-
-  let currentRollType = $rollMetadata.ROLL_TYPE;
-
-  const resetExpressionSettings = (forceReset) => {
-    // Load the defaults when the roll type changes or Reset button is clicked
-    if (!forceReset && $rollMetadata.ROLL_TYPE === currentRollType) return;
-    currentRollType = $rollMetadata.ROLL_TYPE;
-  };
-
-  /* eslint-disable no-unused-expressions, no-sequences */
-  $: $rollMetadata, resetExpressionSettings(false);
 </script>
 
 <div id="expression-panel">
@@ -50,21 +40,23 @@
         {#each Object.keys($expressionParameters.tunable || {}) as expressionParam}
           <div>
             <label class="exp-param" for={`"input_"{expressionParam}`}
-              >{expressionParam}</label
+              >{$expressionParameters.tunable[expressionParam].alias}</label
             >
             <div>
               <input
+                disabled={$appWaiting}
                 class="param-value"
                 id={`"input_"{expressionParam}`}
                 type="number"
-                value={$expressionParameters.tunable[expressionParam]}
+                min={$expressionParameters.tunable[expressionParam].min}
+                max={$expressionParameters.tunable[expressionParam].max}
+                step={$expressionParameters.tunable[expressionParam].step}
+                value={$expressionParameters.tunable[expressionParam].value}
                 on:change={(e) => {
-                  $expressionParameters.tunable[expressionParam] = parseFloat(
-                    e.target.value,
-                  );
-                  $expressionParameters.tunable[expressionParam] = parseFloat(
-                    e.target.value,
-                  );
+                  $expressionParameters.tunable[expressionParam].value =
+                    parseFloat(e.target.value);
+                  $expressionParameters.tunable[expressionParam].value =
+                    parseFloat(e.target.value);
                   reloadRoll();
                 }}
               />
@@ -75,8 +67,7 @@
           <button
             type="button"
             on:click={() => {
-              resetExpressionSettings(true);
-              reloadRoll();
+              reloadRoll(true);
             }}>Reset to Defaults</button
           >
         </div>

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -551,15 +551,15 @@
       // overlays are drawn, but ideally it shouldn't happen this way.
       if (expParams === undefined || !("tunable" in expParams)) return;
       guides = {
-        p: parseInt(expParams.tunable.welte_p, 10),
-        mf: parseInt(expParams.tunable.welte_mf, 10),
-        f: parseInt(expParams.tunable.welte_f, 10),
+        p: parseInt(expParams.tunable.welte_p.value, 10),
+        mf: parseInt(expParams.tunable.welte_mf.value, 10),
+        f: parseInt(expParams.tunable.welte_f.value, 10),
       };
     } else if ($rollMetadata.ROLL_TYPE === "88-note") {
       if (expParams === undefined || !("tunable" in expParams)) return;
       guides = {
-        mf: parseInt(expParams.tunable.default_mf, 10),
-        f: parseInt(expParams.tunable.accent_f, 10),
+        mf: parseInt(expParams.tunable.default_mf.value, 10),
+        f: parseInt(expParams.tunable.accent_f.value, 10),
       };
     }
     partitionGuidesAndCurve(

--- a/src/components/SamplePlayer.svelte
+++ b/src/components/SamplePlayer.svelte
@@ -430,7 +430,6 @@
         audioRecorder.exportRecording();
         break;
       default:
-        break;
     }
   };
 

--- a/src/components/TabbedPanel.svelte
+++ b/src/components/TabbedPanel.svelte
@@ -50,13 +50,11 @@
   import ViewerMetrics from "./ViewerMetrics.svelte";
   import ExpressionSettings from "./ExpressionSettings.svelte";
 
-  export let skipToPercentage;
   export let reloadRoll;
 
   const panels = {
     controls: {
       component: BasicSettings,
-      props: { skipToPercentage },
       icon: "sliders",
       title: "Performance controls",
     },

--- a/src/components/ViewerMetrics.svelte
+++ b/src/components/ViewerMetrics.svelte
@@ -24,18 +24,16 @@
 
 <div id="viewer-metrics">
   <div class="metric">
-    <span>Feet per Minute:</span><span
+    <span>Roll Speed:</span><span
       >{($ticksPerSecond
         ? ($ticksPerSecond / 300 / 12) * 60
         : ($rollMetadata.TICKS_PER_QUARTER * 60) / (300 * 12.0)
-      ).toFixed(2)}</span
+      ).toFixed(2)} ft/min</span
     >
   </div>
   <div class="metric">
     <span>Time Index:</span><span
-      >{($ticksPerSecond ? $currentTick / $ticksPerSecond : 0).toFixed(
-        1,
-      )}s</span
+      >{($ticksPerSecond ? $currentTick / $ticksPerSecond : 0).toFixed(1)} s</span
     >
   </div>
 </div>

--- a/src/expression-boxes/expressive-midi.js
+++ b/src/expression-boxes/expressive-midi.js
@@ -139,9 +139,9 @@ export default class ExpressiveMidiExpressionizer {
       if (velocity === 0) {
         this.stopNote(noteNumber, NoteSource.Midi);
       } else {
-        const expressionizedVelocity =
+        const noteVelocity =
           this.noteVelocitiesMap[tick]?.[noteNumber] || velocity;
-        this.startNote(noteNumber, expressionizedVelocity, NoteSource.Midi);
+        this.startNote(noteNumber, noteVelocity, NoteSource.Midi);
         activeNotes.add(noteNumber);
       }
     } else if (name === "Controller Change" && get(rollPedalingOnOff)) {

--- a/src/expression-boxes/lib/expression-welte-mignon.js
+++ b/src/expression-boxes/lib/expression-welte-mignon.js
@@ -17,13 +17,11 @@ export const ExpressionWelteMignon = (BaseClass) =>
       fast_decresc_stop: null,
     };
 
-    initializeExpressionizer = () => {
-      this.startingExpState.velocity =
-        this.defaultExpressionParams.tunable.welte_p;
-      super.initializeExpressionizer();
-    };
-
     computeDerivedExpressionParams = () => {
+      this.startingExpState.velocity =
+        get(expressionParameters)?.tunable.welte_p.value ||
+        this.defaultExpressionParams.tunable.welte_p.value;
+
       // The derived parameters are computed from the tunable parameters and
       //  are used to calculate the expression velocities, but cannot be
       //  directly adjusted via the expression settings controls
@@ -42,12 +40,17 @@ export const ExpressionWelteMignon = (BaseClass) =>
         punch_ext_ratio,
       } = tunable;
 
+      const hydratedTunableParams = this.hydrateExpressionParams(tunable);
+
       return {
-        tunable,
-        slow_step: (welte_mf - welte_p) / slow_decay_rate,
-        fastC_step: (welte_mf - welte_p) / fastC_decay_rate,
-        fastD_step: -(welte_f - welte_p) / fastD_decay_rate,
-        tracker_extension: parseInt(tracker_diameter * punch_ext_ratio, 10),
+        tunable: hydratedTunableParams,
+        slow_step: (welte_mf.value - welte_p.value) / slow_decay_rate.value,
+        fastC_step: (welte_mf.value - welte_p.value) / fastC_decay_rate.value,
+        fastD_step: -(welte_f.value - welte_p.value) / fastD_decay_rate.value,
+        tracker_extension: parseInt(
+          tracker_diameter.value * punch_ext_ratio.value,
+          10,
+        ),
       };
     };
 
@@ -92,30 +95,30 @@ export const ExpressionWelteMignon = (BaseClass) =>
       const velocityDelta = newVelocity - expState.velocity;
       if (expState.mf_start !== null) {
         // If the previous velocity was above MF, keep it there
-        if (expState.velocity > welte_mf) {
+        if (expState.velocity > welte_mf.value) {
           newVelocity =
             velocityDelta < 0
-              ? Math.max(welte_mf + 0.001, newVelocity)
-              : Math.min(welte_f, newVelocity);
+              ? Math.max(welte_mf.value + 0.001, newVelocity)
+              : Math.min(welte_f.value, newVelocity);
           // If the previous velocity was below MF, keep it there
-        } else if (expState.velocity < welte_mf) {
+        } else if (expState.velocity < welte_mf.value) {
           newVelocity =
             velocityDelta > 0
-              ? Math.min(welte_mf - 0.001, newVelocity)
-              : Math.max(welte_p, newVelocity);
+              ? Math.min(welte_mf.value - 0.001, newVelocity)
+              : Math.max(welte_p.value, newVelocity);
         }
       } else if (
         expState.slow_cresc_start !== null &&
         !isFastCrescOn &&
-        expState.velocity < welte_loud
+        expState.velocity < welte_loud.value
       ) {
         // If the MF hook is off and only slow crescendo is on, the velocity
         //  should never exceed welte_loud (which is lower than welte_f)
-        newVelocity = Math.min(newVelocity, welte_loud - 0.001);
+        newVelocity = Math.min(newVelocity, welte_loud.value - 0.001);
       }
 
       // Ensure the velocity always stays between welte_p and welte_f
-      newVelocity = clamp(newVelocity, welte_p, welte_f);
+      newVelocity = clamp(newVelocity, welte_p.value, welte_f.value);
 
       return newVelocity;
     };

--- a/src/expression-boxes/lib/in-app-expressionizer.js
+++ b/src/expression-boxes/lib/in-app-expressionizer.js
@@ -91,6 +91,10 @@ export default class InAppExpressionizer {
     },
   };
 
+  // The point here is to apply the parameter templates above to all applicable
+  //  roll types, but allow the settings for each specific roll type to override
+  //  these values. Probably that could be done instead with some kind of class
+  //  inheritance setup, but this is OK for now.
   hydrateExpressionParams = (tunableParams) => {
     const hydratedParams = {};
     const tunableKeys = Object.keys(tunableParams);

--- a/src/expression-boxes/welte-green.js
+++ b/src/expression-boxes/welte-green.js
@@ -7,17 +7,17 @@ export default class WelteGreenExpressionizer extends ExpressionWelteMignon(
 ) {
   defaultExpressionParams = {
     tunable: {
-      welte_p: 35.0,
-      welte_mf: 60.0,
-      welte_f: 90.0,
-      welte_loud: 75.0,
-      left_adjust: -5.0,
-      slow_decay_rate: 2455, // 1 velocity step in 2.455s
-      fastC_decay_rate: 245,
-      fastD_decay_rate: 269,
-      tracker_diameter: 16.7,
-      punch_ext_ratio: 0.75,
-      accelFtPerMin2: 0.2, // TODO Double check
+      welte_p: { value: 35.0 },
+      welte_mf: { value: 60.0 },
+      welte_f: { value: 90.0 },
+      welte_loud: { value: 75.0 },
+      left_adjust: { value: -5.0 },
+      slow_decay_rate: { value: 2455 }, // 1 velocity step in 2.455s
+      fastC_decay_rate: { value: 245 },
+      fastD_decay_rate: { value: 269 },
+      tracker_diameter: { value: 16.7 },
+      punch_ext_ratio: { value: 0.75 },
+      accelFtPerMin2: { value: 0.2 }, // TODO Double check
     },
   };
 

--- a/src/expression-boxes/welte-licensee.js
+++ b/src/expression-boxes/welte-licensee.js
@@ -5,17 +5,17 @@ export default class WelteLicenseeExpressionizer extends WelteRedExpressionizer 
   //  -- only some default expression parameters are different.
   defaultExpressionParams = {
     tunable: {
-      welte_p: 35.0,
-      welte_mf: 60.0,
-      welte_f: 90.0,
-      welte_loud: 75.0,
-      left_adjust: -5.0, // bass notes can be a bit too loud (kind of a kludge)
-      slow_decay_rate: 2163, // 1 velocity step in 2.163s
-      fastC_decay_rate: 220,
-      fastD_decay_rate: 186,
-      tracker_diameter: 10.8, // P. Phillips: .5 mm smaller than Welte-Mignon
-      punch_ext_ratio: 0.75,
-      accelFtPerMin2: 0.2,
+      welte_p: { value: 35.0 },
+      welte_mf: { value: 60.0 },
+      welte_f: { value: 90.0 },
+      welte_loud: { value: 75.0 },
+      left_adjust: { value: -5.0 }, // bass notes can be a bit too loud (kind of a kludge)
+      slow_decay_rate: { value: 2163 }, // 1 velocity step in 2.163s
+      fastC_decay_rate: { value: 220 },
+      fastD_decay_rate: { value: 186 },
+      tracker_diameter: { value: 10.8 }, // P. Phillips: .5 mm smaller than Welte-Mignon
+      punch_ext_ratio: { value: 0.75 },
+      accelFtPerMin2: { value: 0.2 },
     },
   };
 

--- a/src/expression-boxes/welte-red.js
+++ b/src/expression-boxes/welte-red.js
@@ -7,17 +7,17 @@ export default class WelteRedExpressionizer extends ExpressionWelteMignon(
 ) {
   defaultExpressionParams = {
     tunable: {
-      welte_p: 35.0,
-      welte_mf: 60.0,
-      welte_f: 90.0,
-      welte_loud: 75.0,
-      left_adjust: -5.0, // bass notes can be a bit too loud (kind of a kludge)
-      slow_decay_rate: 2380, // rates are in steps/ms, i.e., 1 step in 2.38s
-      fastC_decay_rate: 300,
-      fastD_decay_rate: 400,
-      tracker_diameter: 16.7, // measured in pixels =~ ticks (1 = 1/300 in)
-      punch_ext_ratio: 0.75,
-      accelFtPerMin2: 0.3147,
+      welte_p: { value: 35.0 },
+      welte_mf: { value: 60.0 },
+      welte_f: { value: 90.0 },
+      welte_loud: { value: 75.0 },
+      left_adjust: { value: -5.0 }, // bass notes can be a bit too loud (kind of a kludge)
+      slow_decay_rate: { value: 2380 }, // rates are in steps/ms, i.e., 1 step in 2.38s
+      fastC_decay_rate: { value: 300 },
+      fastD_decay_rate: { value: 400 },
+      tracker_diameter: { value: 16.7 }, // measured in pixels =~ ticks (1 = 1/300 in)
+      punch_ext_ratio: { value: 0.75 },
+      accelFtPerMin2: { value: 0.3147 },
     },
   };
 

--- a/src/stores.js
+++ b/src/stores.js
@@ -16,8 +16,9 @@ class KeyboardRegion {
   }
 }
 
-// App mode
+// App state
 export const appMode = createStore("perform");
+export const appWaiting = createStore(false);
 
 // Metadata
 export const rollMetadata = createStore({});


### PR DESCRIPTION
This PR also includes corrections to how pedaling maps are constructed from note MIDI data for in-app expression, as well as fixes to some functionality that the changes from the last PR didn't quite get right (e.g., allowing expression parameters to be reset at any time or during a roll change, without risking an error due to race conditions in the latter case).