### PR TITLE
add navigation

### DIFF
--- a/src/components/RollDetails.svelte
+++ b/src/components/RollDetails.svelte
@@ -143,8 +143,7 @@
   </nav>
   <dt>Work</dt>
   <dd class="large">
-    <select on:change={navigateToDruid}>
-      <option value={metadata.druid}>{metadata.title}</option>
+    <select on:change={navigateToDruid} value={metadata.druid}>
       {#each catalog as work}
         <option value={work.druid}>{work.title}</option>
       {/each}

--- a/src/components/RollDetails.svelte
+++ b/src/components/RollDetails.svelte
@@ -97,6 +97,8 @@
     const offset = direction === "←" ? -1 : 1;
     if (index + offset >= 0 && index + offset < catalog.length)
       neighbors[direction] = catalog[index + offset];
+    else
+      neighbors[direction] = undefined;
   }
 
   const unavailable = "<span>Unavailable</span>";
@@ -105,10 +107,14 @@
 <dl>
   <nav>
     {#each Object.entries(neighbors) as [direction, neighbor]}
+      {#if neighbor}
       <a
         href={`/?druid=${neighbor.druid}`}
         >{direction}</a
       >
+      {:else}
+        <a class="disabled">{direction}</a>
+      {/if}
     {/each}
   </nav>
   <dt>Title</dt>

--- a/src/components/RollDetails.svelte
+++ b/src/components/RollDetails.svelte
@@ -24,7 +24,9 @@
     }
   }
 
-  dd {
+  dd,
+  dd *,
+  dd * * {
     color: var(--black);
     font-family: SourceSans3, sans-serif;
     display: inline;
@@ -63,7 +65,7 @@
   li a:hover {
     text-decoration: underline;
   }
-  
+
   nav {
     display: flex;
     justify-content: space-between;
@@ -81,6 +83,25 @@
     text-align: center;
     text-decoration: none;
   }
+
+  nav a.disabled {
+    background-color: var(--black);
+    cursor: not-allowed;
+  }
+
+  select {
+    background-color: var(--white);
+    border-radius: 5px;
+    border: none;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  select::selection {
+    background-color: var(--cardinal-red-dark);
+    color: var(--white);
+  }
 </style>
 
 <script>
@@ -97,29 +118,37 @@
     const offset = direction === "←" ? -1 : 1;
     if (index + offset >= 0 && index + offset < catalog.length)
       neighbors[direction] = catalog[index + offset];
-    else
-      neighbors[direction] = undefined;
+    else neighbors[direction] = undefined;
   }
 
   const unavailable = "<span>Unavailable</span>";
+
+  function navigateToDruid(event) {
+    const selectedDruid = event.target.value;
+    if (selectedDruid) {
+      window.location.href = `/?druid=${selectedDruid}`;
+    }
+  }
 </script>
 
 <dl>
   <nav>
     {#each Object.entries(neighbors) as [direction, neighbor]}
       {#if neighbor}
-      <a
-        href={`/?druid=${neighbor.druid}`}
-        >{direction}</a
-      >
+        <a href={`/?druid=${neighbor.druid}`}>{direction}</a>
       {:else}
         <a class="disabled">{direction}</a>
       {/if}
     {/each}
   </nav>
-  <dt>Title</dt>
+  <dt>Work</dt>
   <dd class="large">
-    {@html metadata.title || unavailable}
+    <select on:change={navigateToDruid}>
+      <option value={metadata.druid}>{metadata.title}</option>
+      {#each catalog as work}
+        <option value={work.druid}>{work.title}</option>
+      {/each}
+    </select>
   </dd>
   {#if metadata.performer}
     <dt>Performer</dt>

--- a/src/components/RollDetails.svelte
+++ b/src/components/RollDetails.svelte
@@ -63,6 +63,24 @@
   li a:hover {
     text-decoration: underline;
   }
+  
+  nav {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 1em;
+  }
+
+  nav a {
+    background-color: var(--cardinal-red-dark);
+    border: none;
+    border-radius: 5px;
+    color: white;
+    cursor: pointer;
+    font-size: 1.2em;
+    padding: 0.5em 1em;
+    text-align: center;
+    text-decoration: none;
+  }
 </style>
 
 <script>
@@ -73,10 +91,26 @@
     (w) => w.performer === metadata.performer && w.druid !== metadata.druid,
   );
 
+  const index = catalog.findIndex((w) => w.druid === metadata.druid);
+  export const neighbors = {};
+  for (const direction of ["←", "→"]) {
+    const offset = direction === "←" ? -1 : 1;
+    if (index + offset >= 0 && index + offset < catalog.length)
+      neighbors[direction] = catalog[index + offset];
+  }
+
   const unavailable = "<span>Unavailable</span>";
 </script>
 
 <dl>
+  <nav>
+    {#each Object.entries(neighbors) as [direction, neighbor]}
+      <a
+        href={`/?druid=${neighbor.druid}`}
+        >{direction}</a
+      >
+    {/each}
+  </nav>
   <dt>Title</dt>
   <dd class="large">
     {@html metadata.title || unavailable}

--- a/src/components/RollDetails.svelte
+++ b/src/components/RollDetails.svelte
@@ -149,6 +149,10 @@
       {/each}
     </select>
   </dd>
+  <dt>Title</dt>
+  <dd class="large">
+    {@html metadata.title || unavailable}
+  </dd>
   {#if metadata.performer}
     <dt>Performer</dt>
     <dd class="large">


### PR DESCRIPTION
This adds navigation buttons to move through the catalogue left and right, and a dropdown to select works. Note that currently, the dropdown's value is unset, until #221 fixes the missing `druid` property.

![image](https://github.com/sul-cidr/pianolatron/assets/90388353/85289ba6-a2fe-4c90-84b7-a73d722067a6)
![image](https://github.com/sul-cidr/pianolatron/assets/90388353/95203d56-6bb8-4261-a096-b60ab6911448)

The styling probably needs to be adjusted.
