### PR TITLE
add missing metadata property druid

### DIFF
--- a/src/Pianolatron.svelte
+++ b/src/Pianolatron.svelte
@@ -235,7 +235,13 @@
 
     metadataReady = fetch(joinPath("json", `${roll.druid}.json`))
       .then((metadataResponse) => {
-        if (metadataResponse.status === 200) return metadataResponse.json();
+        if (metadataResponse.status === 200)
+          return metadataResponse.json().then(
+              (metadataJson) => {
+                metadataJson.druid = roll.druid;
+                return metadataJson;
+              },
+            );
         throw new Error("Error fetching metadata file! (Operation cancelled)");
       })
       .catch((err) => {


### PR DESCRIPTION
`RollDetails` attempts to access `metadata.druid`, which is always undefined. This leads to `Similar Works By This Performer` including the original work itself, because this check is essentially bypassed.
https://github.com/sul-cidr/pianolatron/blob/236a9c8f97fc6b57d4a885b83190c4b22c8775cf/src/components/RollDetails.svelte#L72-L74
the `druid` is not contained in the `metadataJson`, so it needs to be added after fetching it.