### PR TITLE
Embed search page has white background, like Spotlight exhibits

### DIFF
--- a/src/pages/search-embed/index.astro
+++ b/src/pages/search-embed/index.astro
@@ -3,7 +3,7 @@ import BaseLayout from "../../layouts/base.astro";
 import Search from "../../components/Search.svelte";
 ---
 
-<BaseLayout title="Pianolatron Search" theme="blue">
+<BaseLayout title="Pianolatron Search" theme="white">
   <main id="content">
     <Search client:only="svelte" />
   </main>

--- a/src/styles/theme.scss
+++ b/src/styles/theme.scss
@@ -16,6 +16,13 @@
   --primary-accent-semiopaque: #{color.adjust(steelblue, $alpha: -0.5)};
 }
 
+[data-theme="white"] {
+  --background-color: white;
+  --background-darker: white;
+  --primary-accent: #006bb8;
+  --primary-accent-semiopaque: #{color.adjust(steelblue, $alpha: -0.5)};
+}
+
 [data-theme="green"] {
   --primary-accent: darkolivegreen;
   --primary-accent-semiopaque: #{color.adjust(darkolivegreen, $alpha: -0.5)};


### PR DESCRIPTION
PRing this for now to get the preview link to add to the demo Spotlight exhibit... but probably it can just be merged?