### PR TITLE
Searchbox Fixes

### DIFF
--- a/src/components/Search.svelte
+++ b/src/components/Search.svelte
@@ -371,7 +371,7 @@
 
     if (searchParts.length) {
       filteredListItems = filteredListItems.filter((item) =>
-        searchParts.some((searchPart) =>
+        searchParts.every((searchPart) =>
           searchFields.some((field) =>
             normalizeText(item[field]).includes(searchPart),
           ),

--- a/src/components/Search.svelte
+++ b/src/components/Search.svelte
@@ -308,17 +308,17 @@
   const markupMatches = (label) => {
     const matchExtents = [];
     const mergedExtents = [];
-    let markedUp = label;
+    let markedUp = label.replace(/\s+/g, " "); // source text has irregular whitespace
     const searchContent = normalizeText(label);
 
     searchParts.forEach((searchPart) => {
       let idx = -1;
       while ((idx = searchContent.indexOf(searchPart, idx + 1)) > -1) {
-        const _idx = idx - startIdxAdjustment(label, idx - 1);
+        const _idx = idx - startIdxAdjustment(markedUp, idx - 1);
         const _idxEnd =
           idx +
           searchPart.length -
-          endIdxAdjustment(label, _idx + searchPart.length - 1);
+          endIdxAdjustment(markedUp, _idx + searchPart.length - 1);
         matchExtents.push([_idx, _idxEnd]);
       }
     });

--- a/src/components/Search.svelte
+++ b/src/components/Search.svelte
@@ -349,6 +349,7 @@
     searchParts = text
       ? normalizeText(text.replace(/<br>|[&/\\#,+()$~%.'":*?<>{}]|nbsp;/g, " "))
           .split(" ")
+          .filter(Boolean)
           .slice(0, 8)
       : [];
   };

--- a/src/components/Search.svelte
+++ b/src/components/Search.svelte
@@ -308,7 +308,7 @@
   const markupMatches = (label) => {
     const matchExtents = [];
     const mergedExtents = [];
-    let markedUp = label.replace(/\s+/g, " "); // source text has irregular whitespace
+    let markedUp = label.replace(/[^\S\n]+/g, " "); // source text has irregular whitespace
     const searchContent = normalizeText(label);
 
     searchParts.forEach((searchPart) => {


### PR DESCRIPTION
This PR fixes the bug when a single punctuation character is entered (but please double check on Safari!), and another related to highlighting going wrong due to irregular spacing in the labels from the upstream metadata.

With respect to the initial impetus regarding the odd behaviour searching for, e.g. "stars and stripes" it wasn't so much a bug (the code was working as written) as a peculiar choice/oversight on my part when (re-)implementing the search box on the search page.  Behaviour is much better and less wtf now :)