### PR TITLE
Streamline hole highlighting behavior

### DIFF
--- a/src/components/AdvancedSettings.svelte
+++ b/src/components/AdvancedSettings.svelte
@@ -144,7 +144,7 @@
         class:disabled={!$playExpressionsOnOff}
       />
       <dd>Control Holes</dd>
-      {#if !$userSettings.showNoteVelocities && !$userSettings.highlightEnabledHoles}
+      {#if !$userSettings.highlightEnabledHoles && !$playExpressionsOnOff}
         <dt
           style="background-color: hsl({defaultHoleColor});"
           transition:slide
@@ -152,7 +152,7 @@
         <dd transition:slide>Note Holes</dd>
       {/if}
     </dl>
-    {#if $userSettings.showNoteVelocities || $userSettings.highlightEnabledHoles}
+    {#if $playExpressionsOnOff}
       <dl class="hole-color-legend" transition:slide>
         <dd>Note Velocity (soft - loud)</dd>
         <dt

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -148,7 +148,6 @@
   } from "../stores";
   import { rollProfile } from "../config/roll-config";
   import { clamp, defaultHoleColor, getHoleLabel } from "../lib/utils";
-  import { getNoteHoleColor } from "../lib/hole-data";
   import RollViewerControls from "./RollViewerControls.svelte";
   import RollViewerScaleBar from "./RollViewerScaleBar.svelte";
   import AriaAnnouncer from "../ui-components/AriaAnnouncer.svelte";
@@ -215,7 +214,6 @@
       startY: offsetY,
       w: width,
       h: height,
-      color: holeColor,
       type: holeType,
     } = hole;
 
@@ -225,7 +223,6 @@
     mark.dataset.holeLabel = holeLabel;
     mark.dataset.noteVelocity = velocity || 64;
 
-    mark.style.setProperty("--highlight-color", `hsl(${holeColor})`);
     mark.classList.add(holeType);
 
     mark.addEventListener("mouseout", () => {
@@ -872,6 +869,20 @@
     // Clear and draw highlights for active holes
     highlightCtx.clearRect(0, 0, highlightCanvas.width, highlightCanvas.height);
     holes.forEach((hole) => {
+      // Skip pedal/control holes when pedaling or expression is off
+      if (hole.type === "pedal" && !$rollPedalingOnOff) return;
+      if (hole.type === "control" && !$playExpressionsOnOff) return;
+
+      // Get highlight color: If base rect shaded, it's always yellow (default)
+      //  If no base shade: blue<->red for notes unless expression is disabled,
+      //  orange for pedals, green for control holes
+      let color = defaultHoleColor;
+      if (!$userSettings.highlightEnabledHoles) {
+        color = hole.color;
+        if (hole.type === "note" && !$playExpressionsOnOff)
+          color = defaultHoleColor;
+      }
+
       const holeX = hole.x;
       const holeY = hole.startY;
       const holeW = hole.w;
@@ -882,26 +893,6 @@
       const screenY = ((holeY - imgBounds.y) / imgBounds.height) * viewerSize.y;
       const screenW = (holeW / imgBounds.width) * viewerSize.x;
       const screenH = (holeH / imgBounds.height) * viewerSize.y;
-
-      // Get highlight color
-      let color = hole.color;
-      if (hole.type === "note" && !$playExpressionsOnOff) {
-        color = getNoteHoleColor(64, 64, 64);
-      }
-      if (
-        hole.type === "note" &&
-        (!$userSettings.showNoteVelocities ||
-          $userSettings.highlightEnabledHoles)
-      ) {
-        color = defaultHoleColor; // yellow default for non-velocity mode
-      }
-      if (
-        !$rollPedalingOnOff &&
-        (hole.type === "pedal" || hole.type === "control")
-      ) {
-        // skip pedal/control holes when roll pedaling is off
-        return;
-      }
 
       // Animate highlight: bright "attack" then fade to steady opacity over 500ms
       let opacity = 0.6;

--- a/src/styles/hole-highlighting.scss
+++ b/src/styles/hole-highlighting.scss
@@ -1,11 +1,9 @@
-$note-highlight-color: yellow;
 $highlight-hover-outline-color: darkturquoise;
 $highlight-hover-outline-width: 6px;
 $highlight-hover-outline-offset: 4px;
 
 #roll-viewer {
   mark {
-    --highlight-color: #{$note-highlight-color};
     background-color: transparent;
 
     // mouseover hole outline and label flag
@@ -74,12 +72,8 @@ $highlight-hover-outline-offset: 4px;
     }
   }
 
-  // if "Use Roll Pedaling" is off, don't highlight pedal holes
+  // if "Use Roll Pedaling" is off, don't fill pedal holes
   &:not(.use-roll-pedaling) {
-    mark.pedal {
-      --highlight-color: none !important;
-    }
-
     rect.pedal {
       fill: none;
     }
@@ -92,12 +86,8 @@ $highlight-hover-outline-offset: 4px;
     }
   }
 
-  // if "Play Expressions" is off, don't highlight control holes
+  // if "Play Expressions" is off, don't fill control holes
   &:not(.play-expressions) {
-    mark.control {
-      --highlight-color: none !important;
-    }
-
     rect.control {
       fill: none;
     }
@@ -110,7 +100,7 @@ $highlight-hover-outline-offset: 4px;
     }
   }
 
-  // if "Play Expressions" is off, use the colour from the middle of the palate
+  // if "Play Expressions" is off, use the colour from the middle of the palette
   //  for all note holes (but only if "Highlight All Holes" is on!)
   &.highlight-enabled-holes:not(.play-expressions) {
     rect.note {
@@ -122,7 +112,7 @@ $highlight-hover-outline-offset: 4px;
     pointer-events: all;
   }
 
-  // when "Highlight All Holes" is off, don't fill the hole <rect/> elements
+  // when "Highlight Enabled Holes" is off, don't fill the hole <rect/> elements
   &:not(.highlight-enabled-holes) {
     svg rect:not(.selection) {
       fill: none;


### PR DESCRIPTION
I noticed some behaviors related to hole highlighting that didn't seem right to me:

- expression hole highlighting being tied to the Use Roll Pedaling button rather than Play Expressions
- control and pedal holes flashing their base colors rather than yellow when active with Highlight Enabled Holes selected

so I set out to correct and somewhat streamline the hole highlighting code and the behavior of the Color Legend. Hopefully it all makes some kind of sense.