### PR TITLE
Move the sidebar nav's position indicator widget to the proper location when the window is resized

### DIFF
--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -345,7 +345,7 @@
     ];
 
     navSelectionSvg = createSelectionOverlaySvg(...navBarLineConfig);
-    // hack: addOverlay takes an onDraw function, using it seem to help keep
+    // hack: addOverlay takes an onDraw function, using it seems to help keep
     // OSD from trying to futz with the positioning in the nav bar.
     openSeadragon.navigator.addOverlay(
       navSelectionSvg,
@@ -890,18 +890,20 @@
       const {
         viewport: navViewport,
         displayRegion: { style },
+        element: navElement,
       } = navigator;
 
       if (mainViewport && navViewport) {
-        const navigatorContainerDims = navViewport.getContainerSize();
-
         const bounds = viewport.getBoundsNoRotate(true);
         const imgBounds = viewport.viewportToImageRectangle(
           viewport.getBounds(),
         );
 
+        // Need to use navElement.clientHeight here because navViewport.getContainerSize()
+        // only returns the original size of the viewport (in screen pixels) even after
+        // the browser window has been resized.
         const topOffset =
-          (imgBounds.getTopLeft().y / imageLength) * navigatorContainerDims.y;
+          (imgBounds.getTopLeft().y / imageLength) * navElement.clientHeight;
 
         const topLeft = navViewport.pixelFromPointNoRotate(
           bounds.getTopLeft(),


### PR DESCRIPTION
This should solve the problem wherein the position indicator on the sidebar navigator mini-roll image doesn't update when the browser window is resized vertically. Such a resize causes the navigator's mini-roll image correspondingly to grow taller or shorter, so if the position indicator's, well, position doesn't change accordingly, it appears in the wrong place on the roll after the window resize.