### PR TITLE
Option to view/play a roll without loading the image

### DIFF
--- a/src/Pianolatron.svelte
+++ b/src/Pianolatron.svelte
@@ -538,14 +538,16 @@
             skipText="Skip to pedal and accent controls"
           />
         {/if}
-        <RollViewer
-          bind:this={rollViewer}
-          bind:rollImageReady
-          imageUrl={currentRoll.image_url}
-          {skipToTick}
-          {progressPercentageToTick}
-          showScaleBar={$appMode === "perform" && $userSettings.showRuler}
-        />
+        {#key $userSettings.hideRollImage}
+          <RollViewer
+            bind:this={rollViewer}
+            bind:rollImageReady
+            imageUrl={currentRoll.image_url}
+            {skipToTick}
+            {progressPercentageToTick}
+            showScaleBar={$appMode === "perform" && $userSettings.showRuler}
+          />
+        {/key}
       {/if}
       {#if $userSettings.showKeyboard && $userSettings.overlayKeyboard}
         <div id="keyboard-overlay" transition:fade>

--- a/src/components/AdvancedSettings.svelte
+++ b/src/components/AdvancedSettings.svelte
@@ -100,10 +100,13 @@
 
   const themes = ["cardinal", "blue", "green", "grey"];
 
+  $: $userSettings.highlightEnabledHoles =
+    $userSettings.highlightEnabledHoles || $userSettings.hideRollImage;
+
   $: document.documentElement.setAttribute("data-theme", $userSettings.theme);
 </script>
 
-<div id="settings-panel">
+<div>
   <fieldset>
     <legend>Visualization Settings</legend>
     <label>
@@ -125,9 +128,17 @@
       Show Roll Viewer Scale Bar:
       <input type="checkbox" bind:checked={$userSettings.showRuler} />
     </label>
+  </fieldset>
+
+  <fieldset>
+    <legend>Roll Settings</legend>
     <label class="setting">
       Holes Get Keyboard Focus:
       <input type="checkbox" bind:checked={$userSettings.keyboardFocusHoles} />
+    </label>
+    <label class="setting">
+      Hide Image (Reloads Roll):
+      <input type="checkbox" bind:checked={$userSettings.hideRollImage} />
     </label>
   </fieldset>
 

--- a/src/components/RollViewer.svelte
+++ b/src/components/RollViewer.svelte
@@ -1126,6 +1126,16 @@
     // Make sure the roll metadata is available before proceeding
     if (!$rollMetadata) return;
 
+    if ($userSettings.hideRollImage) {
+      const canvas = document.createElement("canvas");
+      canvas.width = $imageWidth;
+      canvas.height = $imageWidth;
+      const ctx = canvas.getContext("2d");
+      ctx.fillStyle = "#00000000";
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+      imageUrl = canvas.toDataURL("image/png");
+    }
+
     openSeadragon = OpenSeadragon({
       id: "roll-viewer",
       showNavigationControl: false,
@@ -1147,6 +1157,10 @@
       navigatorDisplayRegionColor: "transparent",
       navigatorMaintainSizeRatio: true,
       tabIndex: -1, // omit from tab order
+      tileSources: {
+        type: "image",
+        url: imageUrl,
+      },
     });
 
     const { navigator } = openSeadragon;
@@ -1216,11 +1230,15 @@
     // on open, configure an event listener for when the images arrive
     //  from the SDR
     openSeadragon.addHandler("open", () => {
-      const tiledImage = viewport.viewer.world.getItemAt(0);
-      tiledImage.addOnceHandler(
-        "fully-loaded-change",
-        () => (rollImageReady = true),
-      );
+      if ($userSettings.hideRollImage) {
+        rollImageReady = true;
+      } else {
+        const tiledImage = viewport.viewer.world.getItemAt(0);
+        tiledImage.addOnceHandler(
+          "fully-loaded-change",
+          () => (rollImageReady = true),
+        );
+      }
     });
 
     // create the holes overlay SVG and "rewind" to the beginning of the
@@ -1308,7 +1326,7 @@
     _updateViewportHandler = () => drawActiveHighlights($throttledTick);
     openSeadragon.addHandler("update-viewport", _updateViewportHandler);
 
-    openSeadragon.open(imageUrl);
+    if (!$userSettings.hideRollImage) openSeadragon.open(imageUrl);
 
     // Initialize highlight canvas context and size for active note drawing
     const resizeHighlightCanvas = () => {

--- a/src/stores.js
+++ b/src/stores.js
@@ -152,6 +152,7 @@ export const userSettings = createPersistedStore("userSettings", {
   showRuler: false,
   keyboardFocusHoles: false,
   headerHidden: false,
+  hideRollImage: false,
 });
 
 // Browser State


### PR DESCRIPTION
This feature is a bit fraught because it has often been desired for a variety of reasons, but also kind of goes against the spirit of the app. And the implementation here is a bit heavy-handed. But I think it's probably worth including it as an advanced option. At the least, it allows the app to work in a degraded fashion if the image source (the SDR's IIIF server) is entirely out of service.