### PR TITLE
Performance improvements

### DIFF
--- a/src/Pianolatron.svelte
+++ b/src/Pianolatron.svelte
@@ -92,6 +92,7 @@
     playbackProgressStart,
     playbackProgressEnd,
     currentTick,
+    throttledTick,
     expressionBox,
     holesIntervalTree,
     recordingInBuffer,
@@ -164,6 +165,7 @@
   const skipToTick = (tick) => {
     if (tick < 0) pausePlayback();
     $currentTick = tick;
+    throttledTick.set(tick);
     updatePlayer(() => midiSamplePlayer.skipToTick($currentTick));
   };
 

--- a/src/components/ExpressionSettings.svelte
+++ b/src/components/ExpressionSettings.svelte
@@ -39,6 +39,7 @@
     playExpressionsOnOff,
     reverbWetDry,
     currentTick,
+    throttledTick,
     volumeCoefficient,
     bassVolumeCoefficient,
     trebleVolumeCoefficient,
@@ -127,6 +128,7 @@
       $velocityCurveMid = allSettings.playbackSettings.velocityCurveMid;
       $velocityCurveHigh = allSettings.playbackSettings.velocityCurveHigh;
       $currentTick = allSettings.playbackSettings.currentTick;
+      throttledTick.set($currentTick);
       $userSettings = allSettings.playbackSettings.userSettings;
       $drawVelocityCurves = allSettings.playbackSettings.drawVelocityCurves;
 

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -146,7 +146,7 @@
     useInAppExpression,
     userSettings,
   } from "../stores";
-  import { clamp, getHoleLabel } from "../lib/utils";
+  import { clamp, defaultHoleColor, getHoleLabel } from "../lib/utils";
   import RollViewerControls from "./RollViewerControls.svelte";
   import RollViewerScaleBar from "./RollViewerScaleBar.svelte";
   import AriaAnnouncer from "../ui-components/AriaAnnouncer.svelte";
@@ -752,10 +752,11 @@
       // Get highlight color
       let color = hole.color;
       if (
-        !$userSettings.showNoteVelocities ||
-        $userSettings.highlightEnabledHoles
+        hole.type === "note" &&
+        (!$userSettings.showNoteVelocities ||
+          $userSettings.highlightEnabledHoles)
       ) {
-        color = "60, 100%, 50%"; // yellow default for non-velocity mode
+        color = defaultHoleColor; // yellow default for non-velocity mode
       }
       if (
         !$rollPedalingOnOff &&
@@ -766,7 +767,7 @@
       }
 
       // Animate highlight: bright "attack" then fade to steady opacity over 500ms
-      let opacity = 0.5;
+      let opacity = 0.6;
       let glow = 8;
       if (!_highlightActivation.has(hole)) {
         _highlightActivation.set(hole, performance.now());
@@ -775,7 +776,7 @@
       if (elapsed < 500) {
         const t = elapsed / 500;
         const eased = easeInOutCubic(t);
-        opacity = 1 - 0.5 * eased;
+        opacity = 1 - 0.4 * eased;
         glow = 8 * (1 - eased);
       }
 

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -124,7 +124,6 @@
   import {
     avgHoleWidth,
     bassExpCurve,
-    currentTick,
     drawVelocityCurves,
     expressionParameters,
     firstHolePx,
@@ -1193,14 +1192,14 @@
     }
     updateSelectionOverlays();
     updateVisibleSvgPartitions();
-    updateViewportFromTick($currentTick);
+    updateViewportFromTick($throttledTick);
   };
 
   /* eslint-disable no-unused-expressions, no-sequences */
   $: ($playbackProgressStart, updateSelection());
   $: ($playbackProgressEnd, updateSelection());
-  $: updateViewportFromTick($currentTick);
-  $: ($transposeHalfStep, rehighlightHoles($currentTick));
+  $: updateViewportFromTick($throttledTick);
+  $: ($transposeHalfStep, rehighlightHoles($throttledTick));
   $: ($drawVelocityCurves,
     partitionExpressionOverlaySvgs($bassExpCurve, $trebleExpCurve));
   $: ($userSettings.activeNoteDetails,

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -772,12 +772,20 @@
       highlightCtx.fill();
 
       // Draw detail label on canvas when active-note-details is enabled
-      if ($userSettings.activeNoteDetails && hole.type === "note") {
-        const noteLabel = hole.label;
+      if ($userSettings.activeNoteDetails) {
+        let noteLabel = hole.label;
         let velocityLine = "";
-        if ($userSettings.showNoteVelocities) {
-          const vel = $playExpressionsOnOff ? (hole.v ?? 64) : 64;
-          velocityLine = `v:${Math.round(vel)}`;
+
+        if (hole.type === "note") {
+          noteLabel = getHoleLabel(
+            hole.m + $transposeHalfStep,
+            $rollMetadata.ROLL_TYPE,
+          );
+
+          if ($userSettings.showNoteVelocities) {
+            const vel = $playExpressionsOnOff ? (hole.v ?? 64) : 64;
+            velocityLine = `v:${Math.round(vel)}`;
+          }
         }
 
         highlightCtx.save();

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -772,7 +772,65 @@
       const radius = Math.min(6, screenW / 4, screenH / 4);
       highlightCtx.roundRect(screenX, screenY, screenW, screenH, radius);
       highlightCtx.fill();
+
+      // Draw detail label on canvas when active-note-details is enabled
+      if ($userSettings.activeNoteDetails && hole.type === "note") {
+        const noteLabel = hole.label;
+        let velocityLine = "";
+        if ($userSettings.showNoteVelocities) {
+          const vel = $playExpressionsOnOff ? (hole.v ?? 64) : 64;
+          velocityLine = `v:${Math.round(vel)}`;
+        }
+
+        highlightCtx.save();
+        highlightCtx.textAlign = "center";
+
+        const cx = screenX + screenW / 2;
+        if (!$scrollDownwards) {
+          drawTextLine(
+            highlightCtx,
+            noteLabel,
+            true,
+            cx,
+            screenY + screenH + 36,
+          );
+          if (velocityLine) {
+            drawTextLine(
+              highlightCtx,
+              velocityLine,
+              false,
+              cx,
+              screenY + screenH + 58,
+            );
+          }
+        } else {
+          if (velocityLine) {
+            drawTextLine(highlightCtx, noteLabel, true, cx, screenY - 36);
+            drawTextLine(highlightCtx, velocityLine, false, cx, screenY - 14);
+          } else {
+            drawTextLine(highlightCtx, noteLabel, true, cx, screenY - 14);
+          }
+        }
+        highlightCtx.restore();
+      }
     });
+  };
+
+  const drawTextLine = (ctx, text, bold, x, y) => {
+    ctx.font = bold ? "bold 18px sans-serif" : "16px sans-serif";
+    const metrics = ctx.measureText(text);
+    const tw = metrics.width;
+    const padding = 6;
+
+    ctx.fillStyle = "rgba(0, 0, 0, 0.35)";
+    ctx.fillRect(x - tw / 2 - padding, y - 11, tw + padding * 2, 22);
+
+    ctx.strokeStyle = "black";
+    ctx.lineWidth = 3;
+    ctx.lineJoin = "round";
+    ctx.strokeText(text, x, y);
+    ctx.fillStyle = "white";
+    ctx.fillText(text, x, y);
   };
 
   // remove the current highlights and re-add them. Needed for when a transpose has taken place
@@ -1104,8 +1162,10 @@
     const resizeHighlightCanvas = () => {
       if (!highlightCanvas || !openSeadragon) return;
       const rect = highlightCanvas.getBoundingClientRect();
-      highlightCanvas.width = Math.round(rect.width);
-      highlightCanvas.height = Math.round(rect.height);
+      const dpr = window.devicePixelRatio ?? 1;
+      highlightCanvas.width = Math.round(rect.width * dpr);
+      highlightCanvas.height = Math.round(rect.height * dpr);
+      highlightCtx.setTransform(dpr, 0, 0, dpr, 0, 0);
     };
 
     if (highlightCanvas) {
@@ -1144,6 +1204,10 @@
   $: ($transposeHalfStep, rehighlightHoles($currentTick));
   $: ($drawVelocityCurves,
     partitionExpressionOverlaySvgs($bassExpCurve, $trebleExpCurve));
+  $: ($userSettings.activeNoteDetails,
+    $userSettings.showNoteVelocities,
+    $playExpressionsOnOff,
+    drawActiveHighlights($throttledTick));
 
   export {
     adjustZoom,

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -125,6 +125,7 @@
     playbackProgressEnd,
     latencyDetected,
     showLatencyWarning,
+    throttledTick,
     transposeHalfStep,
     playExpressionsOnOff,
     rollMetadata,
@@ -1051,7 +1052,7 @@
   $: ($playbackProgressStart, updateSelection());
   $: ($playbackProgressEnd, updateSelection());
   $: updateViewportFromTick($currentTick);
-  $: highlightHoles($currentTick);
+  $: highlightHoles($throttledTick);
   $: ($transposeHalfStep, rehighlightHoles($currentTick));
   $: ($drawVelocityCurves,
     partitionExpressionOverlaySvgs($bassExpCurve, $trebleExpCurve));

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -38,7 +38,7 @@
       position: absolute;
       top: calc(50% - var(--trackerbar-height) / 2);
       width: calc(100% - var(--navigator-width));
-      z-index: 1;
+      z-index: 3;
     }
 
     // overlay to mask white borders on the roll images

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -66,7 +66,7 @@
       pointer-events: none;
       position: absolute;
       top: 0;
-      width: 100%;
+      width: calc(100% - var(--navigator-width));
       z-index: 2;
     }
 
@@ -734,6 +734,7 @@
     const canvasRect = highlightCanvas.getBoundingClientRect();
     const bounds = viewport.getBoundsNoRotate(true);
     const imgBounds = viewport.viewportToImageRectangle(bounds);
+    const viewerSize = viewport.getContainerSize();
 
     // Clear and draw highlights for active holes
     highlightCtx.clearRect(0, 0, highlightCanvas.width, highlightCanvas.height);
@@ -744,12 +745,10 @@
       const holeH = hole.h;
 
       // Convert image coords to screen pixel coords on the canvas
-      const screenX =
-        ((holeX - imgBounds.x) / imgBounds.width) * canvasRect.width;
-      const screenY =
-        ((holeY - imgBounds.y) / imgBounds.height) * canvasRect.height;
-      const screenW = (holeW / imgBounds.width) * canvasRect.width;
-      const screenH = (holeH / imgBounds.height) * canvasRect.height;
+      const screenX = ((holeX - imgBounds.x) / imgBounds.width) * viewerSize.x;
+      const screenY = ((holeY - imgBounds.y) / imgBounds.height) * viewerSize.y;
+      const screenW = (holeW / imgBounds.width) * viewerSize.x;
+      const screenH = (holeH / imgBounds.height) * viewerSize.y;
 
       // Get highlight color
       let color = hole.color;

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -147,6 +147,7 @@
     userSettings,
   } from "../stores";
   import { clamp, defaultHoleColor, getHoleLabel } from "../lib/utils";
+  import { getNoteHoleColor } from "../lib/hole-data";
   import RollViewerControls from "./RollViewerControls.svelte";
   import RollViewerScaleBar from "./RollViewerScaleBar.svelte";
   import AriaAnnouncer from "../ui-components/AriaAnnouncer.svelte";
@@ -751,6 +752,9 @@
 
       // Get highlight color
       let color = hole.color;
+      if (hole.type === "note" && !$playExpressionsOnOff) {
+        color = getNoteHoleColor(64, 64, 64);
+      }
       if (
         hole.type === "note" &&
         (!$userSettings.showNoteVelocities ||

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -59,6 +59,17 @@
       background: white !important;
     }
 
+    #active-note-highlight-canvas {
+      background: transparent !important;
+      height: 100%;
+      left: 0;
+      pointer-events: none;
+      position: absolute;
+      top: 0;
+      width: 100%;
+      z-index: 2;
+    }
+
     :global(.openseadragon-canvas:focus) {
       outline: none;
     }
@@ -170,6 +181,8 @@
 
   let selectionSvg;
   let navSelectionSvg;
+  let highlightCanvas;
+  let highlightCtx = null;
 
   const createMark = (hole) => {
     const {
@@ -697,30 +710,75 @@
     partitionExpressionOverlaySvgs($bassExpCurve, $trebleExpCurve);
   };
 
-  const highlightHoles = (tick) => {
-    if (!openSeadragon) return;
+  // Draw active note highlights on canvas instead of as DOM elements.
+  const drawActiveHighlights = (tick) => {
+    if (!highlightCtx || !openSeadragon) return;
 
     const holes = $holesIntervalTree.search(tick, tick);
+    if (!holes.length) {
+      highlightCtx.clearRect(
+        0,
+        0,
+        highlightCanvas.width,
+        highlightCanvas.height,
+      );
+      return;
+    }
 
-    marks = marks.filter(([hole, elem]) => {
-      if (holes.includes(hole)) return true;
-      viewport.viewer.removeOverlay(elem);
-      return false;
-    });
-
+    // Announce active holes
     holes.forEach((hole) => {
       announcement = hole.label.replace("#", "♯").replace("_", " ");
-      if (marks.map(([_hole]) => _hole).includes(hole)) return;
-      const mark = createMark(hole);
-      mark.classList.add("active");
-      marks.push([hole, mark]);
+    });
+
+    const canvasRect = highlightCanvas.getBoundingClientRect();
+    const bounds = viewport.getBoundsNoRotate(true);
+    const imgBounds = viewport.viewportToImageRectangle(bounds);
+
+    // Clear and draw highlights for active holes
+    highlightCtx.clearRect(0, 0, highlightCanvas.width, highlightCanvas.height);
+    holes.forEach((hole) => {
+      const holeX = hole.x;
+      const holeY = hole.startY;
+      const holeW = hole.w;
+      const holeH = hole.h;
+
+      // Convert image coords to screen pixel coords on the canvas
+      const screenX =
+        ((holeX - imgBounds.x) / imgBounds.width) * canvasRect.width;
+      const screenY =
+        ((holeY - imgBounds.y) / imgBounds.height) * canvasRect.height;
+      const screenW = (holeW / imgBounds.width) * canvasRect.width;
+      const screenH = (holeH / imgBounds.height) * canvasRect.height;
+
+      // Get highlight color
+      let color = hole.color;
+      if (
+        !$userSettings.showNoteVelocities ||
+        $userSettings.highlightEnabledHoles
+      ) {
+        color = "60, 100%, 50%"; // yellow default for non-velocity mode
+      }
+      if (
+        !$rollPedalingOnOff &&
+        (hole.type === "pedal" || hole.type === "control")
+      ) {
+        // skip pedal/control holes when roll pedaling is off
+        return;
+      }
+
+      highlightCtx.fillStyle = `hsla(${color}, 0.8)`;
+      highlightCtx.beginPath();
+      const radius = Math.min(6, screenW / 4, screenH / 4);
+      highlightCtx.roundRect(screenX, screenY, screenW, screenH, radius);
+      highlightCtx.fill();
     });
   };
 
-  // remove the current hightlights readd them. Needed for when a transpose has taken place
+  // remove the current highlights and re-add them. Needed for when a transpose has taken place
+  // NOTE: This appears to be redundant?
   const rehighlightHoles = (tick) => {
-    highlightHoles(-1);
-    highlightHoles(tick);
+    drawActiveHighlights(-1);
+    drawActiveHighlights(tick);
   };
 
   // Pan the viewer to bring the position of `@tick` to the center of
@@ -1036,6 +1094,25 @@
     };
 
     openSeadragon.open(imageUrl);
+
+    // Initialize highlight canvas context and size for active note drawing
+    const resizeHighlightCanvas = () => {
+      if (!highlightCanvas || !openSeadragon) return;
+      const rect = highlightCanvas.getBoundingClientRect();
+      highlightCanvas.width = Math.round(rect.width);
+      highlightCanvas.height = Math.round(rect.height);
+    };
+
+    if (highlightCanvas) {
+      highlightCtx = highlightCanvas.getContext("2d");
+      resizeHighlightCanvas();
+    }
+
+    // Resize observer to keep canvas internal dimensions synced with CSS size
+    if (highlightCanvas && typeof ResizeObserver !== "undefined") {
+      const resizeObserver = new ResizeObserver(resizeHighlightCanvas);
+      resizeObserver.observe(highlightCanvas.parentElement);
+    }
   });
 
   const closeLatencyWarning = () => ($showLatencyWarning = false);
@@ -1053,10 +1130,19 @@
   $: ($playbackProgressStart, updateSelection());
   $: ($playbackProgressEnd, updateSelection());
   $: updateViewportFromTick($currentTick);
-  $: highlightHoles($throttledTick);
   $: ($transposeHalfStep, rehighlightHoles($currentTick));
   $: ($drawVelocityCurves,
     partitionExpressionOverlaySvgs($bassExpCurve, $trebleExpCurve));
+
+  let rafId = null;
+  const scheduleHighlightDraw = () => {
+    if (rafId !== null || !highlightCtx) return;
+    rafId = requestAnimationFrame(() => {
+      rafId = null;
+      drawActiveHighlights($throttledTick);
+    });
+  };
+  $: ($throttledTick, scheduleHighlightDraw());
 
   export {
     adjustZoom,
@@ -1109,6 +1195,8 @@
       <RollViewerScaleBar {ppi} />
     {/if}
   {/if}
+
+  <canvas id="active-note-highlight-canvas" bind:this={highlightCanvas} />
 
   {#if $latencyDetected && $showLatencyWarning}
     <LatencyWarning {closeLatencyWarning} />

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -1,6 +1,7 @@
 <svelte:options accessors />
 
 <style lang="scss">
+  @use "src/styles/sass-globals.scss" as *;
   // See styles/hole-highlighting.scss for all the <mark/> and <rect/> styling
 
   #roll-viewer {

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -730,7 +730,6 @@
       announcement = hole.label.replace("#", "♯").replace("_", " ");
     });
 
-    const canvasRect = highlightCanvas.getBoundingClientRect();
     const bounds = viewport.getBoundsNoRotate(true);
     const imgBounds = viewport.viewportToImageRectangle(bounds);
     const viewerSize = viewport.getContainerSize();

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -816,7 +816,7 @@
             noteLabel,
             true,
             cx,
-            screenY + screenH + 36,
+            screenY + screenH + 28,
           );
           if (velocityLine) {
             drawTextLine(
@@ -824,7 +824,7 @@
               velocityLine,
               false,
               cx,
-              screenY + screenH + 58,
+              screenY + screenH + 50,
             );
           }
         } else {

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -824,17 +824,12 @@
 
   const drawTextLine = (ctx, text, bold, x, y) => {
     ctx.font = bold ? "bold 18px sans-serif" : "16px sans-serif";
-    const metrics = ctx.measureText(text);
-    const tw = metrics.width;
-    const padding = 6;
+    ctx.textAlign = "center";
+    ctx.shadowColor = "rgba(0, 0, 0, 0.8)";
+    ctx.shadowBlur = 4;
+    ctx.shadowOffsetX = 0;
+    ctx.shadowOffsetY = 1;
 
-    ctx.fillStyle = "rgba(0, 0, 0, 0.35)";
-    ctx.fillRect(x - tw / 2 - padding, y - 11, tw + padding * 2, 22);
-
-    ctx.strokeStyle = "black";
-    ctx.lineWidth = 3;
-    ctx.lineJoin = "round";
-    ctx.strokeText(text, x, y);
     ctx.fillStyle = "white";
     ctx.fillText(text, x, y);
   };

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -117,7 +117,7 @@
 </style>
 
 <script>
-  import { onMount } from "svelte";
+  import { onDestroy, onMount } from "svelte";
   import { fade } from "svelte/transition";
   import IntervalTree from "node-interval-tree";
   import OpenSeadragon from "openseadragon";
@@ -164,6 +164,7 @@
   const maxZoomLevel = 4;
   const horizontalPanIncrement = 40;
 
+  let _updateViewportHandler;
   let announcement;
   let openSeadragon;
   let viewport;
@@ -1093,6 +1094,10 @@
       //  constraints applied here), we'll just neuter it here.
     };
 
+    // Draw highlights when OSD viewport updates
+    _updateViewportHandler = () => drawActiveHighlights($throttledTick);
+    openSeadragon.addHandler("update-viewport", _updateViewportHandler);
+
     openSeadragon.open(imageUrl);
 
     // Initialize highlight canvas context and size for active note drawing
@@ -1115,6 +1120,12 @@
     }
   });
 
+  onDestroy(() => {
+    if (openSeadragon && _updateViewportHandler) {
+      openSeadragon.removeHandler("update-viewport", _updateViewportHandler);
+    }
+  });
+
   const closeLatencyWarning = () => ($showLatencyWarning = false);
 
   const updateSelection = () => {
@@ -1133,16 +1144,6 @@
   $: ($transposeHalfStep, rehighlightHoles($currentTick));
   $: ($drawVelocityCurves,
     partitionExpressionOverlaySvgs($bassExpCurve, $trebleExpCurve));
-
-  let rafId = null;
-  const scheduleHighlightDraw = () => {
-    if (rafId !== null || !highlightCtx) return;
-    rafId = requestAnimationFrame(() => {
-      rafId = null;
-      drawActiveHighlights($throttledTick);
-    });
-  };
-  $: ($throttledTick, scheduleHighlightDraw());
 
   export {
     adjustZoom,

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -183,6 +183,7 @@
   let navSelectionSvg;
   let highlightCanvas;
   let highlightCtx = null;
+  const _highlightActivation = new WeakMap();
 
   const createMark = (hole) => {
     const {
@@ -764,11 +765,29 @@
         return;
       }
 
-      highlightCtx.fillStyle = `hsla(${color}, 0.8)`;
+      // Animate highlight: bright "attack" then fade to steady opacity over 500ms
+      let opacity = 0.5;
+      let glow = 8;
+      if (!_highlightActivation.has(hole)) {
+        _highlightActivation.set(hole, performance.now());
+      }
+      const elapsed = performance.now() - _highlightActivation.get(hole);
+      if (elapsed < 500) {
+        const t = elapsed / 500;
+        const eased = easeInOutCubic(t);
+        opacity = 1 - 0.5 * eased;
+        glow = 8 * (1 - eased);
+      }
+
+      highlightCtx.save();
+      highlightCtx.shadowColor = `hsla(${color}, ${opacity * 0.5})`;
+      highlightCtx.shadowBlur = glow;
+      highlightCtx.fillStyle = `hsla(${color}, ${opacity})`;
       highlightCtx.beginPath();
       const radius = Math.min(6, screenW / 4, screenH / 4);
       highlightCtx.roundRect(screenX, screenY, screenW, screenH, radius);
       highlightCtx.fill();
+      highlightCtx.restore();
 
       // Draw detail label on canvas when active-note-details is enabled
       if ($userSettings.activeNoteDetails) {
@@ -832,6 +851,10 @@
     ctx.fillStyle = "white";
     ctx.fillText(text, x, y);
   };
+
+  // cribbed from https://github.com/gre/bezier-easing
+  const easeInOutCubic = (t) =>
+    t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2;
 
   // remove the current highlights and re-add them. Needed for when a transpose has taken place
   // NOTE: This appears to be redundant?

--- a/src/components/SamplePlayer.svelte
+++ b/src/components/SamplePlayer.svelte
@@ -38,6 +38,7 @@
     playRepeat,
     playbackProgressStart,
     latencyDetected,
+    throttledTick,
     ticksPerSecond,
     expressionBox,
   } from "../stores";
@@ -168,6 +169,7 @@
   const skipToTick = (tick) => {
     if (tick < 0) pausePlayback();
     $currentTick = tick;
+    throttledTick.set(tick);
     updatePlayer(() => midiSamplePlayer.skipToTick($currentTick));
   };
 
@@ -396,7 +398,10 @@
 
   midiSamplePlayer.on("playing", ({ tick }) => {
     if (!$isPlaying) $isPlaying = true;
-    if (tick <= midiSamplePlayer.totalTicks) currentTick.set(tick);
+    if (tick <= midiSamplePlayer.totalTicks) {
+      currentTick.set(tick);
+      throttledTick.set(tick);
+    }
     if (tick >= midiSamplePlayer.totalTicks) $isPlaying = false;
   });
 

--- a/src/components/SamplePlayer.svelte
+++ b/src/components/SamplePlayer.svelte
@@ -342,6 +342,7 @@
 
   const resetPlayback = () => {
     currentTick.reset();
+    throttledTick.set(0);
     midiSamplePlayer.stop();
     activeNotes.reset();
     softOnOff.reset();

--- a/src/lib/hole-data.js
+++ b/src/lib/hole-data.js
@@ -23,10 +23,10 @@ const holeColorMap = [
   "348, 96%, 36%",
 ];
 
-const defaultHoleColor = "60, 100%, 50%"; // yellow (default)
-const controlHoleColor = "120, 73%, 75%"; // light green
-const pedalHoleColor = "39, 100%, 50%"; // orange;
+const defaultHoleColor = "60, 100%, 40%"; // yellow (default)
+const controlHoleColor = "120, 73%, 60%"; // light green
 
+const pedalHoleColor = "39, 100%, 45%"; // orange
 const getNoteName = (midiNumber) => {
   const octave = parseInt(midiNumber / 12, 10) - 1;
   const name = [

--- a/src/lib/hole-data.js
+++ b/src/lib/hole-data.js
@@ -77,6 +77,23 @@ const getHoleLabel = (midiNumber, rollType) => {
   return `mid_${midiNumber}`;
 };
 
+export const getNoteHoleColor = (
+  velocity,
+  minNoteVelocity,
+  maxNoteVelocity,
+) => {
+  if (!velocity) return defaultHoleColor;
+  return holeColorMap[
+    Math.round(
+      mapToRange(
+        normalizeInRange(velocity, minNoteVelocity, maxNoteVelocity),
+        0,
+        holeColorMap.length - 1,
+      ),
+    )
+  ];
+};
+
 const annotateHoleData = (
   holeData,
   rollType,
@@ -94,19 +111,6 @@ const annotateHoleData = (
     ],
     [Infinity, -Infinity],
   );
-
-  const getNoteHoleColor = ({ v: velocity }) => {
-    if (!velocity) return defaultHoleColor;
-    return holeColorMap[
-      Math.round(
-        mapToRange(
-          normalizeInRange(velocity, minNoteVelocity, maxNoteVelocity),
-          0,
-          holeColorMap.length - 1,
-        ),
-      )
-    ];
-  };
 
   return holeData.map((hole) => {
     // hole.y is the coordinate of the beginning of the hole *in the direction
@@ -133,7 +137,7 @@ const annotateHoleData = (
         break;
 
       case "note":
-        hole.color = getNoteHoleColor(hole);
+        hole.color = getNoteHoleColor(hole.v, minNoteVelocity, maxNoteVelocity);
         hole.type = "note";
         break;
 

--- a/src/lib/stores.js
+++ b/src/lib/stores.js
@@ -60,3 +60,32 @@ export const createSetStore = () => {
     reset: (newValue) => set(new Set(newValue)),
   };
 };
+
+/**
+ * Throttled store that batches `set()` calls with requestAnimationFrame.
+ * Multiple calls within the same rAF window are coalesced into a single
+ * update.
+ */
+export const createThrottledStore = (initialValue) => {
+  let pendingValue = initialValue;
+  let rafId = null;
+
+  const store = writable(initialValue);
+  const { subscribe } = store;
+
+  return {
+    set(value) {
+      if (value === pendingValue) return;
+      pendingValue = value;
+
+      if (rafId !== null) return;
+
+      rafId = requestAnimationFrame(() => {
+        rafId = null;
+        store.set(pendingValue);
+      });
+    },
+
+    subscribe,
+  };
+};

--- a/src/stores.js
+++ b/src/stores.js
@@ -3,6 +3,7 @@ import {
   createStore,
   createSetStore,
   createPersistedStore,
+  createThrottledStore,
 } from "./lib/stores";
 import { watchMedia } from "./lib/mq-store";
 
@@ -132,6 +133,7 @@ export const drawVelocityCurves = createStore(true);
 // Playback State
 export const isPlaying = createStore(false);
 export const currentTick = createStore(0);
+export const throttledTick = createThrottledStore(0);
 export const playbackProgress = createStore(0);
 export const playbackProgressStart = createStore();
 export const playbackProgressEnd = createStore(1);

--- a/src/stores.js
+++ b/src/stores.js
@@ -36,27 +36,27 @@ export const scrollDownwards = derived(
   rollMetadata,
   ($rollMetadata) => $rollMetadata.ROLL_TYPE === "welte-red",
 );
-export const firstHolePx = derived(
-  rollMetadata,
-   ($rollMetadata) => $rollMetadata.ROLL_TYPE === "welte-red"
-      ? parseInt($rollMetadata.FIRST_HOLE, 10)
-      : parseInt($rollMetadata.IMAGE_LENGTH, 10) -
-        parseInt($rollMetadata.FIRST_HOLE, 10));
-export const lastHolePx = derived(
-  rollMetadata,
-    ($rollMetadata) => $rollMetadata.ROLL_TYPE === "welte-red"
-      ? parseInt($rollMetadata.LAST_HOLE, 10)
-      : parseInt($rollMetadata.IMAGE_LENGTH, 10) -
-        parseInt($rollMetadata.LAST_HOLE, 10));
-export const imageLength = derived(
-  rollMetadata,
-  ($rollMetadata) => (parseInt($rollMetadata.IMAGE_LENGTH, 10)));
-export const imageWidth = derived(
-  rollMetadata,
-  ($rollMetadata) => (parseInt($rollMetadata.IMAGE_WIDTH, 10)));
-export const avgHoleWidth = derived(
-  rollMetadata,
-  ($rollMetadata) => (parseInt($rollMetadata.AVG_HOLE_WIDTH, 10)));
+export const firstHolePx = derived(rollMetadata, ($rollMetadata) =>
+  $rollMetadata.ROLL_TYPE === "welte-red"
+    ? parseInt($rollMetadata.FIRST_HOLE, 10)
+    : parseInt($rollMetadata.IMAGE_LENGTH, 10) -
+      parseInt($rollMetadata.FIRST_HOLE, 10),
+);
+export const lastHolePx = derived(rollMetadata, ($rollMetadata) =>
+  $rollMetadata.ROLL_TYPE === "welte-red"
+    ? parseInt($rollMetadata.LAST_HOLE, 10)
+    : parseInt($rollMetadata.IMAGE_LENGTH, 10) -
+      parseInt($rollMetadata.LAST_HOLE, 10),
+);
+export const imageLength = derived(rollMetadata, ($rollMetadata) =>
+  parseInt($rollMetadata.IMAGE_LENGTH, 10),
+);
+export const imageWidth = derived(rollMetadata, ($rollMetadata) =>
+  parseInt($rollMetadata.IMAGE_WIDTH, 10),
+);
+export const avgHoleWidth = derived(rollMetadata, ($rollMetadata) =>
+  parseInt($rollMetadata.AVG_HOLE_WIDTH, 10),
+);
 
 export const holesIntervalTree = writable();
 

--- a/src/styles/hole-highlighting.scss
+++ b/src/styles/hole-highlighting.scss
@@ -43,22 +43,6 @@ $highlight-hover-outline-offset: 4px;
     }
   }
 
-  // .active marks are currently playing -- the ::before pseudo element overlays the highlight color
-  mark.active::before {
-    position: absolute;
-    content: "";
-    top: 0;
-    left: 0;
-    bottom: 0;
-    right: 0;
-    mix-blend-mode: multiply;
-    animation: mark-recede 0.5s ease-in-out;
-    background-color: var(--highlight-color);
-    box-shadow: 0 0 5px var(--highlight-color);
-    display: inline-block;
-    border-radius: 20px;
-  }
-
   // .flag-left marks have their label "flag" pointing to the left
   mark.flag-left:hover::after {
     left: auto;
@@ -74,72 +58,6 @@ $highlight-hover-outline-offset: 4px;
     bottom: -($highlight-hover-outline-offset + $highlight-hover-outline-width);
   }
 
-  // if "Display Note Velocities" is on, a tooltip is displayed on .active marks
-  &.active-note-details {
-    mark.active::after {
-      background-color: none;
-      color: white;
-      content: attr(data-hole-label);
-      display: block;
-      font-weight: bold;
-      left: 50%;
-      padding: 8px 4px;
-      position: absolute;
-      text-shadow: 0px 0px 8px black;
-      top: 0;
-      mix-blend-mode: normal;
-      transform: translate(-50%, -100%);
-      pointer-events: none;
-    }
-
-    // tooltip is below perforation when the roll scrolls downwards
-    mark.flag-bottom.active::after {
-      top: auto;
-      bottom: 0;
-      transform: translate(-50%, 100%);
-    }
-
-    // when hovering a mark, revert to the outline+flag style
-    mark:hover::after {
-      left: calc(
-        100% + #{$highlight-hover-outline-offset} + #{$highlight-hover-outline-width}
-      );
-      padding: 8px ($highlight-hover-outline-width + 4px) 8px 4px;
-      top: -($highlight-hover-outline-offset + $highlight-hover-outline-width);
-      transform: none;
-    }
-
-    // ditto for .flag-left marks
-    mark.flag-left:hover::after {
-      left: auto;
-      right: calc(
-        100% + #{$highlight-hover-outline-offset} + #{$highlight-hover-outline-width}
-      );
-      padding: 8px 4px 8px ($highlight-hover-outline-width + 4px);
-    }
-
-    // and .flag-bottom marks
-    mark.flag-bottom:hover::after {
-      top: auto;
-      bottom: -($highlight-hover-outline-offset + $highlight-hover-outline-width);
-      transform: translate(0);
-    }
-  }
-
-  // when "Highlight All Holes" is on, force a yellow highlight
-  &.highlight-enabled-holes {
-    mark {
-      --highlight-color: #{$note-highlight-color} !important;
-    }
-  }
-
-  // if "Display Note Velocities" is *not* on, force a yellow highlight for .note marks
-  &:not(.show-note-velocities) {
-    mark.note {
-      --highlight-color: #{$note-highlight-color} !important;
-    }
-  }
-
   // if "Display Note Velocities" is on...
   &.show-note-velocities {
     // ...label "flags" for note marks use the data-note-velocity value too
@@ -147,32 +65,11 @@ $highlight-hover-outline-offset: 4px;
       content: attr(data-hole-label) "\av:" attr(data-note-velocity);
     }
 
-    // ...and if "Show Details for Active Notes" is also on...
-    &.active-note-details {
-      // ..."tooltips" for note marks use the data-note-velocity value too
-      mark.note.active::after {
-        content: attr(data-hole-label) "\av:" attr(data-note-velocity);
-      }
-    }
-
     // if "Play Expressions" is off, velocity is 64, so...
     &:not(.play-expressions) {
-      // ...the highlight color is adjusted (if "Highlight Enabled Holes" is off)
-      &:not(.highlight-enabled-holes) mark.note {
-        --highlight-color: hsla(217, 73%, 86%, 0.8) !important;
-      }
-
       // ...and so is the label
       mark.note:hover::after {
         content: attr(data-hole-label) "\av:64";
-      }
-
-      // ...and if "Show Details for Active Notes" is also on...
-      &.active-note-details {
-        // ...so too is the "tooltip"
-        mark.note.active::after {
-          content: attr(data-hole-label) "\av:64";
-        }
       }
     }
   }


### PR DESCRIPTION
Basically two (related) interventions here:

2f67eb7983c279e2747794dddd63bb19163123f0 creates a `$throttledTick` store (for use in the visualization only) which batches updates according to the animation frame rate, to avoid doing more work than necessary (`$currentTick` can, in theory, update up to 1,000 times per second, and does generally in practice exceed 500 times per second).

fb65da8803f302cd2432a7c40edf033f2dcbbd21 replaces the (now throttled) DOM-based hole highlighting with an approach based on a `<canvas/>` element.

Together they seem to make a noticeable improvement, especially on Firefox and on less powerful devices.  I _think_ the user-facing behaviour is otherwise entirely unchanged, but there are a bunch of edge cases that I might not have tested thoroughly.  However, I think the perf wins are worth the churn and the risk of an edge case slipping through and needing to be fixed later.  Lmk if you agree :) 