### PR TITLE
UI for when roll emulation settings are not available

### DIFF
--- a/src/components/AdvancedSettings.svelte
+++ b/src/components/AdvancedSettings.svelte
@@ -162,7 +162,8 @@
       Play Expressions:
       <input
         type="checkbox"
-        bind:checked={$playExpressionsOnOff}
+        checked={$rollHasExpressions && $playExpressionsOnOff}
+        on:change={() => ($playExpressionsOnOff = !$playExpressionsOnOff)}
         disabled={!$rollHasExpressions}
       />
     </div>
@@ -170,7 +171,8 @@
       Use Roll Pedaling:
       <input
         type="checkbox"
-        bind:checked={$rollPedalingOnOff}
+        checked={$rollHasExpressions && $rollPedalingOnOff}
+        on:change={() => ($rollPedalingOnOff = !$rollPedalingOnOff)}
         disabled={!$rollHasExpressions}
       />
     </div>
@@ -178,7 +180,8 @@
       Emulate Roll Acceleration:
       <input
         type="checkbox"
-        bind:checked={$useMidiTempoEventsOnOff}
+        checked={$rollHasExpressions && $useMidiTempoEventsOnOff}
+        on:change={() => ($useMidiTempoEventsOnOff = !$useMidiTempoEventsOnOff)}
         disabled={!$rollHasExpressions}
       />
     </div>

--- a/src/components/AdvancedSettings.svelte
+++ b/src/components/AdvancedSettings.svelte
@@ -95,25 +95,25 @@
 <div id="settings-panel">
   <fieldset>
     <legend>Visualization Settings</legend>
-    <div>
+    <label>
       Show Details for Active Notes:
       <input type="checkbox" bind:checked={$userSettings.activeNoteDetails} />
-    </div>
-    <div>
+    </label>
+    <label>
       Display Note Velocities:
       <input type="checkbox" bind:checked={$userSettings.showNoteVelocities} />
-    </div>
-    <div>
+    </label>
+    <label>
       Highlight Enabled Holes:
       <input
         type="checkbox"
         bind:checked={$userSettings.highlightEnabledHoles}
       />
-    </div>
-    <div class="setting">
+    </label>
+    <label class="setting">
       Show Roll Viewer Scale Bar:
       <input type="checkbox" bind:checked={$userSettings.showRuler} />
-    </div>
+    </label>
   </fieldset>
 
   <fieldset>
@@ -158,7 +158,7 @@
 
   <fieldset>
     <legend>Roll Emulation Settings</legend>
-    <div>
+    <label>
       Play Expressions:
       <input
         type="checkbox"
@@ -166,8 +166,8 @@
         on:change={() => ($playExpressionsOnOff = !$playExpressionsOnOff)}
         disabled={!$rollHasExpressions}
       />
-    </div>
-    <div>
+    </label>
+    <label>
       Use Roll Pedaling:
       <input
         type="checkbox"
@@ -175,8 +175,8 @@
         on:change={() => ($rollPedalingOnOff = !$rollPedalingOnOff)}
         disabled={!$rollHasExpressions}
       />
-    </div>
-    <div>
+    </label>
+    <label>
       Emulate Roll Acceleration:
       <input
         type="checkbox"
@@ -184,7 +184,7 @@
         on:change={() => ($useMidiTempoEventsOnOff = !$useMidiTempoEventsOnOff)}
         disabled={!$rollHasExpressions}
       />
-    </div>
+    </label>
   </fieldset>
 
   <div class="theme-selector">

--- a/src/components/AdvancedSettings.svelte
+++ b/src/components/AdvancedSettings.svelte
@@ -86,6 +86,7 @@
     controlHoleColor,
     holeColorMap,
   } from "../lib/utils";
+  import { tooltip } from "../lib/tooltip-action";
 
   const themes = ["cardinal", "blue", "green", "grey"];
 
@@ -156,7 +157,11 @@
     {/if}
   </fieldset>
 
-  <fieldset>
+  <fieldset
+    use:tooltip={$rollHasExpressions
+      ? null
+      : "No Expressions are available for this roll type"}
+  >
     <legend>Roll Emulation Settings</legend>
     <label>
       Play Expressions:

--- a/src/components/TabbedPanel.svelte
+++ b/src/components/TabbedPanel.svelte
@@ -33,7 +33,8 @@
       font-size: 1.4em;
     }
 
-    :global(fieldset div) {
+    :global(fieldset div),
+    :global(fieldset label) {
       display: flex;
       justify-content: space-between;
     }

--- a/src/styles/checkboxes-and-radio-buttons.scss
+++ b/src/styles/checkboxes-and-radio-buttons.scss
@@ -36,3 +36,7 @@
 [type="radio"] {
   border-radius: 50%;
 }
+
+label:has([type="checkbox"]:disabled) {
+  opacity: 0.5;
+}


### PR DESCRIPTION
This is marginal gains for a rare edge case, but unobjectionable I hope.  The `:has` selector has pretty good support these days, but the use here will just degrade acceptably where it's not available.