### PR TITLE
Better layout on resize and when keyboard maximized

### DIFF
--- a/src/Pianolatron.svelte
+++ b/src/Pianolatron.svelte
@@ -27,7 +27,7 @@
   }
 
   .listen-app {
-    height: calc(100vh - 124px);
+    height: calc(100vh - 135px);
   }
   .perform-app {
     height: 100vh;
@@ -38,11 +38,6 @@
 
   :global(#left-sidebar) {
     grid-area: left;
-
-    p {
-      opacity: 0.5;
-      padding: 0.5em 1em;
-    }
   }
 
   #roll {
@@ -70,6 +65,7 @@
   }
 
   .sidebar {
+    position: absolute;
     display: flex;
     flex-direction: column;
     gap: 0.5em;
@@ -123,7 +119,6 @@
     notify,
     clearNotification,
   } from "./ui-components/Notification.svelte";
-  import FlexCollapsible from "./ui-components/FlexCollapsible.svelte";
   import LoadingSpinner from "./ui-components/LoadingSpinner.svelte";
   import RollPlayerControls from "./components/RollPlayerControls.svelte";
   import catalog from "./config/catalog.json";
@@ -495,21 +490,23 @@
 <main id="app" class={appClass}>
   <h1>{pageTitle || "Pianolatron"}</h1>
   <div>
-    <div class="sidebar">
-      <h2>Roll Details</h2>
-      {#if $appMode === "perform"}<RollSelector
-          bind:currentRoll
-          {rollListItems}
-        />{/if}
-      {#if appReady}
-        <RollDetails {metadata} />
-        {#if !$holesIntervalTree.count}
-          <p>
-            Note:<br />Hole visualization data is not available for this roll at
-            this time. Hole highlighting will not be enabled.
-          </p>
+    <div id="left-sidebar" style="width: 20vw;">
+      <div class="sidebar">
+        <h2>Roll Details</h2>
+        {#if $appMode === "perform"}<RollSelector
+            bind:currentRoll
+            {rollListItems}
+          />{/if}
+        {#if appReady}
+          <RollDetails {metadata} />
+          {#if !$holesIntervalTree.count}
+            <p>
+              Note:<br />Hole visualization data is not available for this roll
+              at this time. Hole highlighting will not be enabled.
+            </p>
+          {/if}
         {/if}
-      {/if}
+      </div>
     </div>
     <div id="roll">
       <h2>Roll Visualization</h2>
@@ -537,11 +534,13 @@
       {/if}
     </div>
     {#if $appMode === "perform"}
-      <div class="sidebar">
-        <h2>App Settings and Controls</h2>
-        {#if appReady}
-          <TabbedPanel {reloadRoll} {exportInAppMIDI} />
-        {/if}
+      <div id="right-sidebar" style="width: 20vw;">
+        <div class="sidebar">
+          <h2>App Settings and Controls</h2>
+          {#if appReady}
+            <TabbedPanel {reloadRoll} {exportInAppMIDI} />
+          {/if}
+        </div>
       </div>
     {/if}
   </div>


### PR DESCRIPTION
This is a suggestion for how to change the [more-accessibility](https://github.com/sul-cidr/pianolatron/tree/more-accessibility) branch (specifically commit [e627ac2](https://github.com/sul-cidr/pianolatron/commit/e627ac206dbdfcc1389f3490f4196876a7a571f9)) so that the sidebars still are no longer collapsible, but the gridded layout behavior of the sidebar(s), roll viewer and piano keyboard (if visible) is the same as previously.

The layout shortcomings of the current version of [more-accessibility](https://github.com/sul-cidr/pianolatron/tree/more-accessibility) are evident when the page is resized vertically, especially when the piano keyboard is maximized.
<img width="1269" height="814" alt="Screenshot 2026-03-31 at 1 48 24 AM" src="https://github.com/user-attachments/assets/c8082f83-f6d8-476f-b2ec-bbc3efc7b52b" />

Note that the previous (more desirable) layout behavior still does have its quirks, such as how the left sidebar can y-overflow in listen mode when it really has vertical room to spare -- this apparently (?) is so that space will be available if the keyboard is maximized. It would be nice to improve this, but it need not be a high priority.
<img width="1390" height="1010" alt="Screenshot 2026-03-31 at 1 43 11 AM" src="https://github.com/user-attachments/assets/311c79a1-42c9-441c-b3ad-f8d9fba52f14" />

Anyway, we probably can just delete the `<FlexCollapsible>` component entirely if this fix is sufficient?

Note also that the `height: calc(100vh - 135px);` is an unrelated change to ensure that the app window doesn't have a vertical scroll bar in listen mode -- the previous value (`124px`) is a leftover from a different page header size.