### PR TITLE
Accessibility accommodations for search page

### DIFF
--- a/src/components/Search.svelte
+++ b/src/components/Search.svelte
@@ -149,6 +149,7 @@
         &:hover,
         &:focus {
           background-color: #e5e7eb;
+          color: black;
         }
       }
     }

--- a/src/components/Search.svelte
+++ b/src/components/Search.svelte
@@ -55,7 +55,7 @@
       li {
         display: inline-block;
         border-radius: 6px;
-        background-color: darkslategray; // var(--primary-accent);
+        background-color: darkslategray;
         color: white;
         padding: 1px 8px 4px;
         margin: 0 4px;
@@ -77,9 +77,18 @@
     }
   }
 
+  .row-links-cell {
+    padding: 0;
+  }
+
+  .row-links {
+    display: flex;
+    align-items: center;
+    justify-content: space-evenly;
+  }
+
   .row-links a {
     color: var(--primary-accent);
-    display: inline-block;
     height: 20px;
 
     :global(svg) {
@@ -100,7 +109,7 @@
     text-align: left;
     width: 100%;
 
-    th {
+    th:not([scope="row"]) {
       background-color: #f9fafb;
       border: 1px solid #e5e7eb;
       box-sizing: border-box;
@@ -114,7 +123,7 @@
       vertical-align: middle;
       white-space: nowrap;
 
-      &:not(:first-child) {
+      &:not(:last-child) {
         background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI0MDIiIGhlaWdodD0iNDAyIiBzdHlsZT0iZmlsbDojMDAwNCI+PHBhdGggZD0iTTczLjA5MiAxNjQuNDUyaDI1NS44MTNjNC45NDkgMCA5LjIzMy0xLjgwNyAxMi44NDgtNS40MjQgMy42MTMtMy42MTYgNS40MjctNy44OTggNS40MjctMTIuODQ3cy0xLjgxMy05LjIyOS01LjQyNy0xMi44NUwyMTMuODQ2IDUuNDI0QzIxMC4yMzIgMS44MTIgMjA1Ljk1MSAwIDIwMC45OTkgMHMtOS4yMzMgMS44MTItMTIuODUgNS40MjRMNjAuMjQyIDEzMy4zMzFjLTMuNjE3IDMuNjE3LTUuNDI0IDcuOTAxLTUuNDI0IDEyLjg1IDAgNC45NDggMS44MDcgOS4yMzEgNS40MjQgMTIuODQ3IDMuNjIxIDMuNjE3IDcuOTAyIDUuNDI0IDEyLjg1IDUuNDI0ek0zMjguOTA1IDIzNy41NDlINzMuMDkyYy00Ljk1MiAwLTkuMjMzIDEuODA4LTEyLjg1IDUuNDIxLTMuNjE3IDMuNjE3LTUuNDI0IDcuODk4LTUuNDI0IDEyLjg0N3MxLjgwNyA5LjIzMyA1LjQyNCAxMi44NDhMMTg4LjE0OSAzOTYuNTdjMy42MjEgMy42MTcgNy45MDIgNS40MjggMTIuODUgNS40MjhzOS4yMzMtMS44MTEgMTIuODQ3LTUuNDI4bDEyNy45MDctMTI3LjkwNmMzLjYxMy0zLjYxNCA1LjQyNy03Ljg5OCA1LjQyNy0xMi44NDggMC00Ljk0OC0xLjgxMy05LjIyOS01LjQyNy0xMi44NDctMy42MTQtMy42MTYtNy44OTktNS40Mi0xMi44NDgtNS40MnoiLz48L3N2Zz4=);
         background-position-x: calc(100% - 9px);
         background-position-y: 50%;
@@ -154,11 +163,13 @@
       background-color: #fff;
     }
 
-    td {
+    td,
+    th:not([scope="col"]) {
       border: 1px solid #e5e7eb;
       box-sizing: content-box;
       height: 64px;
       padding: 0 min(1.5%, 24px);
+      font-weight: normal;
 
       &:first-child div {
         display: flex;
@@ -222,7 +233,7 @@
   let currentPage = 1;
   let filteredAndPagedItems;
 
-  const searchFields = ["title", "composerArranger", "performer", "publisher"];
+  const searchFields = ["publisher", "title", "composerArranger", "performer"];
 
   const unDecomposableMap = {
     ł: "l",
@@ -401,12 +412,29 @@
     Filtered: {filteredListItems?.length} / {catalog.length}
   </div>
   <!-- facets -->
-  <table>
+  <table
+    aria-label="Search/Browse Results: Piano Rolls"
+    aria-rowcount={pageSize}
+  >
     <thead>
       <tr>
-        <th>Play/Perform/MIDI/Image</th>
         <th
           tabindex="0"
+          scope="col"
+          on:click={() => sortItems("publisher")}
+          on:keypress={({ key }) => key === "Enter" && sortItems("publisher")}
+          aria-sort={sortOrder === "publisher-asc"
+            ? "ascending"
+            : sortOrder === "publisher-desc"
+              ? "descending"
+              : null}
+          class:sortedAsc={sortOrder === "publisher-asc"}
+          class:sortedDesc={sortOrder === "publisher-desc"}
+          >Publisher / Label</th
+        >
+        <th
+          tabindex="0"
+          scope="col"
           on:click={() => sortItems("work")}
           on:keypress={({ key }) => key === "Enter" && sortItems("work")}
           aria-sort={sortOrder === "work-asc"
@@ -419,6 +447,7 @@
         >
         <th
           tabindex="0"
+          scope="col"
           on:click={() => sortItems("composerArranger")}
           on:keypress={({ key }) =>
             key === "Enter" && sortItems("composerArranger")}
@@ -433,6 +462,7 @@
         >
         <th
           tabindex="0"
+          scope="col"
           on:click={() => sortItems("performer")}
           on:keypress={({ key }) => key === "Enter" && sortItems("performer")}
           aria-sort={sortOrder === "performer-asc"
@@ -443,57 +473,18 @@
           class:sortedAsc={sortOrder === "performer-asc"}
           class:sortedDesc={sortOrder === "performer-desc"}>Performer</th
         >
-        <th
-          tabindex="0"
-          on:click={() => sortItems("publisher")}
-          on:keypress={({ key }) => key === "Enter" && sortItems("publisher")}
-          aria-sort={sortOrder === "publisher-asc"
-            ? "ascending"
-            : sortOrder === "publisher-desc"
-              ? "descending"
-              : null}
-          class:sortedAsc={sortOrder === "publisher-asc"}
-          class:sortedDesc={sortOrder === "publisher-desc"}>Publisher</th
-        >
+        <th scope="col">Play/Perform/MIDI/Image</th>
       </tr>
     </thead>
     <tbody>
       {#each filteredAndPagedItems as item}
         {@const imageLink = `https://stacks.stanford.edu/file/${item.druid}/${item.image_url.split("/").slice(-2, -1)[0]}.jp2`}
         <tr>
-          <td class="row-links">
-            <div>
-              <a
-                href="/?druid={item.druid}"
-                title="Play roll {item.title}"
-                target="_blank"
-              >
-                <Icon name="play" aria-label="Play roll {item.title}" />
-              </a>
-              <a
-                href="/perform/?druid={item.druid}"
-                title="Perform roll {item.title}"
-                target="_blank"
-              >
-                <Icon name="piano" aria-label="Perform roll {item.title}" />
-              </a>
-              <a
-                href="/midi/{item.druid}.mid"
-                title="Download MIDI for roll {item.title}"
-              >
-                <Icon
-                  name="midi"
-                  aria-label="Download MIDI for roll {item.title}"
-                />
-              </a>
-              <a href={imageLink} title="Download image for roll {item.title}">
-                <Icon
-                  name="roll-image"
-                  aria-label="Download image for roll {item.title}"
-                />
-              </a>
-            </div>
-          </td>
+          <th scope="row">
+            {@html searchParts.length
+              ? markupMatches(item.publisher)
+              : item.publisher}
+          </th>
           <td>
             {@html searchParts.length ? markupMatches(item.work) : item.work}
           </td>
@@ -507,10 +498,49 @@
               ? markupMatches(item.performer)
               : item.performer}
           </td>
-          <td>
-            {@html searchParts.length
-              ? markupMatches(item.publisher)
-              : item.publisher}
+          <td class="row-links-cell">
+            <div class="row-links">
+              <div>
+                <a
+                  href="/?druid={item.druid}"
+                  title="Play roll {item.title}"
+                  target="_blank"
+                >
+                  <Icon name="play" aria-label="Play roll {item.title}" />
+                </a>
+              </div>
+              <div>
+                <a
+                  href="/perform/?druid={item.druid}"
+                  title="Perform roll {item.title}"
+                  target="_blank"
+                >
+                  <Icon name="piano" aria-label="Perform roll {item.title}" />
+                </a>
+              </div>
+              <div>
+                <a
+                  href="/midi/{item.druid}.mid"
+                  title="Download MIDI for roll {item.title}"
+                >
+                  <Icon
+                    name="midi"
+                    aria-label="Download MIDI for roll {item.title}"
+                  />
+                </a>
+              </div>
+              <div>
+                <a
+                  href={imageLink}
+                  title="Download image for roll {item.title}"
+                >
+                  <Icon
+                    name="roll-image"
+                    aria-label="Download image for roll {item.title}"
+                  />
+                </a>
+              </div>
+            </div>
           </td>
         </tr>
       {/each}

--- a/src/components/Search.svelte
+++ b/src/components/Search.svelte
@@ -424,11 +424,8 @@
           scope="col"
           on:click={() => sortItems("publisher")}
           on:keypress={({ key }) => key === "Enter" && sortItems("publisher")}
-          aria-sort={sortOrder === "publisher-asc"
-            ? "ascending"
-            : sortOrder === "publisher-desc"
-              ? "descending"
-              : null}
+          aria-sort={(sortOrder === "publisher-asc" && "ascending") ||
+            (sortOrder === "publisher-desc" && "descending")}
           class:sortedAsc={sortOrder === "publisher-asc"}
           class:sortedDesc={sortOrder === "publisher-desc"}
           >Publisher / Label</th
@@ -438,11 +435,8 @@
           scope="col"
           on:click={() => sortItems("work")}
           on:keypress={({ key }) => key === "Enter" && sortItems("work")}
-          aria-sort={sortOrder === "work-asc"
-            ? "ascending"
-            : sortOrder === "work-desc"
-              ? "descending"
-              : null}
+          aria-sort={(sortOrder === "work-asc" && "ascending") ||
+            (sortOrder === "work-desc" && "descending")}
           class:sortedAsc={sortOrder === "work-asc"}
           class:sortedDesc={sortOrder === "work-desc"}>Title</th
         >
@@ -452,11 +446,8 @@
           on:click={() => sortItems("composerArranger")}
           on:keypress={({ key }) =>
             key === "Enter" && sortItems("composerArranger")}
-          aria-sort={sortOrder === "composerArranger-asc"
-            ? "ascending"
-            : sortOrder === "composerArranger-desc"
-              ? "descending"
-              : null}
+          aria-sort={(sortOrder === "composerArranger-asc" && "ascending") ||
+            (sortOrder === "composerArranger-desc" && "descending")}
           class:sortedAsc={sortOrder === "composerArranger-asc"}
           class:sortedDesc={sortOrder === "composerArranger-desc"}
           >Composer / Arranger</th
@@ -466,11 +457,8 @@
           scope="col"
           on:click={() => sortItems("performer")}
           on:keypress={({ key }) => key === "Enter" && sortItems("performer")}
-          aria-sort={sortOrder === "performer-asc"
-            ? "ascending"
-            : sortOrder === "performer-desc"
-              ? "descending"
-              : null}
+          aria-sort={(sortOrder === "performer-asc" && "ascending") ||
+            (sortOrder === "performer-desc" && "descending")}
           class:sortedAsc={sortOrder === "performer-asc"}
           class:sortedDesc={sortOrder === "performer-desc"}>Performer</th
         >

--- a/src/components/Search.svelte
+++ b/src/components/Search.svelte
@@ -46,7 +46,7 @@
       }
 
       ul {
-        flex: 1 0 auto;
+        flex: 1 0 min-content;
         margin: 0;
         text-align: left;
         padding: 0;

--- a/src/components/Search.svelte
+++ b/src/components/Search.svelte
@@ -409,6 +409,11 @@
           tabindex="0"
           on:click={() => sortItems("work")}
           on:keypress={({ key }) => key === "Enter" && sortItems("work")}
+          aria-sort={sortOrder === "work-asc"
+            ? "ascending"
+            : sortOrder === "work-desc"
+              ? "descending"
+              : null}
           class:sortedAsc={sortOrder === "work-asc"}
           class:sortedDesc={sortOrder === "work-desc"}>Title</th
         >
@@ -417,6 +422,11 @@
           on:click={() => sortItems("composerArranger")}
           on:keypress={({ key }) =>
             key === "Enter" && sortItems("composerArranger")}
+          aria-sort={sortOrder === "composerArranger-asc"
+            ? "ascending"
+            : sortOrder === "composerArranger-desc"
+              ? "descending"
+              : null}
           class:sortedAsc={sortOrder === "composerArranger-asc"}
           class:sortedDesc={sortOrder === "composerArranger-desc"}
           >Composer / Arranger</th
@@ -425,6 +435,11 @@
           tabindex="0"
           on:click={() => sortItems("performer")}
           on:keypress={({ key }) => key === "Enter" && sortItems("performer")}
+          aria-sort={sortOrder === "performer-asc"
+            ? "ascending"
+            : sortOrder === "performer-desc"
+              ? "descending"
+              : null}
           class:sortedAsc={sortOrder === "performer-asc"}
           class:sortedDesc={sortOrder === "performer-desc"}>Performer</th
         >
@@ -432,6 +447,11 @@
           tabindex="0"
           on:click={() => sortItems("publisher")}
           on:keypress={({ key }) => key === "Enter" && sortItems("publisher")}
+          aria-sort={sortOrder === "publisher-asc"
+            ? "ascending"
+            : sortOrder === "publisher-desc"
+              ? "descending"
+              : null}
           class:sortedAsc={sortOrder === "publisher-asc"}
           class:sortedDesc={sortOrder === "publisher-desc"}>Publisher</th
         >

--- a/src/components/Search.svelte
+++ b/src/components/Search.svelte
@@ -463,21 +463,34 @@
         <tr>
           <td class="row-links">
             <div>
-              <a href="/?druid={item.druid}" title="Play roll" target="_blank">
-                <Icon name="play" aria-label="Play roll" />
+              <a
+                href="/?druid={item.druid}"
+                title="Play roll {item.title}"
+                target="_blank"
+              >
+                <Icon name="play" aria-label="Play roll {item.title}" />
               </a>
               <a
                 href="/perform/?druid={item.druid}"
-                title="Perform roll"
+                title="Perform roll {item.title}"
                 target="_blank"
               >
-                <Icon name="piano" aria-label="Perform roll" />
+                <Icon name="piano" aria-label="Perform roll {item.title}" />
               </a>
-              <a href="/midi/{item.druid}.mid" title="Download MIDI">
-                <Icon name="midi" aria-label="Download MIDI" />
+              <a
+                href="/midi/{item.druid}.mid"
+                title="Download MIDI for roll {item.title}"
+              >
+                <Icon
+                  name="midi"
+                  aria-label="Download MIDI for roll {item.title}"
+                />
               </a>
-              <a href={imageLink} title="Download image">
-                <Icon name="roll-image" aria-label="Download Image" />
+              <a href={imageLink} title="Download image for roll {item.title}">
+                <Icon
+                  name="roll-image"
+                  aria-label="Download image for roll {item.title}"
+                />
               </a>
             </div>
           </td>

--- a/src/components/Search.svelte
+++ b/src/components/Search.svelte
@@ -147,7 +147,7 @@
     td:first-child,
     th:last-child,
     td:last-child {
-      width: min(16vw, 240px);
+      width: min(17vw, 240px);
     }
 
     tbody {

--- a/src/components/Search.svelte
+++ b/src/components/Search.svelte
@@ -46,7 +46,10 @@
       }
 
       ul {
+        display: flex;
+        flex-wrap: wrap;
         flex: 1 0 min-content;
+        gap: 8px;
         margin: 0;
         text-align: left;
         padding: 0;
@@ -58,7 +61,7 @@
         background-color: darkslategray;
         color: white;
         padding: 1px 8px 4px;
-        margin: 0 4px;
+        margin: 0;
         cursor: pointer;
 
         button {

--- a/src/components/Search.svelte
+++ b/src/components/Search.svelte
@@ -72,7 +72,6 @@
 
         &.active {
           background-color: var(--primary-accent);
-          color: black;
         }
       }
     }

--- a/src/components/Search.svelte
+++ b/src/components/Search.svelte
@@ -72,6 +72,7 @@
 
         &.active {
           background-color: var(--primary-accent);
+          color: black;
         }
       }
     }

--- a/src/components/Search.svelte
+++ b/src/components/Search.svelte
@@ -426,7 +426,8 @@
           on:click={() => sortItems("publisher")}
           on:keypress={({ key }) => key === "Enter" && sortItems("publisher")}
           aria-sort={(sortOrder === "publisher-asc" && "ascending") ||
-            (sortOrder === "publisher-desc" && "descending")}
+            (sortOrder === "publisher-desc" && "descending") ||
+            null}
           class:sortedAsc={sortOrder === "publisher-asc"}
           class:sortedDesc={sortOrder === "publisher-desc"}
           >Publisher / Label</th
@@ -437,7 +438,8 @@
           on:click={() => sortItems("work")}
           on:keypress={({ key }) => key === "Enter" && sortItems("work")}
           aria-sort={(sortOrder === "work-asc" && "ascending") ||
-            (sortOrder === "work-desc" && "descending")}
+            (sortOrder === "work-desc" && "descending") ||
+            null}
           class:sortedAsc={sortOrder === "work-asc"}
           class:sortedDesc={sortOrder === "work-desc"}>Title</th
         >
@@ -448,7 +450,8 @@
           on:keypress={({ key }) =>
             key === "Enter" && sortItems("composerArranger")}
           aria-sort={(sortOrder === "composerArranger-asc" && "ascending") ||
-            (sortOrder === "composerArranger-desc" && "descending")}
+            (sortOrder === "composerArranger-desc" && "descending") ||
+            null}
           class:sortedAsc={sortOrder === "composerArranger-asc"}
           class:sortedDesc={sortOrder === "composerArranger-desc"}
           >Composer / Arranger</th
@@ -459,7 +462,8 @@
           on:click={() => sortItems("performer")}
           on:keypress={({ key }) => key === "Enter" && sortItems("performer")}
           aria-sort={(sortOrder === "performer-asc" && "ascending") ||
-            (sortOrder === "performer-desc" && "descending")}
+            (sortOrder === "performer-desc" && "descending") ||
+            null}
           class:sortedAsc={sortOrder === "performer-asc"}
           class:sortedDesc={sortOrder === "performer-desc"}>Performer</th
         >

--- a/src/styles/theme.scss
+++ b/src/styles/theme.scss
@@ -11,7 +11,7 @@
 [data-theme="blue"] {
   --background-color: aliceblue;
   --background-darker: hsl(208, 100%, 90%);
-  --primary-accent: steelblue;
+  --primary-accent: #427aa9;
   --primary-accent-semiopaque: #{transparentize(steelblue, 0.5)};
 }
 


### PR DESCRIPTION
These are all of the accessibility fixes I can come up with based on the feedback we've received so far. The commit messages tell the whole story, but here's a summary of the most significant changes:
- Changed the layout of the facet pills so they don't push the "Filtered: " text off the edge of the screen when zoomed at 200% on a laptop screen.
- Added logic to set the `aria-sorted=ascending|descending` attribute on table column headers
- Expanded the link button labels and titles so that instead of just reading "Play roll" they now read "Play roll [TITLE]", etc.
- Swapped the Publisher/Label and Play/Perform/etc. links columns so that the leftmost data column can serve as row headers (with the appropriate markup), improving legibility of the table contents via screen readers.
- Various color scheme tweaks so that selected pills and active headers don't trigger minimum text/background contrast rules.